### PR TITLE
[Feat] 퀘스트 탭 UI 구현 및 퀘스트 관련 API 연동

### DIFF
--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/datasource/QuestDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/datasource/QuestDataSource.kt
@@ -1,6 +1,9 @@
 package com.ilsangtech.ilsang.core.data.quest.datasource
 
 import com.ilsangtech.ilsang.core.network.model.quest.LargeRewardQuestResponse
+import com.ilsangtech.ilsang.core.network.model.quest.UncompletedEventQuestResponse
+import com.ilsangtech.ilsang.core.network.model.quest.UncompletedNormalQuestResponse
+import com.ilsangtech.ilsang.core.network.model.quest.UncompletedRepeatQuestResponse
 import com.ilsangtech.ilsang.core.network.model.quest.UncompletedTotalQuestResponse
 
 interface QuestDataSource {
@@ -19,4 +22,23 @@ interface QuestDataSource {
         size: Int = 3,
         sort: List<String> = emptyList()
     ): LargeRewardQuestResponse
+
+    suspend fun getUncompletedNormalQuest(
+        authorization: String,
+        page: Int,
+        size: Int
+    ): UncompletedNormalQuestResponse
+
+    suspend fun getUncompletedRepeatQuest(
+        authorization: String,
+        page: Int,
+        size: Int,
+        status: String = "NONE"
+    ): UncompletedRepeatQuestResponse
+
+    suspend fun getUncompletedEventQuest(
+        authorization: String,
+        page: Int,
+        size: Int
+    ): UncompletedEventQuestResponse
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/datasource/QuestDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/datasource/QuestDataSourceImpl.kt
@@ -2,6 +2,9 @@ package com.ilsangtech.ilsang.core.data.quest.datasource
 
 import com.ilsangtech.ilsang.core.network.api.QuestApiService
 import com.ilsangtech.ilsang.core.network.model.quest.LargeRewardQuestResponse
+import com.ilsangtech.ilsang.core.network.model.quest.UncompletedEventQuestResponse
+import com.ilsangtech.ilsang.core.network.model.quest.UncompletedNormalQuestResponse
+import com.ilsangtech.ilsang.core.network.model.quest.UncompletedRepeatQuestResponse
 import com.ilsangtech.ilsang.core.network.model.quest.UncompletedTotalQuestResponse
 import javax.inject.Inject
 
@@ -36,6 +39,44 @@ class QuestDataSourceImpl @Inject constructor(
             page = page,
             size = size,
             sort = sort
+        )
+    }
+
+    override suspend fun getUncompletedNormalQuest(
+        authorization: String,
+        page: Int,
+        size: Int
+    ): UncompletedNormalQuestResponse {
+        return questApiService.getUncompletedNormalQuest(
+            authorization = authorization,
+            page = page,
+            size = size
+        )
+    }
+
+    override suspend fun getUncompletedRepeatQuest(
+        authorization: String,
+        page: Int,
+        size: Int,
+        status: String
+    ): UncompletedRepeatQuestResponse {
+        return questApiService.getUncompletedRepeatQuest(
+            authorization = authorization,
+            page = page,
+            size = size,
+            status = status
+        )
+    }
+
+    override suspend fun getUncompletedEventQuest(
+        authorization: String,
+        page: Int,
+        size: Int
+    ): UncompletedEventQuestResponse {
+        return questApiService.getUncompletedEventQuest(
+            authorization = authorization,
+            page = page,
+            size = size
         )
     }
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/repository/QuestRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/repository/QuestRepositoryImpl.kt
@@ -38,4 +38,29 @@ class QuestRepositoryImpl(
         }
     }
 
+    override suspend fun getUncompletedNormalQuests(): List<Quest> {
+        return questDataSource.getUncompletedNormalQuest(
+            authorization = userRepository.currentUser!!.authorization!!,
+            page = 0,
+            size = 60
+        ).data.map(QuestNetworkModel::toQuest)
+    }
+
+    override suspend fun getUncompletedRepeatQuests(status: String): List<Quest> {
+        return questDataSource.getUncompletedRepeatQuest(
+            authorization = userRepository.currentUser!!.authorization!!,
+            page = 0,
+            size = 60,
+            status = status
+        ).data.map(QuestNetworkModel::toQuest)
+    }
+
+    override suspend fun getUncompletedEventQuests(): List<Quest> {
+        return questDataSource.getUncompletedEventQuest(
+            authorization = userRepository.currentUser!!.authorization!!,
+            page = 0,
+            size = 60
+        ).data.map(QuestNetworkModel::toQuest)
+    }
+
 }

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/QuestRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/QuestRepository.kt
@@ -8,4 +8,14 @@ interface QuestRepository {
     suspend fun getRecommendedQuests(): List<Quest>
 
     suspend fun getLargeRewardQuests(): Map<String, List<Quest>>
+
+    // 미완료한 기본 퀘스트 목록 조회
+    suspend fun getUncompletedNormalQuests(): List<Quest>
+
+    // 미완료한 반복 퀘스트 목록 조회
+    suspend fun getUncompletedRepeatQuests(status: String): List<Quest>
+
+    // 미완료한 이벤트 퀘스트 목록 조회
+    suspend fun getUncompletedEventQuests(): List<Quest>
+
 }

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/QuestType.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/QuestType.kt
@@ -1,0 +1,8 @@
+package com.ilsangtech.ilsang.core.model
+
+enum class QuestType(val title: String) {
+    NORMAL("기본"),
+    REPEAT("반복"),
+    EVENT("이벤트"),
+    STORY("스토리")
+}

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/RepeatQuestPeriod.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/RepeatQuestPeriod.kt
@@ -1,0 +1,7 @@
+package com.ilsangtech.ilsang.core.model
+
+sealed interface RepeatQuestPeriod {
+    data object DAILY : RepeatQuestPeriod
+    data object WEEKLY : RepeatQuestPeriod
+    data object MONTHLY : RepeatQuestPeriod
+}

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/Reward.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/Reward.kt
@@ -7,6 +7,6 @@ data class Reward(
     val questId: String,
     val rewardId: String,
     val target: String?,
-    val title: String,
+    val title: String?,
     val type: String
 )

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/RewardType.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/RewardType.kt
@@ -1,0 +1,9 @@
+package com.ilsangtech.ilsang.core.model
+
+enum class RewardType(val title: String) {
+    STRENGTH("체력"),
+    INTELLECT("지능"),
+    CHARM("매력"),
+    FUN("재미"),
+    SOCIABILITY("사회성")
+}

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/QuestApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/QuestApiService.kt
@@ -1,6 +1,7 @@
 package com.ilsangtech.ilsang.core.network.api
 
 import com.ilsangtech.ilsang.core.network.model.quest.LargeRewardQuestResponse
+import com.ilsangtech.ilsang.core.network.model.quest.UncompletedEventQuestResponse
 import com.ilsangtech.ilsang.core.network.model.quest.UncompletedNormalQuestResponse
 import com.ilsangtech.ilsang.core.network.model.quest.UncompletedRepeatQuestResponse
 import com.ilsangtech.ilsang.core.network.model.quest.UncompletedTotalQuestResponse
@@ -32,7 +33,7 @@ interface QuestApiService {
     suspend fun getUncompletedNormalQuest(
         @Header("authorization") authorization: String,
         @Query("page") page: Int = 0,
-        @Query("size") size: Int = 60,
+        @Query("size") size: Int = 60
     ): UncompletedNormalQuestResponse
 
     // 미완료한 반복 퀘스트 목록 조회
@@ -43,4 +44,12 @@ interface QuestApiService {
         @Query("size") size: Int = 60,
         @Query("status") status: String = "NONE"
     ): UncompletedRepeatQuestResponse
+
+    //미완료한 이벤트 퀘스트 목록 조회
+    @GET("customer/uncompletedEventQuest")
+    suspend fun getUncompletedEventQuest(
+        @Header("authorization") authorization: String,
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 60
+    ): UncompletedEventQuestResponse
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/QuestApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/QuestApiService.kt
@@ -1,6 +1,7 @@
 package com.ilsangtech.ilsang.core.network.api
 
 import com.ilsangtech.ilsang.core.network.model.quest.LargeRewardQuestResponse
+import com.ilsangtech.ilsang.core.network.model.quest.UncompletedNormalQuestResponse
 import com.ilsangtech.ilsang.core.network.model.quest.UncompletedTotalQuestResponse
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -24,4 +25,12 @@ interface QuestApiService {
         @Query("size") size: Int = 3,
         @Query("sort") sort: List<String> = emptyList()
     ): LargeRewardQuestResponse
+
+    // 미완료한 기본 퀘스트 목록 조회
+    @GET("customer/uncompletedQuest")
+    suspend fun getUncompletedNormalQuest(
+        @Header("authorization") authorization: String,
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 60,
+    ): UncompletedNormalQuestResponse
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/QuestApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/QuestApiService.kt
@@ -2,6 +2,7 @@ package com.ilsangtech.ilsang.core.network.api
 
 import com.ilsangtech.ilsang.core.network.model.quest.LargeRewardQuestResponse
 import com.ilsangtech.ilsang.core.network.model.quest.UncompletedNormalQuestResponse
+import com.ilsangtech.ilsang.core.network.model.quest.UncompletedRepeatQuestResponse
 import com.ilsangtech.ilsang.core.network.model.quest.UncompletedTotalQuestResponse
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -33,4 +34,13 @@ interface QuestApiService {
         @Query("page") page: Int = 0,
         @Query("size") size: Int = 60,
     ): UncompletedNormalQuestResponse
+
+    // 미완료한 반복 퀘스트 목록 조회
+    @GET("customer/uncompletedRepeatQuest")
+    suspend fun getUncompletedRepeatQuest(
+        @Header("authorization") authorization: String,
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 60,
+        @Query("status") status: String = "NONE"
+    ): UncompletedRepeatQuestResponse
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/RewardNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/RewardNetworkModel.kt
@@ -10,6 +10,6 @@ data class RewardNetworkModel(
     val questId: String,
     val rewardId: String,
     val target: String?,
-    val title: String,
+    val title: String?,
     val type: String
 )

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/UncompletedEventQuestResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/UncompletedEventQuestResponse.kt
@@ -1,0 +1,13 @@
+package com.ilsangtech.ilsang.core.network.model.quest
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UncompletedEventQuestResponse(
+    val `data`: List<QuestNetworkModel>,
+    val message: String,
+    val page: Int,
+    val size: Int,
+    val status: String,
+    val total: Int
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/UncompletedNormalQuestResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/UncompletedNormalQuestResponse.kt
@@ -1,0 +1,13 @@
+package com.ilsangtech.ilsang.core.network.model.quest
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UncompletedNormalQuestResponse(
+    val `data`: List<QuestNetworkModel>,
+    val message: String,
+    val page: Int,
+    val size: Int,
+    val status: String,
+    val total: Int
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/UncompletedRepeatQuestResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/UncompletedRepeatQuestResponse.kt
@@ -1,0 +1,13 @@
+package com.ilsangtech.ilsang.core.network.model.quest
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UncompletedRepeatQuestResponse(
+    val `data`: List<QuestNetworkModel>,
+    val message: String,
+    val page: Int,
+    val size: Int,
+    val status: String,
+    val total: Int
+)

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
@@ -49,7 +49,7 @@ fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
                     homeTapUiState = homeTapUiState
                 )
             }
-            composable(HomeTap.Quest.name) { QuestTabScreen() }
+            composable(HomeTap.Quest.name) { QuestTabScreen(homeViewModel) }
             composable(HomeTap.Approval.name) {}
             composable(HomeTap.Ranking.name) {}
             composable(HomeTap.My.name) {}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
@@ -47,7 +47,16 @@ fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
                 HomeTapScreen(
                     userNickname = userNickname,
                     homeTapUiState = homeTapUiState
-                )
+                ) {
+                    homeViewModel.selectSortType("포인트 높은 순")
+                    navController.navigate(HomeTap.Quest.name) {
+                        popUpTo(navController.graph.startDestinationId) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                }
             }
             composable(HomeTap.Quest.name) { QuestTabScreen(homeViewModel) }
             composable(HomeTap.Approval.name) {}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.navigation.compose.rememberNavController
 import com.ilsangtech.ilsang.designsystem.component.ILSANGNavigationBar
 import com.ilsangtech.ilsang.designsystem.component.ILSANGNavigationBarItem
 import com.ilsangtech.ilsang.feature.home.home.HomeTapScreen
+import com.ilsangtech.ilsang.feature.home.quest.QuestTabScreen
 
 @Composable
 fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
@@ -48,7 +49,7 @@ fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
                     homeTapUiState = homeTapUiState
                 )
             }
-            composable(HomeTap.Quest.name) {}
+            composable(HomeTap.Quest.name) { QuestTabScreen() }
             composable(HomeTap.Approval.name) {}
             composable(HomeTap.Ranking.name) {}
             composable(HomeTap.My.name) {}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
@@ -6,11 +6,18 @@ import com.ilsangtech.ilsang.core.domain.BannerRepository
 import com.ilsangtech.ilsang.core.domain.QuestRepository
 import com.ilsangtech.ilsang.core.domain.RankRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
+import com.ilsangtech.ilsang.core.model.QuestType
+import com.ilsangtech.ilsang.core.model.RepeatQuestPeriod
+import com.ilsangtech.ilsang.core.model.RewardType
 import com.ilsangtech.ilsang.feature.home.home.HomeTapSuccessData
 import com.ilsangtech.ilsang.feature.home.home.HomeTapUiState
+import com.ilsangtech.ilsang.feature.home.quest.QuestTabUiData
+import com.ilsangtech.ilsang.feature.home.quest.QuestTabUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
@@ -55,4 +62,82 @@ class HomeViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = HomeTapUiState.Loading
     )
+
+    private var _selectedQuestType = MutableStateFlow(QuestType.NORMAL)
+    val selectedQuestType = _selectedQuestType.asStateFlow()
+
+    private var _selectedRewardType = MutableStateFlow(RewardType.STRENGTH)
+    val selectedRewardType = _selectedRewardType.asStateFlow()
+
+    private var _selectedRepeatPeriod = MutableStateFlow<RepeatQuestPeriod>(RepeatQuestPeriod.DAILY)
+    val selectedRepeatPeriod = _selectedRepeatPeriod.asStateFlow()
+
+    private var _selectedSortType = MutableStateFlow("포인트 높은 순")
+    val selectedSortType = _selectedSortType.asStateFlow()
+
+    val questTabUiState: StateFlow<QuestTabUiState> = combine(
+        selectedQuestType, selectedRewardType, selectedRepeatPeriod, selectedSortType
+    ) { questType, rewardType, repeatPeriod, sortType ->
+        try {
+            val questList = when (questType) {
+                QuestType.NORMAL -> questRepository.getUncompletedNormalQuests()
+                QuestType.REPEAT -> questRepository.getUncompletedRepeatQuests(
+                    when (repeatPeriod) {
+                        RepeatQuestPeriod.DAILY -> "DAILY"
+                        RepeatQuestPeriod.WEEKLY -> "WEEKLY"
+                        RepeatQuestPeriod.MONTHLY -> "MONTHLY"
+                    }
+                )
+
+                QuestType.EVENT -> questRepository.getUncompletedEventQuests()
+                else -> emptyList()
+            }.filter { quest ->
+                quest.rewardList.find { it.content == rewardType.name } != null
+            }.sortedBy {
+                when (sortType) {
+                    "포인트 높은 순" -> {
+                        it.rewardList.sumOf { reward ->
+                            -reward.quantity
+                        }
+                    }
+
+                    "포인트 낮은 순" -> {
+                        it.rewardList.sumOf { reward ->
+                            reward.quantity
+                        }
+                    }
+
+                    else -> {
+                        -it.score
+                    }
+                }
+            }
+
+            QuestTabUiState.Success(
+                data = QuestTabUiData(questList)
+            )
+        } catch (e: Exception) {
+            QuestTabUiState.Error(e)
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = QuestTabUiState.Loading
+    )
+
+    fun selectQuestType(questType: QuestType) {
+        _selectedQuestType.value = questType
+    }
+
+    fun selectRewardType(rewardType: RewardType) {
+        _selectedRewardType.value = rewardType
+    }
+
+    fun selectRepeatPeriod(repeatQuestPeriod: RepeatQuestPeriod) {
+        _selectedRepeatPeriod.value = repeatQuestPeriod
+    }
+
+    fun selectSortType(sortType: String) {
+        _selectedSortType.value = sortType
+    }
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import com.ilsangtech.ilsang.core.domain.BannerRepository
 import com.ilsangtech.ilsang.core.domain.QuestRepository
 import com.ilsangtech.ilsang.core.domain.RankRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
+import com.ilsangtech.ilsang.core.model.Quest
 import com.ilsangtech.ilsang.core.model.QuestType
 import com.ilsangtech.ilsang.core.model.RepeatQuestPeriod
 import com.ilsangtech.ilsang.core.model.RewardType
@@ -76,54 +77,60 @@ class HomeViewModel @Inject constructor(
     val selectedSortType = _selectedSortType.asStateFlow()
 
     val questTabUiState: StateFlow<QuestTabUiState> = combine(
-        selectedQuestType, selectedRewardType, selectedRepeatPeriod, selectedSortType
-    ) { questType, rewardType, repeatPeriod, sortType ->
-        try {
-            val questList = when (questType) {
-                QuestType.NORMAL -> questRepository.getUncompletedNormalQuests()
-                QuestType.REPEAT -> questRepository.getUncompletedRepeatQuests(
-                    when (repeatPeriod) {
-                        RepeatQuestPeriod.DAILY -> "DAILY"
-                        RepeatQuestPeriod.WEEKLY -> "WEEKLY"
-                        RepeatQuestPeriod.MONTHLY -> "MONTHLY"
-                    }
-                )
+        selectedQuestType, selectedRepeatPeriod
+    ) { questType, repeatPeriod ->
+        when (questType) {
+            QuestType.NORMAL -> questRepository.getUncompletedNormalQuests()
+            QuestType.REPEAT -> questRepository.getUncompletedRepeatQuests(
+                when (repeatPeriod) {
+                    RepeatQuestPeriod.DAILY -> "DAILY"
+                    RepeatQuestPeriod.WEEKLY -> "WEEKLY"
+                    RepeatQuestPeriod.MONTHLY -> "MONTHLY"
+                }
+            )
 
-                QuestType.EVENT -> questRepository.getUncompletedEventQuests()
-                else -> emptyList()
-            }.filter { quest ->
+            QuestType.EVENT -> questRepository.getUncompletedEventQuests()
+            else -> emptyList()
+        }
+    }
+        .combine(selectedRewardType) { quests, rewardType ->
+            quests.filter { quest ->
                 quest.rewardList.find { it.content == rewardType.name } != null
-            }.sortedBy {
+            }
+        }.combine<List<Quest>, String, QuestTabUiState>(selectedSortType) { quests, sortType ->
+            val sortedQuests = quests.sortedBy { quest ->
                 when (sortType) {
                     "포인트 높은 순" -> {
-                        it.rewardList.sumOf { reward ->
+                        quest.rewardList.sumOf { reward ->
                             -reward.quantity
                         }
                     }
 
                     "포인트 낮은 순" -> {
-                        it.rewardList.sumOf { reward ->
+                        quest.rewardList.sumOf { reward ->
                             reward.quantity
                         }
                     }
 
                     else -> {
-                        -it.score
+                        -quest.score
                     }
                 }
             }
-
             QuestTabUiState.Success(
-                data = QuestTabUiData(questList)
+                QuestTabUiData(
+                    questList = sortedQuests
+                )
             )
-        } catch (e: Exception) {
-            QuestTabUiState.Error(e)
         }
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = QuestTabUiState.Loading
-    )
+        .catch {
+            emit(QuestTabUiState.Error(it))
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = QuestTabUiState.Loading
+        )
 
     fun selectQuestType(questType: QuestType) {
         _selectedQuestType.value = questType

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
@@ -37,6 +37,7 @@ import com.ilsangtech.ilsang.feature.home.quest.QuestBottomSheet
 fun HomeTapScreen(
     userNickname: String?,
     homeTapUiState: HomeTapUiState,
+    navigateToQuestTab: () -> Unit
 ) {
     Surface(
         modifier = Modifier.fillMaxSize()
@@ -81,7 +82,12 @@ fun HomeTapScreen(
                     )
                 }
                 item { Spacer(Modifier.height(36.dp)) }
-                item { LargeRewardQuestsContent(homeTapUiState.data.largeRewardQuests) }
+                item {
+                    LargeRewardQuestsContent(
+                        largeRewardQuests = homeTapUiState.data.largeRewardQuests,
+                        navigateToQuestTab = navigateToQuestTab
+                    )
+                }
                 item { Spacer(Modifier.height(36.dp)) }
                 item { UserRankContent(homeTapUiState.data.topRankUsers) }
                 item { Spacer(Modifier.height(84.dp)) }
@@ -137,5 +143,5 @@ fun HomeTapScreenPreview() {
     HomeTapScreen(
         "누구누구",
         HomeTapUiState.Loading
-    )
+    ) {}
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
@@ -15,6 +15,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -24,8 +28,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.ilsangtech.ilsang.core.model.Banner
+import com.ilsangtech.ilsang.core.model.Quest
 import com.ilsangtech.ilsang.feature.home.BuildConfig
 import com.ilsangtech.ilsang.feature.home.R
+import com.ilsangtech.ilsang.feature.home.quest.QuestBottomSheet
 
 @Composable
 fun HomeTapScreen(
@@ -35,17 +41,43 @@ fun HomeTapScreen(
     Surface(
         modifier = Modifier.fillMaxSize()
     ) {
+        var bottomSheetQuest by remember { mutableStateOf<Quest?>(null) }
+        var showBottomSheet by remember { mutableStateOf(false) }
+
+        if (showBottomSheet) {
+            bottomSheetQuest?.let {
+                QuestBottomSheet(
+                    quest = it,
+                    showBottomSheet = showBottomSheet,
+                    onDismiss = {
+                        showBottomSheet = false
+                        bottomSheetQuest = null
+                    }
+                )
+            }
+        }
+
         if (homeTapUiState is HomeTapUiState.Success) {
             LazyColumn {
                 item { HomeTapTopBar() }
                 items(homeTapUiState.data.banners) { banner -> BannerView(banner) }
                 item { Spacer(Modifier.height(36.dp)) }
-                popularQuestsContent(homeTapUiState.data.popularQuests)
+                popularQuestsContent(
+                    popularQuests = homeTapUiState.data.popularQuests,
+                    onPopularQuestClick = {
+                        bottomSheetQuest = it
+                        showBottomSheet = true
+                    }
+                )
                 item { Spacer(Modifier.height(36.dp)) }
                 item {
                     RecommendedQuestsContent(
                         userNickname = userNickname,
-                        recommendedQuests = homeTapUiState.data.recommendedQuests
+                        recommendedQuests = homeTapUiState.data.recommendedQuests,
+                        onRecommendedQuestClick = {
+                            bottomSheetQuest = it
+                            showBottomSheet = true
+                        }
                     )
                 }
                 item { Spacer(Modifier.height(36.dp)) }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/LargeRewardQuestContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/LargeRewardQuestContent.kt
@@ -45,13 +45,16 @@ import com.ilsangtech.ilsang.feature.home.quest.DefaultQuestCard
 import kotlinx.coroutines.launch
 
 @Composable
-fun LargeRewardQuestsContent(largeRewardQuests: Map<String, List<Quest>>) {
+fun LargeRewardQuestsContent(
+    largeRewardQuests: Map<String, List<Quest>>,
+    navigateToQuestTab: () -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 20.dp)
     ) {
-        val tabList = remember { RewardType.entries.map { it.title} }
+        val tabList = remember { RewardType.entries.map { it.title } }
         val rewardTypeList = remember { RewardType.entries }
 
         val coroutineScope = rememberCoroutineScope()
@@ -124,7 +127,7 @@ fun LargeRewardQuestsContent(largeRewardQuests: Map<String, List<Quest>>) {
             modifier = Modifier
                 .align(Alignment.End)
                 .clickable(
-                    onClick = {},
+                    onClick = navigateToQuestTab,
                     interactionSource = null,
                     indication = null
                 )
@@ -186,6 +189,6 @@ private val largeRewardQuestTapStyle = TextStyle(
 @Preview(showBackground = true, device = "id:small_phone")
 @Composable
 fun LargeRewardQuestsContentPreview() {
-    LargeRewardQuestsContent(mapOf())
+    LargeRewardQuestsContent(mapOf()) {}
 }
 

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/LargeRewardQuestContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/LargeRewardQuestContent.kt
@@ -1,29 +1,18 @@
 package com.ilsangtech.ilsang.feature.home.home
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
@@ -34,32 +23,25 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.zIndex
-import coil3.compose.AsyncImage
 import com.ilsangtech.ilsang.core.model.Quest
-import com.ilsangtech.ilsang.core.model.Reward
-import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
+import com.ilsangtech.ilsang.core.model.RewardType
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_semibold
 import com.ilsangtech.ilsang.designsystem.theme.badge02TextStyle
 import com.ilsangtech.ilsang.designsystem.theme.bodyTextStyle
-import com.ilsangtech.ilsang.designsystem.theme.caption02
 import com.ilsangtech.ilsang.designsystem.theme.gray300
-import com.ilsangtech.ilsang.designsystem.theme.gray400
 import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.designsystem.theme.primary
-import com.ilsangtech.ilsang.feature.home.BuildConfig
 import com.ilsangtech.ilsang.feature.home.R
+import com.ilsangtech.ilsang.feature.home.quest.DefaultQuestCard
 import kotlinx.coroutines.launch
 
 @Composable
@@ -69,9 +51,8 @@ fun LargeRewardQuestsContent(largeRewardQuests: Map<String, List<Quest>>) {
             .fillMaxWidth()
             .padding(horizontal = 20.dp)
     ) {
-        val tabList = remember { listOf("체력", "지능", "매력", "재미", "사회성") }
-        val rewardTypeList =
-            remember { listOf("STRENGTH", "INTELLECT", "FUN", "SOCIABILITY", "CHARM") }
+        val tabList = remember { RewardType.entries.map { it.title} }
+        val rewardTypeList = remember { RewardType.entries }
 
         val coroutineScope = rememberCoroutineScope()
         val pagerState = rememberPagerState { tabList.size }
@@ -125,10 +106,16 @@ fun LargeRewardQuestsContent(largeRewardQuests: Map<String, List<Quest>>) {
             state = pagerState
         ) {
             Column {
-                largeRewardQuests[rewardTypeList[pagerState.currentPage]]?.forEach {
-                    LargeRewardQuestCard(
+                largeRewardQuests[rewardTypeList[pagerState.currentPage].name]?.forEach {
+                    DefaultQuestCard(
                         modifier = Modifier.padding(bottom = 12.dp),
-                        quest = it
+                        quest = it,
+                        badge = { modifier ->
+                            LargeRewardQuestBadge(
+                                modifier = modifier,
+                                xpSum = it.rewardList.sumOf { reward -> reward.quantity }
+                            )
+                        }
                     )
                 }
             }
@@ -158,86 +145,6 @@ fun LargeRewardQuestsContent(largeRewardQuests: Map<String, List<Quest>>) {
     }
 }
 
-@Composable
-fun LargeRewardQuestCard(
-    modifier: Modifier = Modifier,
-    quest: Quest
-) {
-    Card(
-        modifier = modifier,
-        colors = CardDefaults.cardColors(
-            containerColor = Color.White
-        )
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    horizontal = 23.dp,
-                    vertical = 20.dp
-                )
-        ) {
-            Box(
-                modifier = Modifier.padding(
-                    top = 10.dp,
-                    end = 10.dp
-                )
-            ) {
-                LargeRewardQuestBadge(
-                    modifier = Modifier
-                        .zIndex(2f)
-                        .offset(x = 10.dp, y = (-10).dp)
-                        .align(Alignment.TopEnd),
-                    xpSum = quest.rewardList.sumOf { it.quantity }
-                )
-                AsyncImage(
-                    modifier = Modifier
-                        .zIndex(1f)
-                        .size(60.dp)
-                        .clip(CircleShape)
-                        .background(
-                            color = largeRewardQuestWriterBackgroundColor,
-                        ),
-                    model = BuildConfig.IMAGE_URL + quest.imageId,
-                    contentDescription = quest.missionTitle
-                )
-            }
-            Spacer(Modifier.width(10.dp))
-            Column {
-                Text(
-                    text = quest.missionTitle,
-                    maxLines = 1,
-                    style = largeRewardQuestTitleStyle,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Text(
-                    text = quest.writer,
-                    maxLines = 1,
-                    style = largeRewardQuestWriterStyle,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Spacer(Modifier.height(4.dp))
-                RewardChips(quest.rewardList)
-            }
-            Spacer(Modifier.weight(1f))
-            FilledIconButton(
-                modifier = Modifier
-                    .size(26.dp)
-                    .align(Alignment.CenterVertically),
-                colors = IconButtonDefaults.filledIconButtonColors(
-                    containerColor = Color(0x1A929292),
-                ),
-                onClick = {}
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.large_reward_quest_right_icon),
-                    tint = gray500,
-                    contentDescription = null
-                )
-            }
-        }
-    }
-}
 
 @Composable
 fun LargeRewardQuestBadge(
@@ -262,85 +169,6 @@ fun LargeRewardQuestBadge(
     }
 }
 
-@Composable
-fun RewardChips(rewardList: List<Reward>) {
-    var storedList = emptyList<Reward>()
-    Column(
-        verticalArrangement = Arrangement.spacedBy(4.dp)
-    ) {
-        rewardList.forEach {
-            if (storedList.size < 3) {
-                storedList = storedList + it
-            } else {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    storedList.forEach { reward ->
-                        RewardChip(reward)
-                    }
-                    storedList = emptyList()
-                }
-            }
-        }
-        if (storedList.isNotEmpty()) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                storedList.forEach { reward ->
-                    RewardChip(reward)
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun RewardChip(reward: Reward) {
-    Box(
-        modifier = Modifier
-            .height(25.dp)
-            .border(
-                width = 1.dp,
-                color = primary,
-                shape = RoundedCornerShape(12.dp)
-            ),
-        contentAlignment = Alignment.Center
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                modifier = Modifier.size(18.dp),
-                painter = painterResource(
-                    when (reward.content) {
-                        "INTELLECT" -> R.drawable.bulb
-                        "SOCIABILITY" -> R.drawable.social
-                        "STRENGTH" -> R.drawable.strength
-                        "FUN" -> R.drawable.`fun`
-                        else -> R.drawable.heart
-                    }
-                ),
-                tint = Color.Unspecified,
-                contentDescription = null
-            )
-
-            Text(
-                text = "${reward.quantity}",
-                style = caption02,
-                color = primary
-            )
-            Spacer(Modifier.width(1.dp))
-            Text(
-                text = "P",
-                style = caption02,
-                color = primary
-            )
-        }
-    }
-}
-
-private val largeRewardQuestWriterBackgroundColor = Color(0xFFF1F5FF)
 
 private val largeRewardQuestsContentTitleStyle = TextStyle(
     fontSize = 19.sp,
@@ -352,19 +180,6 @@ private val largeRewardQuestTapStyle = TextStyle(
     fontSize = 14.sp,
     lineHeight = 18.sp,
     fontFamily = FontFamily(Font(pretendard_semibold))
-)
-
-private val largeRewardQuestTitleStyle = TextStyle(
-    fontSize = 15.sp,
-    lineHeight = 20.sp,
-    fontFamily = FontFamily(Font(pretendard_semibold))
-)
-
-private val largeRewardQuestWriterStyle = TextStyle(
-    fontSize = 11.sp,
-    lineHeight = 16.sp,
-    fontFamily = FontFamily(Font(pretendard_regular)),
-    color = gray400
 )
 
 

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/PopularQuestsContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/PopularQuestsContent.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.feature.home.home
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,6 +16,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -25,12 +27,15 @@ import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
 import coil3.compose.AsyncImage
 import com.ilsangtech.ilsang.core.model.Quest
+import com.ilsangtech.ilsang.core.model.QuestType
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_semibold
 import com.ilsangtech.ilsang.designsystem.theme.gray400
 import com.ilsangtech.ilsang.feature.home.BuildConfig
+import com.ilsangtech.ilsang.feature.home.quest.QuestTypeBadge
 
 
 @Composable
@@ -47,35 +52,56 @@ fun PopularQuestCard(
         ),
         onClick = onCardClick
     ) {
-        AsyncImage(
-            modifier = Modifier.height(160.dp),
-            model = BuildConfig.IMAGE_URL + quest.mainImageId,
-            contentScale = ContentScale.Crop,
-            contentDescription = quest.missionTitle
-        )
-        Spacer(Modifier.height(9.dp))
-        Column(
-            modifier = Modifier
-                .padding(horizontal = 16.dp)
-                .padding(bottom = 16.dp)
-                .fillMaxWidth()
-                .height(
-                    popularQuestCardTitleStyle.lineHeight.value.dp * 2
-                            + popularQuestCardWriterStyle.lineHeight.value.dp
+        Box {
+            Box(
+                modifier = Modifier
+                    .zIndex(1f)
+                    .align(Alignment.TopEnd)
+                    .padding(top = 16.dp, end = 16.dp)
+            ) {
+                if (quest.type == QuestType.REPEAT.name) {
+                    QuestTypeBadge(
+                        repeatType = QuestType.REPEAT.title
+                    )
+                } else {
+                    LargeRewardQuestBadge(
+                        xpSum = quest.rewardList.sumOf { it.quantity }
+                    )
+                }
+            }
+
+            Column {
+                AsyncImage(
+                    modifier = Modifier.height(160.dp),
+                    model = BuildConfig.IMAGE_URL + quest.mainImageId,
+                    contentScale = ContentScale.Crop,
+                    contentDescription = quest.missionTitle
                 )
-        ) {
-            Text(
-                text = quest.missionTitle,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                style = popularQuestCardTitleStyle
-            )
-            Text(
-                text = quest.writer,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                style = popularQuestCardWriterStyle
-            )
+                Spacer(Modifier.height(9.dp))
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 16.dp)
+                        .fillMaxWidth()
+                        .height(
+                            popularQuestCardTitleStyle.lineHeight.value.dp * 2
+                                    + popularQuestCardWriterStyle.lineHeight.value.dp
+                        )
+                ) {
+                    Text(
+                        text = quest.missionTitle,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        style = popularQuestCardTitleStyle
+                    )
+                    Text(
+                        text = quest.writer,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        style = popularQuestCardWriterStyle
+                    )
+                }
+            }
         }
     }
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/PopularQuestsContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/PopularQuestsContent.kt
@@ -36,15 +36,16 @@ import com.ilsangtech.ilsang.feature.home.BuildConfig
 @Composable
 fun PopularQuestCard(
     modifier: Modifier = Modifier,
-    quest: Quest
+    quest: Quest,
+    onCardClick: () -> Unit
 ) {
     Card(
         modifier = modifier,
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(
             containerColor = Color.White
-        )
-
+        ),
+        onClick = onCardClick
     ) {
         AsyncImage(
             modifier = Modifier.height(160.dp),
@@ -79,7 +80,10 @@ fun PopularQuestCard(
     }
 }
 
-fun LazyListScope.popularQuestsContent(popularQuests: List<Quest>) {
+fun LazyListScope.popularQuestsContent(
+    popularQuests: List<Quest>,
+    onPopularQuestClick: (Quest) -> Unit
+) {
     item {
         Text(
             modifier = Modifier.padding(horizontal = 20.dp),
@@ -110,12 +114,14 @@ fun LazyListScope.popularQuestsContent(popularQuests: List<Quest>) {
                     ) {
                         PopularQuestCard(
                             modifier = Modifier.weight(1f),
-                            quest = questSubList[index]
+                            quest = questSubList[index],
+                            onCardClick = { onPopularQuestClick(questSubList[index]) }
                         )
                         Spacer(Modifier.width(8.dp))
                         PopularQuestCard(
                             modifier = Modifier.weight(1f),
-                            quest = questSubList[index + 1]
+                            quest = questSubList[index + 1],
+                            onCardClick = { onPopularQuestClick(questSubList[index + 1]) }
                         )
                     }
                     if (index != questSubList.size - 1) {

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/RecommenedQuestContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/RecommenedQuestContent.kt
@@ -37,7 +37,8 @@ import com.ilsangtech.ilsang.feature.home.BuildConfig
 @Composable
 fun RecommendedQuestsContent(
     userNickname: String?,
-    recommendedQuests: List<Quest>
+    recommendedQuests: List<Quest>,
+    onRecommendedQuestClick: (Quest) -> Unit
 ) {
     Column(
         modifier = Modifier.padding(horizontal = 20.dp)
@@ -51,14 +52,20 @@ fun RecommendedQuestsContent(
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             items(recommendedQuests) { quest ->
-                RecommendedQuestView(quest)
+                RecommendedQuestView(
+                    quest = quest,
+                    onCardClick = { onRecommendedQuestClick(quest) }
+                )
             }
         }
     }
 }
 
 @Composable
-fun RecommendedQuestView(quest: Quest) {
+fun RecommendedQuestView(
+    quest: Quest,
+    onCardClick: () -> Unit
+) {
     Card(
         modifier = Modifier.size(
             width = 152.dp,
@@ -67,7 +74,8 @@ fun RecommendedQuestView(quest: Quest) {
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(
             containerColor = Color.White,
-        )
+        ),
+        onClick = onCardClick
     ) {
 
         Column(

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/DefaultQuestCard.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/DefaultQuestCard.kt
@@ -22,6 +22,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,6 +56,16 @@ fun DefaultQuestCard(
     quest: Quest,
     badge: @Composable (Modifier) -> Unit
 ) {
+    var showBottomSheet by remember { mutableStateOf(false) }
+
+    if (showBottomSheet) {
+        QuestBottomSheet(
+            quest = quest,
+            showBottomSheet = showBottomSheet,
+            onDismiss = { showBottomSheet = false }
+        )
+    }
+
     Card(
         modifier = modifier,
         colors = CardDefaults.cardColors(
@@ -115,7 +129,7 @@ fun DefaultQuestCard(
                 colors = IconButtonDefaults.filledIconButtonColors(
                     containerColor = Color(0x1A929292),
                 ),
-                onClick = {}
+                onClick = { showBottomSheet = true }
             ) {
                 Icon(
                     painter = painterResource(R.drawable.large_reward_quest_right_icon),

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/DefaultQuestCard.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/DefaultQuestCard.kt
@@ -1,0 +1,221 @@
+package com.ilsangtech.ilsang.feature.home.quest
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import coil3.compose.AsyncImage
+import com.ilsangtech.ilsang.core.model.Quest
+import com.ilsangtech.ilsang.core.model.Reward
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_semibold
+import com.ilsangtech.ilsang.designsystem.theme.caption02
+import com.ilsangtech.ilsang.designsystem.theme.gray400
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.feature.home.BuildConfig
+import com.ilsangtech.ilsang.feature.home.R
+
+@Composable
+fun DefaultQuestCard(
+    modifier: Modifier = Modifier,
+    quest: Quest,
+    badge: @Composable (Modifier) -> Unit
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = Color.White
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = 23.dp,
+                    vertical = 20.dp
+                )
+        ) {
+            Box(
+                modifier = Modifier.padding(
+                    top = 10.dp,
+                    end = 10.dp
+                )
+            ) {
+                badge(
+                    modifier
+                        .align(Alignment.TopEnd)
+                        .zIndex(2f)
+                        .offset(x = 10.dp, y = (-10).dp)
+                )
+                AsyncImage(
+                    modifier = Modifier
+                        .zIndex(1f)
+                        .size(60.dp)
+                        .clip(CircleShape)
+                        .background(
+                            color = defaultQuestCardWriterBackgroundColor,
+                        ),
+                    model = BuildConfig.IMAGE_URL + quest.imageId,
+                    contentDescription = quest.missionTitle
+                )
+            }
+            Spacer(Modifier.width(10.dp))
+            Column {
+                Text(
+                    text = quest.missionTitle,
+                    maxLines = 1,
+                    style = defaultQuestCardTitleStyle,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = quest.writer,
+                    maxLines = 1,
+                    style = defaultQuestCardWriterStyle,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(Modifier.height(4.dp))
+                RewardChips(quest.rewardList)
+            }
+            Spacer(Modifier.weight(1f))
+            FilledIconButton(
+                modifier = Modifier
+                    .size(26.dp)
+                    .align(Alignment.CenterVertically),
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = Color(0x1A929292),
+                ),
+                onClick = {}
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.large_reward_quest_right_icon),
+                    tint = gray500,
+                    contentDescription = null
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun RewardChips(rewardList: List<Reward>) {
+    var storedList = emptyList<Reward>()
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        rewardList.forEach {
+            if (storedList.size < 3) {
+                storedList = storedList + it
+            } else {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    storedList.forEach { reward ->
+                        RewardChip(reward)
+                    }
+                    storedList = emptyList()
+                }
+            }
+        }
+        if (storedList.isNotEmpty()) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                storedList.forEach { reward ->
+                    RewardChip(reward)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun RewardChip(reward: Reward) {
+    Box(
+        modifier = Modifier
+            .height(25.dp)
+            .border(
+                width = 1.dp,
+                color = primary,
+                shape = RoundedCornerShape(12.dp)
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                modifier = Modifier.size(18.dp),
+                painter = painterResource(
+                    when (reward.content) {
+                        "INTELLECT" -> R.drawable.bulb
+                        "SOCIABILITY" -> R.drawable.social
+                        "STRENGTH" -> R.drawable.strength
+                        "FUN" -> R.drawable.`fun`
+                        else -> R.drawable.heart
+                    }
+                ),
+                tint = Color.Unspecified,
+                contentDescription = null
+            )
+
+            Text(
+                text = "${reward.quantity}",
+                style = caption02,
+                color = primary
+            )
+            Spacer(Modifier.width(1.dp))
+            Text(
+                text = "P",
+                style = caption02,
+                color = primary
+            )
+        }
+    }
+}
+
+private val defaultQuestCardWriterBackgroundColor = Color(0xFFF1F5FF)
+
+private val defaultQuestCardTitleStyle = TextStyle(
+    fontSize = 15.sp,
+    lineHeight = 20.sp,
+    fontFamily = FontFamily(Font(pretendard_semibold))
+)
+
+private val defaultQuestCardWriterStyle = TextStyle(
+    fontSize = 11.sp,
+    lineHeight = 16.sp,
+    fontFamily = FontFamily(Font(pretendard_regular)),
+    color = gray400
+)

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/DefaultQuestCard.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/DefaultQuestCard.kt
@@ -143,33 +143,18 @@ fun DefaultQuestCard(
 
 @Composable
 fun RewardChips(rewardList: List<Reward>) {
-    var storedList = emptyList<Reward>()
     Column(
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        rewardList.forEach {
-            if (storedList.size < 3) {
-                storedList = storedList + it
-            } else {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    storedList.forEach { reward ->
+        rewardList
+            .chunked(3)
+            .forEach { chunk ->
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    chunk.forEach { reward ->
                         RewardChip(reward)
                     }
-                    storedList = emptyList()
                 }
             }
-        }
-        if (storedList.isNotEmpty()) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                storedList.forEach { reward ->
-                    RewardChip(reward)
-                }
-            }
-        }
     }
 }
 

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestBottomSheet.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestBottomSheet.kt
@@ -1,0 +1,490 @@
+package com.ilsangtech.ilsang.feature.home.quest
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.ilsangtech.ilsang.core.model.Quest
+import com.ilsangtech.ilsang.core.model.QuestType
+import com.ilsangtech.ilsang.core.model.Reward
+import com.ilsangtech.ilsang.core.model.RewardType
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_bold
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_semibold
+import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.designsystem.theme.badge01TextStyle
+import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.heading01
+import com.ilsangtech.ilsang.designsystem.theme.heading02
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.primary100
+import com.ilsangtech.ilsang.feature.home.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuestBottomSheet(
+    quest: Quest,
+    showBottomSheet: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val bottomSheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
+
+    if (showBottomSheet) {
+        LaunchedEffect(Unit) {
+            bottomSheetState.show()
+        }
+    } else {
+        LaunchedEffect(Unit) {
+            bottomSheetState.hide()
+        }
+    }
+
+    ModalBottomSheet(
+        sheetState = bottomSheetState,
+        onDismissRequest = { onDismiss() },
+        containerColor = Color.White,
+        dragHandle = {
+            BottomSheetDefaults.DragHandle(
+                width = 30.dp,
+                height = 4.dp,
+                color = gray100,
+                shape = RoundedCornerShape(20.dp),
+            )
+        }
+    ) {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 15.dp),
+            text = "퀘스트 정보",
+            style = questBottomSheetTitleStyle,
+            textAlign = TextAlign.Center
+        )
+        Column(
+            modifier = Modifier.padding(
+                vertical = 10.dp,
+                horizontal = 20.dp
+            )
+        ) {
+            QuestBottomSheetHeader(quest)
+            HorizontalDivider(
+                thickness = 1.dp,
+                color = gray100
+            )
+            QuestBottomSheetContent(
+                quest = quest,
+                onApproveButtonClick = {
+                    onDismiss()
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun QuestBottomSheetHeader(quest: Quest) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier.padding(top = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFFF1F5FF)),
+                model = quest.imageId,
+                contentDescription = quest.missionTitle
+            )
+            Spacer(Modifier.width(8.dp))
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text =
+                        (QuestType.entries.find {
+                            it.name == quest.type
+                        }?.title ?: "기본") + " 퀘스트",
+                    style = questBottomSheetQuestTypeTextStyle
+                )
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = quest.missionTitle,
+                    style = questBottomSheetQuestTitleStyle,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .background(
+                        color = primary100,
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    .padding(10.dp)
+            ) {
+                Text(
+                    text = "${quest.rewardList.sumOf { it.quantity }}XP",
+                    style = heading01,
+                    color = primary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun QuestBottomSheetContent(
+    quest: Quest,
+    onApproveButtonClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .background(
+                    color = primary,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .padding(
+                    horizontal = 8.dp,
+                    vertical = 4.dp
+                )
+        ) {
+            Text(
+                text = "획득 가능 스텟",
+                style = badge01TextStyle,
+                color = Color.White
+            )
+        }
+        ObtainableStatItemContent(quest.rewardList)
+        Text(
+            text = "퀘스트를 수행하셨나요?\n" +
+                    "인증 후 포인트를 적립받으세요",
+            textAlign = TextAlign.Center,
+            style = questBottomSheetDescriptionTextStyle
+        )
+        Button(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onApproveButtonClick,
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = primary
+            ),
+            contentPadding = PaddingValues(vertical = 16.dp)
+        ) {
+            Text(
+                text = "퀘스트 인증하기",
+                style = questBottomSheetApproveButtonTextStyle
+            )
+        }
+    }
+}
+
+@Composable
+fun ObtainableStatItemContent(rewardList: List<Reward>) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(32.dp)
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            val strengthReward = rewardList.find { it.content == RewardType.STRENGTH.name }
+            val intellectReward = rewardList.find { it.content == RewardType.INTELLECT.name }
+            val charmReward = rewardList.find { it.content == RewardType.CHARM.name }
+
+            ObtainableStatItem(
+                rewardType = RewardType.STRENGTH,
+                xp = strengthReward?.quantity ?: 0
+            )
+            ObtainableStatItem(
+                rewardType = RewardType.INTELLECT,
+                xp = intellectReward?.quantity ?: 0
+            )
+            ObtainableStatItem(
+                rewardType = RewardType.CHARM,
+                xp = charmReward?.quantity ?: 0
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            val funReward = rewardList.find { it.content == RewardType.FUN.name }
+            val sociabilityReward = rewardList.find { it.content == RewardType.SOCIABILITY.name }
+
+            ObtainableStatItem(
+                rewardType = RewardType.FUN,
+                xp = funReward?.quantity ?: 0
+            )
+            ObtainableStatItem(
+                rewardType = RewardType.SOCIABILITY,
+                xp = sociabilityReward?.quantity ?: 0
+            )
+        }
+    }
+}
+
+@Composable
+fun ObtainableStatItem(rewardType: RewardType, xp: Int) {
+    val painterResource = painterResource(
+        when (rewardType) {
+            RewardType.STRENGTH -> {
+                R.drawable.strength
+            }
+
+            RewardType.INTELLECT -> {
+                R.drawable.bulb
+            }
+
+            RewardType.CHARM -> {
+                R.drawable.heart
+            }
+
+            RewardType.FUN -> {
+                R.drawable.`fun`
+            }
+
+            RewardType.SOCIABILITY -> {
+                R.drawable.social
+            }
+        }
+    )
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .width(60.dp)
+                .background(
+                    color = background,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .padding(vertical = 4.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = rewardType.title,
+                style = heading02,
+                color = gray500
+            )
+        }
+        Icon(
+            modifier = Modifier.size(48.dp),
+            painter = painterResource,
+            tint = Color.Unspecified,
+            contentDescription = "보상 타입 아이콘"
+        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "${xp}P",
+                style = questBottomSheetRewardPointTextStyle
+            )
+            Icon(
+                modifier = Modifier.padding(
+                    vertical = 3.dp,
+                    horizontal = 4.dp
+                ),
+                painter = painterResource(R.drawable.quest_bottom_sheet_reward_xp_up),
+                tint = Color.Unspecified,
+                contentDescription = null
+            )
+        }
+    }
+}
+
+private val questBottomSheetTitleStyle = TextStyle(
+    fontFamily = FontFamily(Font(pretendard_bold)),
+    fontSize = 17.sp,
+    lineHeight = 22.sp,
+    color = gray500
+)
+
+private val questBottomSheetQuestTypeTextStyle = TextStyle(
+    fontFamily = FontFamily(Font(pretendard_regular)),
+    fontSize = 15.sp,
+    lineHeight = 30.sp,
+    letterSpacing = (-0.02).em,
+    color = gray500
+)
+
+private val questBottomSheetQuestTitleStyle = TextStyle(
+    fontFamily = FontFamily(Font(pretendard_bold)),
+    fontSize = 18.sp,
+    color = gray500,
+    lineHeight = 30.sp,
+    letterSpacing = (-0.02).sp,
+)
+
+private val questBottomSheetRewardPointTextStyle = TextStyle(
+    fontFamily = FontFamily(Font(pretendard_bold)),
+    fontSize = 13.sp,
+    lineHeight = 20.sp,
+    color = primary
+)
+
+private val questBottomSheetDescriptionTextStyle = TextStyle(
+    fontFamily = FontFamily(Font(pretendard_regular)),
+    fontSize = 14.sp,
+    lineHeight = 22.sp,
+    color = gray500
+)
+
+private val questBottomSheetApproveButtonTextStyle = TextStyle(
+    fontFamily = FontFamily(Font(pretendard_semibold)),
+    fontSize = 16.sp,
+    lineHeight = 18.sp,
+    color = Color.White
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+fun QuestBottomSheetPreview() {
+
+    ModalBottomSheet(
+        sheetState = rememberStandardBottomSheetState(
+            initialValue = SheetValue.Expanded
+        ),
+        onDismissRequest = { },
+        containerColor = Color.White,
+        dragHandle = {
+            BottomSheetDefaults.DragHandle(
+                width = 30.dp,
+                height = 4.dp,
+                color = gray100,
+                shape = RoundedCornerShape(20.dp),
+            )
+        }
+    ) {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 15.dp),
+            text = "퀘스트 정보",
+            style = questBottomSheetTitleStyle,
+            textAlign = TextAlign.Center
+        )
+
+        Column(
+            modifier = Modifier.padding(
+                vertical = 10.dp,
+                horizontal = 20.dp
+            )
+        ) {
+            QuestBottomSheetHeader(previewQuest)
+            HorizontalDivider(
+                thickness = 1.dp,
+                color = gray100
+            )
+            QuestBottomSheetContent(
+                quest = previewQuest,
+                onApproveButtonClick = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun QuestBottomSheetHeaderPreview() {
+    QuestBottomSheetHeader(previewQuest)
+}
+
+@Preview(showBackground = true)
+@Composable
+fun QuestBottomSheetContentPreview() {
+    QuestBottomSheetContent(quest = previewQuest) {}
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ObtainableStatItemsPreview() {
+    Column {
+        ObtainableStatItem(RewardType.STRENGTH, 100)
+        ObtainableStatItem(RewardType.INTELLECT, 1000)
+        ObtainableStatItem(RewardType.CHARM, 500)
+        ObtainableStatItem(RewardType.FUN, 300)
+        ObtainableStatItem(RewardType.SOCIABILITY, 10)
+    }
+}
+
+private val previewReward = Reward(
+    content = "",
+    quantity = 100,
+    rewardId = "",
+    type = "INTELLECT",
+    discountRate = 0,
+    questId = "",
+    target = "",
+    title = ""
+)
+
+private val previewQuest = Quest(
+    createDate = "",
+    creatorRole = "",
+    expireDate = "",
+    favoriteYn = false,
+    imageId = "",
+    mainImageId = "",
+    marketId = "",
+    missionId = "",
+    missionTitle = "아메리카노 마시기",
+    missionType = "",
+    popularYn = true,
+    questId = "",
+    rewardList = listOf(previewReward),
+    score = 40,
+    status = "",
+    target = "",
+    type = "",
+    writer = ""
+)

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabHeader.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabHeader.kt
@@ -16,10 +16,6 @@ import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
@@ -40,16 +36,30 @@ import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.designsystem.theme.primary
 
 @Composable
-fun QuestTapHeader() {
+fun QuestTapHeader(
+    selectedQuestType: QuestType,
+    selectedRewardType: RewardType,
+    onSelectQuestType: (QuestType) -> Unit,
+    onSelectRewardType: (RewardType) -> Unit
+) {
     Column {
-        QuestTypeTabRow()
+        QuestTypeTabRow(
+            selectedQuestType = selectedQuestType,
+            onSelectedQuestType = onSelectQuestType
+        )
         Spacer(Modifier.height(5.dp))
-        RewardTypeTabRow()
+        RewardTypeTabRow(
+            selectedRewardType,
+            onSelectRewardType
+        )
     }
 }
 
 @Composable
-fun QuestTypeTabRow() {
+fun QuestTypeTabRow(
+    selectedQuestType: QuestType,
+    onSelectedQuestType: (QuestType) -> Unit
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -59,20 +69,19 @@ fun QuestTypeTabRow() {
             ),
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        var selectedQuestTypeTab by remember { mutableStateOf(QuestType.entries.first()) }
         QuestType.entries.forEach { questType ->
             Box(
                 modifier = Modifier
                     .clickable(
                         interactionSource = null,
                         indication = null,
-                        onClick = { selectedQuestTypeTab = questType }
+                        onClick = { onSelectedQuestType(questType) }
                     )
             ) {
                 Text(
                     text = questType.title,
                     style = questTypeTabTitleStyle,
-                    color = if (selectedQuestTypeTab == questType) gray500 else gray300
+                    color = if (selectedQuestType == questType) gray500 else gray300
                 )
             }
         }
@@ -80,18 +89,20 @@ fun QuestTypeTabRow() {
 }
 
 @Composable
-fun RewardTypeTabRow() {
-    var selectedRewardTypeTab by remember { mutableStateOf(RewardType.entries.first()) }
+fun RewardTypeTabRow(
+    selectedRewardType: RewardType,
+    onSelectRewardType: (RewardType) -> Unit
+) {
     TabRow(
         modifier = Modifier.fillMaxWidth(),
         containerColor = Color.Transparent,
-        selectedTabIndex = RewardType.entries.indexOf(selectedRewardTypeTab),
+        selectedTabIndex = RewardType.entries.indexOf(selectedRewardType),
         indicator = { tabPositions ->
-            if (RewardType.entries.indexOf(selectedRewardTypeTab) < tabPositions.size)
+            if (RewardType.entries.indexOf(selectedRewardType) < tabPositions.size)
                 TabRowDefaults.PrimaryIndicator(
                     modifier = Modifier.tabIndicatorOffset(
                         currentTabPosition =
-                        tabPositions[RewardType.entries.indexOf(selectedRewardTypeTab)]
+                        tabPositions[RewardType.entries.indexOf(selectedRewardType)]
                     ),
                     color = primary,
                     shape = RectangleShape,
@@ -108,8 +119,8 @@ fun RewardTypeTabRow() {
     ) {
         RewardType.entries.forEach { rewardType ->
             Tab(
-                selected = selectedRewardTypeTab == rewardType,
-                onClick = { selectedRewardTypeTab = rewardType },
+                selected = selectedRewardType == rewardType,
+                onClick = { onSelectRewardType(rewardType) },
                 selectedContentColor = gray500,
                 unselectedContentColor = gray300
             ) {
@@ -138,11 +149,13 @@ private val rewardTypeTabTitleStyle = TextStyle(
 @Preview(showBackground = true)
 @Composable
 fun QuestTypeTabRowPreview() {
-    QuestTypeTabRow()
+    QuestTypeTabRow(
+        selectedQuestType = QuestType.REPEAT,
+    ) {}
 }
 
 @Preview(showBackground = true)
 @Composable
 fun RewardTypeTabRowPreview() {
-    RewardTypeTabRow()
+    RewardTypeTabRow(selectedRewardType = RewardType.STRENGTH) {}
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabHeader.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabHeader.kt
@@ -1,0 +1,148 @@
+package com.ilsangtech.ilsang.feature.home.quest
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.core.model.QuestType
+import com.ilsangtech.ilsang.core.model.RewardType
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_bold
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_semibold
+import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.gray300
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.primary
+
+@Composable
+fun QuestTapHeader() {
+    Column {
+        QuestTypeTabRow()
+        Spacer(Modifier.height(5.dp))
+        RewardTypeTabRow()
+    }
+}
+
+@Composable
+fun QuestTypeTabRow() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = 20.dp,
+                vertical = 10.dp
+            ),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        var selectedQuestTypeTab by remember { mutableStateOf(QuestType.entries.first()) }
+        QuestType.entries.forEach { questType ->
+            Box(
+                modifier = Modifier
+                    .clickable(
+                        interactionSource = null,
+                        indication = null,
+                        onClick = { selectedQuestTypeTab = questType }
+                    )
+            ) {
+                Text(
+                    text = questType.title,
+                    style = questTypeTabTitleStyle,
+                    color = if (selectedQuestTypeTab == questType) gray500 else gray300
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun RewardTypeTabRow() {
+    var selectedRewardTypeTab by remember { mutableStateOf(RewardType.entries.first()) }
+    TabRow(
+        modifier = Modifier.fillMaxWidth(),
+        containerColor = Color.Transparent,
+        selectedTabIndex = RewardType.entries.indexOf(selectedRewardTypeTab),
+        indicator = { tabPositions ->
+            if (RewardType.entries.indexOf(selectedRewardTypeTab) < tabPositions.size)
+                TabRowDefaults.PrimaryIndicator(
+                    modifier = Modifier.tabIndicatorOffset(
+                        currentTabPosition =
+                        tabPositions[RewardType.entries.indexOf(selectedRewardTypeTab)]
+                    ),
+                    color = primary,
+                    shape = RectangleShape,
+                    width = 40.dp,
+                    height = 3.dp
+                )
+        },
+        divider = {
+            HorizontalDivider(
+                color = gray100,
+                thickness = 0.4.dp
+            )
+        }
+    ) {
+        RewardType.entries.forEach { rewardType ->
+            Tab(
+                selected = selectedRewardTypeTab == rewardType,
+                onClick = { selectedRewardTypeTab = rewardType },
+                selectedContentColor = gray500,
+                unselectedContentColor = gray300
+            ) {
+                Text(
+                    modifier = Modifier.padding(vertical = 10.dp),
+                    text = rewardType.title,
+                    style = rewardTypeTabTitleStyle,
+                )
+            }
+        }
+    }
+}
+
+private val questTypeTabTitleStyle = TextStyle(
+    fontFamily = FontFamily(Font(pretendard_bold)),
+    fontSize = 21.sp,
+    lineHeight = 1.4.em
+)
+
+private val rewardTypeTabTitleStyle = TextStyle(
+    fontFamily = FontFamily(Font(pretendard_semibold)),
+    fontSize = 14.sp,
+    lineHeight = 24.sp
+)
+
+@Preview(showBackground = true)
+@Composable
+fun QuestTypeTabRowPreview() {
+    QuestTypeTabRow()
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RewardTypeTabRowPreview() {
+    RewardTypeTabRow()
+}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
@@ -1,0 +1,40 @@
+package com.ilsangtech.ilsang.feature.home.quest
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+
+@Composable
+fun QuestTabScreen() {
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+    ) {
+        Column {
+            QuestTapHeader()
+            Box(modifier = Modifier.fillMaxWidth()) {
+                SortTypeMenuContent(Modifier.zIndex(1f))
+                LazyColumn(
+                    modifier = Modifier.offset(y = 64.dp)
+                ) {}
+            }
+        }
+    }
+}
+
+@Preview(backgroundColor = 0xFFF6F6F6)
+@Composable
+fun QuestTabScreenPreview() {
+    QuestTabScreen()
+}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.ilsangtech.ilsang.core.model.QuestType
 
 @Composable
 fun QuestTabScreen() {
@@ -24,7 +25,10 @@ fun QuestTabScreen() {
         Column {
             QuestTapHeader()
             Box(modifier = Modifier.fillMaxWidth()) {
-                SortTypeMenuContent(Modifier.zIndex(1f))
+                SortTypeMenuContent(
+                    modifier = Modifier.zIndex(1f),
+                    questType = QuestType.NORMAL
+                )
                 LazyColumn(
                     modifier = Modifier.offset(y = 64.dp)
                 ) {}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
@@ -2,36 +2,113 @@ package com.ilsangtech.ilsang.feature.home.quest
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ilsangtech.ilsang.core.model.QuestType
+import com.ilsangtech.ilsang.core.model.RepeatQuestPeriod
+import com.ilsangtech.ilsang.core.model.RewardType
+import com.ilsangtech.ilsang.feature.home.HomeViewModel
+import com.ilsangtech.ilsang.feature.home.home.LargeRewardQuestBadge
 
 @Composable
-fun QuestTabScreen() {
+fun QuestTabScreen(homeViewModel: HomeViewModel) {
+    val selectedQuestType by homeViewModel.selectedQuestType.collectAsStateWithLifecycle()
+    val selectedRewardType by homeViewModel.selectedRewardType.collectAsStateWithLifecycle()
+    val selectedRepeatPeriod by homeViewModel.selectedRepeatPeriod.collectAsStateWithLifecycle()
+    val selectedSortType by homeViewModel.selectedSortType.collectAsStateWithLifecycle()
+    val questTabUiState by homeViewModel.questTabUiState.collectAsStateWithLifecycle()
+
+    QuestTabScreen(
+        selectedQuestType = selectedQuestType,
+        selectedRewardType = selectedRewardType,
+        selectedRepeatPeriod = selectedRepeatPeriod,
+        selectedSortType = selectedSortType,
+        questTabUiState = questTabUiState,
+        onSelectQuestType = homeViewModel::selectQuestType,
+        onSelectRewardType = homeViewModel::selectRewardType,
+        onSelectRepeatPeriod = homeViewModel::selectRepeatPeriod,
+        onSelectSortType = homeViewModel::selectSortType
+    )
+}
+
+@Composable
+fun QuestTabScreen(
+    selectedQuestType: QuestType,
+    selectedRewardType: RewardType,
+    selectedRepeatPeriod: RepeatQuestPeriod,
+    selectedSortType: String,
+    questTabUiState: QuestTabUiState,
+    onSelectQuestType: (QuestType) -> Unit,
+    onSelectRewardType: (RewardType) -> Unit,
+    onSelectRepeatPeriod: (RepeatQuestPeriod) -> Unit,
+    onSelectSortType: (String) -> Unit
+) {
     Surface(
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
     ) {
         Column {
-            QuestTapHeader()
+            QuestTapHeader(
+                selectedQuestType = selectedQuestType,
+                selectedRewardType = selectedRewardType,
+                onSelectQuestType = onSelectQuestType,
+                onSelectRewardType = onSelectRewardType
+            )
             Box(modifier = Modifier.fillMaxWidth()) {
                 SortTypeMenuContent(
                     modifier = Modifier.zIndex(1f),
-                    questType = QuestType.NORMAL
+                    questType = selectedQuestType,
+                    selectedRepeatPeriod = selectedRepeatPeriod,
+                    selectedSortType = selectedSortType,
+                    onSelectRepeatPeriod = onSelectRepeatPeriod,
+                    onSelectSortType = onSelectSortType
                 )
                 LazyColumn(
                     modifier = Modifier.offset(y = 64.dp)
-                ) {}
+                ) {
+                    if (questTabUiState is QuestTabUiState.Success) {
+                        items(questTabUiState.data.questList) { quest ->
+                            DefaultQuestCard(
+                                quest = quest,
+                                badge = { modifier ->
+                                    if (selectedQuestType == QuestType.REPEAT) {
+                                        QuestTypeBadge(
+                                            modifier = modifier,
+                                            repeatType = when (quest.target) {
+                                                "DAILY" -> "일간"
+                                                "WEEKLY" -> "주간"
+                                                else -> "월간"
+                                            }
+                                        )
+                                    } else {
+                                        LargeRewardQuestBadge(
+                                            modifier = modifier,
+                                            xpSum = quest.rewardList.sumOf { it.quantity },
+                                        )
+                                    }
+                                }
+                            )
+                        }
+                        item {
+                            Spacer(Modifier.height(64.dp))
+                        }
+                    }
+                }
             }
         }
     }
@@ -40,5 +117,17 @@ fun QuestTabScreen() {
 @Preview(backgroundColor = 0xFFF6F6F6)
 @Composable
 fun QuestTabScreenPreview() {
-    QuestTabScreen()
+    QuestTabScreen(
+        selectedQuestType = QuestType.NORMAL,
+        selectedRewardType = RewardType.STRENGTH,
+        selectedRepeatPeriod = RepeatQuestPeriod.DAILY,
+        selectedSortType = "최신순",
+        questTabUiState = QuestTabUiState.Success(
+            QuestTabUiData(emptyList())
+        ),
+        onSelectQuestType = {},
+        onSelectRewardType = {},
+        onSelectRepeatPeriod = {},
+        onSelectSortType = {}
+    )
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.feature.home.quest
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -79,7 +81,10 @@ fun QuestTabScreen(
                     onSelectSortType = onSelectSortType
                 )
                 LazyColumn(
-                    modifier = Modifier.offset(y = 64.dp)
+                    modifier = Modifier
+                        .offset(y = 64.dp)
+                        .padding(horizontal = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     if (questTabUiState is QuestTabUiState.Success) {
                         items(questTabUiState.data.questList) { quest ->

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabUiState.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabUiState.kt
@@ -1,7 +1,6 @@
 package com.ilsangtech.ilsang.feature.home.quest
 
 import com.ilsangtech.ilsang.core.model.Quest
-import com.ilsangtech.ilsang.core.model.QuestType
 
 sealed interface QuestTabUiState {
     data object Loading : QuestTabUiState
@@ -9,9 +8,5 @@ sealed interface QuestTabUiState {
     data class Error(val throwable: Throwable) : QuestTabUiState
 }
 
-data class QuestTabUiData(
-    val selectedQuestType: QuestType,
-    val selectedSortType: List<String>,
-    val questList: List<Quest>,
-)
+data class QuestTabUiData(val questList: List<Quest>)
 

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabUiState.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabUiState.kt
@@ -1,0 +1,17 @@
+package com.ilsangtech.ilsang.feature.home.quest
+
+import com.ilsangtech.ilsang.core.model.Quest
+import com.ilsangtech.ilsang.core.model.QuestType
+
+sealed interface QuestTabUiState {
+    data object Loading : QuestTabUiState
+    data class Success(val data: QuestTabUiData) : QuestTabUiState
+    data class Error(val throwable: Throwable) : QuestTabUiState
+}
+
+data class QuestTabUiData(
+    val selectedQuestType: QuestType,
+    val selectedSortType: List<String>,
+    val questList: List<Quest>,
+)
+

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTypeBadge.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTypeBadge.kt
@@ -17,7 +17,10 @@ import androidx.compose.ui.unit.dp
 import com.ilsangtech.ilsang.designsystem.theme.badge02TextStyle
 
 @Composable
-fun QuestTypeBadge(repeatType: String) {
+fun QuestTypeBadge(
+    modifier: Modifier = Modifier,
+    repeatType: String
+) {
     val badgeBrush = when (repeatType) {
         "일간" -> Brush.horizontalGradient(
             colors = listOf(
@@ -42,7 +45,7 @@ fun QuestTypeBadge(repeatType: String) {
     }
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .size(
                 width = 40.dp,
                 height = 20.dp

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTypeBadge.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTypeBadge.kt
@@ -1,0 +1,80 @@
+package com.ilsangtech.ilsang.feature.home.quest
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ilsangtech.ilsang.designsystem.theme.badge02TextStyle
+
+@Composable
+fun QuestTypeBadge(repeatType: String) {
+    val badgeBrush = when (repeatType) {
+        "일간" -> Brush.horizontalGradient(
+            colors = listOf(
+                Color(0xFF7D17FF),
+                Color(0xFFA45DFF)
+            )
+        )
+
+        "주간" -> Brush.horizontalGradient(
+            colors = listOf(
+                Color(0xFF45009E),
+                Color(0xFF7000FF)
+            )
+        )
+
+        else -> Brush.horizontalGradient(
+            colors = listOf(
+                Color(0xFF00DA30),
+                Color(0xFFD1FF05)
+            )
+        )
+    }
+
+    Box(
+        modifier = Modifier
+            .size(
+                width = 40.dp,
+                height = 20.dp
+            )
+            .background(
+                brush = badgeBrush,
+                shape = RoundedCornerShape(20.dp)
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = repeatType,
+            style = badge02TextStyle,
+            color = if (repeatType == "월간") {
+                monthlyBadgeTextColor
+            } else {
+                Color.White
+            }
+        )
+    }
+}
+
+private val monthlyBadgeTextColor = Color(0xFF005E15)
+
+@Preview(showBackground = true)
+@Composable
+private fun QuestTypeBadgePreview() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        QuestTypeBadge(repeatType = "주간")
+        QuestTypeBadge(repeatType = "일간")
+        QuestTypeBadge(repeatType = "월간")
+    }
+}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/SortTypeMenuContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/SortTypeMenuContent.kt
@@ -161,9 +161,9 @@ fun DropDownMenu(
                 Icon(
                     painter = painterResource(
                         if (!expanded) {
-                            R.drawable.dropdown_menu_down
-                        } else {
                             R.drawable.dropdown_menu_up
+                        } else {
+                            R.drawable.dropdown_menu_down
                         }
                     ),
                     contentDescription = null

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/SortTypeMenuContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/SortTypeMenuContent.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.ilsangtech.ilsang.core.model.QuestType
+import com.ilsangtech.ilsang.core.model.RepeatQuestPeriod
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
 import com.ilsangtech.ilsang.designsystem.theme.gray100
 import com.ilsangtech.ilsang.designsystem.theme.gray500
@@ -41,7 +42,11 @@ import com.ilsangtech.ilsang.feature.home.R
 @Composable
 fun SortTypeMenuContent(
     modifier: Modifier,
-    questType: QuestType
+    questType: QuestType,
+    selectedRepeatPeriod: RepeatQuestPeriod,
+    selectedSortType: String,
+    onSelectRepeatPeriod: (RepeatQuestPeriod) -> Unit,
+    onSelectSortType: (String) -> Unit
 ) {
     Row(
         modifier = modifier
@@ -54,35 +59,59 @@ fun SortTypeMenuContent(
         horizontalArrangement = Arrangement.End
     ) {
         if (questType == QuestType.REPEAT) {
-            RepeatQuestSortTypeMenu()
+            RepeatQuestSortTypeMenu(
+                repeatQuestPeriod = selectedRepeatPeriod,
+                onSelectRepeatPeriod = onSelectRepeatPeriod
+            )
         }
         Spacer(Modifier.width(8.dp))
-        QuestSortTypeMenu()
+        QuestSortTypeMenu(
+            selectedSortType = selectedSortType,
+            onSelectSortType = onSelectSortType
+        )
     }
 }
 
 @Composable
-fun RepeatQuestSortTypeMenu() {
+fun RepeatQuestSortTypeMenu(
+    repeatQuestPeriod: RepeatQuestPeriod,
+    onSelectRepeatPeriod: (RepeatQuestPeriod) -> Unit
+) {
     val questTypeList = remember { listOf("일간", "주간", "월간") }
-    var selectedSortType by remember { mutableStateOf(questTypeList.first()) }
+    val selectedTitle = when (repeatQuestPeriod) {
+        RepeatQuestPeriod.DAILY -> "일간"
+        RepeatQuestPeriod.WEEKLY -> "주간"
+        RepeatQuestPeriod.MONTHLY -> "월간"
+    }
+
     DropDownMenu(
         modifier = Modifier,
         width = 85.dp,
         titleList = questTypeList,
-        selectedTitle = selectedSortType
-    ) { type -> selectedSortType = type }
+        selectedTitle = selectedTitle,
+        onTitleSelected = { title ->
+            when (title) {
+                "일간" -> onSelectRepeatPeriod(RepeatQuestPeriod.DAILY)
+                "주간" -> onSelectRepeatPeriod(RepeatQuestPeriod.WEEKLY)
+                "월간" -> onSelectRepeatPeriod(RepeatQuestPeriod.MONTHLY)
+            }
+        }
+    )
 }
 
 @Composable
-fun QuestSortTypeMenu() {
+fun QuestSortTypeMenu(
+    selectedSortType: String,
+    onSelectSortType: (String) -> Unit
+) {
     val questTypeList = remember { listOf("포인트 높은 순", "포인트 낮은 순", "인기순") }
-    var selectedSortType by remember { mutableStateOf(questTypeList.first()) }
     DropDownMenu(
         modifier = Modifier,
         width = 150.dp,
         titleList = questTypeList,
-        selectedTitle = selectedSortType
-    ) { type -> selectedSortType = type }
+        selectedTitle = selectedSortType,
+        onTitleSelected = onSelectSortType
+    )
 }
 
 @Composable
@@ -203,6 +232,10 @@ private val dropdownMenuTitleStyle = TextStyle(
 fun SortTypeMenuContentPreview() {
     SortTypeMenuContent(
         modifier = Modifier,
-        questType = QuestType.REPEAT
+        questType = QuestType.REPEAT,
+        selectedRepeatPeriod = RepeatQuestPeriod.DAILY,
+        selectedSortType = "최신순",
+        onSelectRepeatPeriod = {},
+        onSelectSortType = {}
     )
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/SortTypeMenuContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/SortTypeMenuContent.kt
@@ -1,0 +1,199 @@
+package com.ilsangtech.ilsang.feature.home.quest
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
+import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.feature.home.R
+
+@Composable
+fun SortTypeMenuContent(modifier: Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                end = 20.dp,
+                top = 8.dp,
+                bottom = 16.dp
+            ),
+        horizontalArrangement = Arrangement.End
+    ) {
+        RepeatQuestSortTypeMenu()
+        Spacer(Modifier.width(8.dp))
+        QuestSortTypeMenu()
+    }
+}
+
+@Composable
+fun RepeatQuestSortTypeMenu() {
+    val questTypeList = remember { listOf("일간", "주간", "월간") }
+    var selectedSortType by remember { mutableStateOf(questTypeList.first()) }
+    DropDownMenu(
+        modifier = Modifier,
+        width = 85.dp,
+        titleList = questTypeList,
+        selectedTitle = selectedSortType
+    ) { type -> selectedSortType = type }
+}
+
+@Composable
+fun QuestSortTypeMenu() {
+    val questTypeList = remember { listOf("포인트 높은 순", "포인트 낮은 순", "인기순") }
+    var selectedSortType by remember { mutableStateOf(questTypeList.first()) }
+    DropDownMenu(
+        modifier = Modifier,
+        width = 150.dp,
+        titleList = questTypeList,
+        selectedTitle = selectedSortType
+    ) { type -> selectedSortType = type }
+}
+
+@Composable
+fun DropDownMenu(
+    modifier: Modifier,
+    width: Dp,
+    titleList: List<String>,
+    selectedTitle: String,
+    onTitleSelected: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column(
+        modifier = modifier
+    ) {
+        Box(
+            modifier = Modifier
+                .width(width)
+                .clickable(
+                    interactionSource = null,
+                    indication = null,
+                    onClick = { expanded = !expanded }
+                )
+                .background(
+                    color = Color.White,
+                    shape = if (!expanded) {
+                        RoundedCornerShape(8.dp)
+                    } else {
+                        RoundedCornerShape(
+                            topStart = 8.dp,
+                            topEnd = 8.dp
+                        )
+                    }
+                )
+                .padding(
+                    horizontal = 12.dp,
+                    vertical = 10.dp
+                )
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = selectedTitle,
+                    style = dropdownMenuTitleStyle
+                )
+                Spacer(Modifier.weight(1f))
+                Icon(
+                    painter = painterResource(
+                        if (!expanded) {
+                            R.drawable.dropdown_menu_down
+                        } else {
+                            R.drawable.dropdown_menu_up
+                        }
+                    ),
+                    contentDescription = null
+                )
+            }
+        }
+        if (expanded) {
+            titleList.filter { title -> title != selectedTitle }
+                .forEachIndexed { index, title ->
+                    HorizontalDivider(
+                        modifier = Modifier.width(width),
+                        color = gray100,
+                        thickness = 0.4.dp
+                    )
+                    Box(
+                        modifier = modifier
+                            .width(width)
+                            .clickable(
+                                interactionSource = null,
+                                indication = null,
+                                onClick = {
+                                    expanded = !expanded
+                                    onTitleSelected(title)
+                                }
+                            )
+                            .background(
+                                color = Color.White,
+                                shape = if (index != titleList.size - 2) {
+                                    RectangleShape
+                                } else {
+                                    RoundedCornerShape(
+                                        bottomStart = 8.dp,
+                                        bottomEnd = 8.dp
+                                    )
+                                }
+                            )
+                            .padding(
+                                horizontal = 12.dp,
+                                vertical = 10.dp
+                            )
+                    ) {
+                        Text(
+                            text = title,
+                            style = dropdownMenuTitleStyle
+                        )
+                    }
+                }
+        }
+    }
+}
+
+private val dropdownMenuTitleStyle = TextStyle(
+    fontFamily = FontFamily(Font(pretendard_regular)),
+    color = gray500,
+    fontSize = 15.sp,
+    lineHeight = 1.3.em
+)
+
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xF6F6F6,
+    heightDp = 200
+)
+@Composable
+fun SortTypeMenuContentPreview() {
+    SortTypeMenuContent(Modifier)
+}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/SortTypeMenuContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/SortTypeMenuContent.kt
@@ -32,13 +32,17 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.core.model.QuestType
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
 import com.ilsangtech.ilsang.designsystem.theme.gray100
 import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.feature.home.R
 
 @Composable
-fun SortTypeMenuContent(modifier: Modifier) {
+fun SortTypeMenuContent(
+    modifier: Modifier,
+    questType: QuestType
+) {
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -49,7 +53,9 @@ fun SortTypeMenuContent(modifier: Modifier) {
             ),
         horizontalArrangement = Arrangement.End
     ) {
-        RepeatQuestSortTypeMenu()
+        if (questType == QuestType.REPEAT) {
+            RepeatQuestSortTypeMenu()
+        }
         Spacer(Modifier.width(8.dp))
         QuestSortTypeMenu()
     }
@@ -195,5 +201,8 @@ private val dropdownMenuTitleStyle = TextStyle(
 )
 @Composable
 fun SortTypeMenuContentPreview() {
-    SortTypeMenuContent(Modifier)
+    SortTypeMenuContent(
+        modifier = Modifier,
+        questType = QuestType.REPEAT
+    )
 }

--- a/feature/home/src/main/res/drawable/dropdown_menu_down.xml
+++ b/feature/home/src/main/res/drawable/dropdown_menu_down.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="20dp"
+    android:viewportWidth="19"
+    android:viewportHeight="20">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M14.874,9.041L9.5,14.415L4.126,9.041"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#575B6C"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/home/src/main/res/drawable/dropdown_menu_up.xml
+++ b/feature/home/src/main/res/drawable/dropdown_menu_up.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="19dp"
+    android:height="20dp"
+    android:viewportWidth="19"
+    android:viewportHeight="20">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M14.874,10.959L9.5,5.585L4.126,10.959"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#575B6C"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/home/src/main/res/drawable/quest_bottom_sheet_reward_xp_up.xml
+++ b/feature/home/src/main/res/drawable/quest_bottom_sheet_reward_xp_up.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="14dp"
+    android:viewportWidth="12"
+    android:viewportHeight="14">
+  <path
+      android:pathData="M6.79,0.444C6.394,0.012 5.712,0.012 5.316,0.444L0.515,5.683C-0.073,6.324 0.382,7.358 1.252,7.358H3.779V12.88C3.779,13.433 4.226,13.88 4.779,13.88H7.233C7.785,13.88 8.233,13.433 8.233,12.88V7.358H10.854C11.724,7.358 12.18,6.324 11.592,5.683L6.79,0.444Z"
+      android:fillColor="#7C25EB"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
이슈 번호:  resolves #20 resolves #21
작업 사항:
- 퀘스트 탭 API를 연동하여 퀘스트 탭 UI를 구현하였습니다.

특이 사항:
- 현재 무한 스크롤을 구현하기에는 API 호출에 제약이 있어서 60개의 데이터를 불러온 후 직접 퀘스트 리스트를 분류하였습니다.
- 하단 시트에서 나오는 퀘스트 타이틀이 긴 경우에는 생략 처리하도록 하였습니다.

UI 화면:
<img width="382" alt="스크린샷 2025-04-13 오전 10 49 55" src="https://github.com/user-attachments/assets/71e7b00d-ed4b-496e-8723-b2ea12af857b" />
<img width="382" alt="스크린샷 2025-04-13 오전 10 50 38" src="https://github.com/user-attachments/assets/f5abac0d-01c4-4fb3-a7b6-42b1eed2de3c" />
<img width="382" alt="스크린샷 2025-04-13 오전 10 51 05" src="https://github.com/user-attachments/assets/a2f551b8-6a78-4224-afbc-1d3c6b1f3d41" />

