### PR TITLE
[Feat] 랭킹 탭 UI 및 API 연동 구현

### DIFF
--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/XpTypeRankMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/XpTypeRankMapper.kt
@@ -1,0 +1,14 @@
+package com.ilsangtech.ilsang.core.data.rank
+
+import com.ilsangtech.ilsang.core.model.UserXpTypeRank
+import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankNetworkModel
+
+fun XpTypeRankNetworkModel.toUserXpTypeRank(): UserXpTypeRank {
+    return UserXpTypeRank(
+        customerId = customerId,
+        nickname = nickname,
+        profileImage = profileImage,
+        xpPoint = xpPoint,
+        xpType = xpType
+    )
+}

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
@@ -1,7 +1,13 @@
 package com.ilsangtech.ilsang.core.data.rank.datasource
 
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankResponse
 
 interface RankDataSource {
     suspend fun getTopRankUsers(): TopUsersResponse
+    suspend fun getXpTypeRank(
+        authorization: String,
+        xpType: String,
+        size: Int
+    ): XpTypeRankResponse
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
@@ -2,12 +2,21 @@ package com.ilsangtech.ilsang.core.data.rank.datasource
 
 import com.ilsangtech.ilsang.core.network.api.RankApiService
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankResponse
 import javax.inject.Inject
 
 class RankDataSourceImpl @Inject constructor(
     private val rankApiService: RankApiService
-): RankDataSource {
+) : RankDataSource {
     override suspend fun getTopRankUsers(): TopUsersResponse {
         return rankApiService.getTopRankUsers()
+    }
+
+    override suspend fun getXpTypeRank(
+        authorization: String,
+        xpType: String,
+        size: Int
+    ): XpTypeRankResponse {
+        return rankApiService.getXpTypeRank(authorization, xpType, size)
     }
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/di/RankDataModule.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/di/RankDataModule.kt
@@ -4,6 +4,7 @@ import com.ilsangtech.ilsang.core.data.rank.datasource.RankDataSource
 import com.ilsangtech.ilsang.core.data.rank.datasource.RankDataSourceImpl
 import com.ilsangtech.ilsang.core.data.rank.repository.RankRepositoryImpl
 import com.ilsangtech.ilsang.core.domain.RankRepository
+import com.ilsangtech.ilsang.core.domain.UserRepository
 import com.ilsangtech.ilsang.core.network.api.RankApiService
 import dagger.Module
 import dagger.Provides
@@ -25,9 +26,13 @@ object RankDataModule {
     @Provides
     @Singleton
     fun provideRankRepository(
+        userRepository: UserRepository,
         rankDataSource: RankDataSource
     ): RankRepository {
-        return RankRepositoryImpl(rankDataSource)
+        return RankRepositoryImpl(
+            userRepository = userRepository,
+            rankDataSource = rankDataSource
+        )
     }
 
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
@@ -2,16 +2,32 @@ package com.ilsangtech.ilsang.core.data.rank.repository
 
 import com.ilsangtech.ilsang.core.data.rank.datasource.RankDataSource
 import com.ilsangtech.ilsang.core.data.rank.toUserRank
+import com.ilsangtech.ilsang.core.data.rank.toUserXpTypeRank
 import com.ilsangtech.ilsang.core.domain.RankRepository
+import com.ilsangtech.ilsang.core.domain.UserRepository
+import com.ilsangtech.ilsang.core.model.RewardType
 import com.ilsangtech.ilsang.core.model.UserRank
+import com.ilsangtech.ilsang.core.model.UserXpTypeRank
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
+import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankNetworkModel
 import javax.inject.Inject
 
 class RankRepositoryImpl @Inject constructor(
+    private val userRepository: UserRepository,
     private val rankDataSource: RankDataSource
 ) : RankRepository {
     override suspend fun getTopRankUsers(): List<UserRank> {
         return rankDataSource.getTopRankUsers()
             .data.map(UserRankNetworkModel::toUserRank)
     }
+
+    override suspend fun getXpTypeRank(rewardType: RewardType): List<UserXpTypeRank> {
+        return rankDataSource.getXpTypeRank(
+            authorization = userRepository.currentUser!!.authorization!!,
+            xpType = rewardType.name,
+            size = 20
+        )
+            .data.map(XpTypeRankNetworkModel::toUserXpTypeRank)
+    }
+
 }

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
@@ -1,7 +1,10 @@
 package com.ilsangtech.ilsang.core.domain
 
+import com.ilsangtech.ilsang.core.model.RewardType
 import com.ilsangtech.ilsang.core.model.UserRank
+import com.ilsangtech.ilsang.core.model.UserXpTypeRank
 
 interface RankRepository {
     suspend fun getTopRankUsers(): List<UserRank>
+    suspend fun getXpTypeRank(rewardType: RewardType): List<UserXpTypeRank>
 }

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/UserXpTypeRank.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/UserXpTypeRank.kt
@@ -1,0 +1,9 @@
+package com.ilsangtech.ilsang.core.model
+
+data class UserXpTypeRank(
+    val customerId: String,
+    val nickname: String,
+    val profileImage: String?,
+    val xpPoint: Int,
+    val xpType: String
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
@@ -1,9 +1,19 @@
 package com.ilsangtech.ilsang.core.network.api
 
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankResponse
 import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Query
 
 interface RankApiService {
     @GET("open/v1/rank/top-users")
     suspend fun getTopRankUsers(): TopUsersResponse
+
+    @GET("customer/rank")
+    suspend fun getXpTypeRank(
+        @Header("authorization") authorization: String,
+        @Query("xpType") xpType: String,
+        @Query("size") size: Int
+    ): XpTypeRankResponse
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/di/NetworkModule.kt
@@ -7,7 +7,7 @@ import com.ilsangtech.ilsang.core.network.api.ChallengeApiService
 import com.ilsangtech.ilsang.core.network.api.EmojiApiService
 import com.ilsangtech.ilsang.core.network.api.ImageApiService
 import com.ilsangtech.ilsang.core.network.api.QuestApiService
- import com.ilsangtech.ilsang.core.network.api.RankApiService
+import com.ilsangtech.ilsang.core.network.api.RankApiService
 import com.ilsangtech.ilsang.core.network.api.UserApiService
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/XpTypeRankNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/XpTypeRankNetworkModel.kt
@@ -1,0 +1,12 @@
+package com.ilsangtech.ilsang.core.network.model.rank
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class XpTypeRankNetworkModel(
+    val customerId: String,
+    val nickname: String,
+    val profileImage: String?,
+    val xpPoint: Int,
+    val xpType: String
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/XpTypeRankResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/XpTypeRankResponse.kt
@@ -1,0 +1,10 @@
+package com.ilsangtech.ilsang.core.network.model.rank
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class XpTypeRankResponse(
+    val `data`: List<XpTypeRankNetworkModel>,
+    val message: String,
+    val status: String
+)

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
@@ -26,6 +26,7 @@ import com.ilsangtech.ilsang.feature.home.approval.ApprovalScreen
 import com.ilsangtech.ilsang.feature.home.home.HomeTapScreen
 import com.ilsangtech.ilsang.feature.home.my.navigation.myTabNavigation
 import com.ilsangtech.ilsang.feature.home.quest.QuestTabScreen
+import com.ilsangtech.ilsang.feature.home.ranking.RankingScreen
 import com.ilsangtech.ilsang.feature.home.submit.SubmitScreen
 
 @Composable
@@ -88,6 +89,9 @@ fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
                     navigateToSubmit = { uri ->
                         homeViewModel.setCapturedImageUri(uri)
                         navController.navigate("Submit")
+                    },
+                    navigateToRankingTab = {
+                        navController.navigate(HomeTap.Ranking.name)
                     }
                 )
             }
@@ -102,7 +106,9 @@ fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
             composable(HomeTap.Approval.name) {
                 ApprovalScreen()
             }
-            composable(HomeTap.Ranking.name) {}
+            composable(HomeTap.Ranking.name) {
+                RankingScreen(homeViewModel)
+            }
             myTabNavigation(
                 homeViewModel = homeViewModel,
                 navigateToMyTabMain = {

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
@@ -260,4 +260,14 @@ class HomeViewModel @Inject constructor(
     fun selectChallenge(challenge: Challenge) {
         _selectedChallenge.value = challenge
     }
+
+    val rankingUiState = flow {
+        emit(
+            RewardType.entries.associateWith { rankRepository.getXpTypeRank(it) }
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = emptyMap()
+    )
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
@@ -46,7 +46,8 @@ fun HomeTapScreen(
     onApproveButtonClick: (Quest) -> Unit,
     navigateToQuestTab: () -> Unit,
     navigateToMyTab: () -> Unit,
-    navigateToSubmit: (Uri) -> Unit
+    navigateToSubmit: (Uri) -> Unit,
+    navigateToRankingTab: () -> Unit
 ) {
     val context = LocalContext.current
     var imageUri by remember { mutableStateOf<Uri?>(null) }
@@ -128,7 +129,12 @@ fun HomeTapScreen(
                     )
                 }
                 item { Spacer(Modifier.height(36.dp)) }
-                item { UserRankContent(homeTapUiState.data.topRankUsers) }
+                item {
+                    UserRankContent(
+                        rankList = homeTapUiState.data.topRankUsers,
+                        navigateToRankingTab = navigateToRankingTab
+                    )
+                }
                 item { Spacer(Modifier.height(84.dp)) }
             }
         }
@@ -191,6 +197,6 @@ fun HomeTapScreenPreview() {
     HomeTapScreen(
         "누구누구",
         HomeTapUiState.Loading,
-        {}, {}, {}, {}
+        {}, {}, {}, {}, {}
     )
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/UserRankContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/UserRankContent.kt
@@ -44,7 +44,10 @@ import com.ilsangtech.ilsang.feature.home.BuildConfig
 import com.ilsangtech.ilsang.feature.home.R
 
 @Composable
-fun UserRankContent(rankList: List<UserRank>) {
+fun UserRankContent(
+    rankList: List<UserRank>,
+    navigateToRankingTab: () -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -60,7 +63,11 @@ fun UserRankContent(rankList: List<UserRank>) {
             )
             Spacer(Modifier.weight(1f))
             Icon(
-                modifier = Modifier.clickable { },
+                modifier = Modifier.clickable(
+                    indication = null,
+                    interactionSource = null,
+                    onClick = navigateToRankingTab
+                ),
                 painter = painterResource(R.drawable.user_rank_content_right_icon),
                 tint = gray500,
                 contentDescription = null
@@ -202,7 +209,7 @@ fun UserRankContentPreview() {
                 "", "닉네임1", 300, null, 1
             )
         )
-    )
+    ) {}
 }
 
 @Preview

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/ranking/RankingTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/ranking/RankingTabScreen.kt
@@ -1,0 +1,92 @@
+package com.ilsangtech.ilsang.feature.home.ranking
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ilsangtech.ilsang.core.model.RewardType
+import com.ilsangtech.ilsang.core.model.UserXpTypeRank
+import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_bold
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.feature.home.HomeViewModel
+
+@Composable
+fun RankingScreen(homeViewModel: HomeViewModel) {
+    val rankingUiState by homeViewModel.rankingUiState.collectAsStateWithLifecycle()
+    RankingScreen(rankingUiState)
+}
+
+@Composable
+fun RankingScreen(rankingUiState: Map<RewardType, List<UserXpTypeRank>>) {
+    var selectedRewardType by remember { mutableStateOf(RewardType.entries.first()) }
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = background
+    ) {
+        Column {
+            RankingScreenHeader(modifier = Modifier.statusBarsPadding())
+            StatRankingTabRow(
+                selectedRewardType = selectedRewardType,
+                onRewardTypeSelect = { selectedRewardType = it }
+            )
+            rankingUiState[selectedRewardType]?.let { userXpTypeRanks ->
+                StatRankingTabContent(
+                    selectedRewardType = selectedRewardType,
+                    userXpTypeRanks = userXpTypeRanks,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun RankingScreenHeader(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                vertical = 10.dp,
+                horizontal = 20.dp
+            )
+    ) {
+        Text(
+            text = "랭킹",
+            style = TextStyle(
+                fontFamily = FontFamily(Font(pretendard_bold)),
+                fontSize = 21.sp,
+                lineHeight = 1.4.em,
+                lineHeightStyle = LineHeightStyle(
+                    alignment = LineHeightStyle.Alignment.Center,
+                    trim = LineHeightStyle.Trim.None
+                ),
+                color = gray500
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun RankingScreenPreview() {
+    RankingScreen(emptyMap())
+}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/ranking/StatRakingTab.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/ranking/StatRakingTab.kt
@@ -1,0 +1,299 @@
+package com.ilsangtech.ilsang.feature.home.ranking
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.ilsangtech.ilsang.core.model.RewardType
+import com.ilsangtech.ilsang.core.model.UserXpTypeRank
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_bold
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
+import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.gray300
+import com.ilsangtech.ilsang.designsystem.theme.gray400
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.heading02
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.feature.home.BuildConfig
+import com.ilsangtech.ilsang.feature.home.R
+import com.ilsangtech.ilsang.feature.home.my.util.XpLevelCalculator
+
+@Composable
+fun StatRankingTabRow(
+    selectedRewardType: RewardType,
+    onRewardTypeSelect: (RewardType) -> Unit
+) {
+    val rewardTypes = RewardType.entries
+
+    TabRow(
+        containerColor = Color.Transparent,
+        contentColor = gray500,
+        selectedTabIndex = selectedRewardType.ordinal,
+        indicator = { tabPositions ->
+            if (selectedRewardType.ordinal < rewardTypes.size) {
+                TabRowDefaults.PrimaryIndicator(
+                    modifier = Modifier
+                        .tabIndicatorOffset(tabPositions[selectedRewardType.ordinal]),
+                    width = 40.dp,
+                    height = 3.dp,
+                    color = primary,
+                    shape = RectangleShape
+                )
+            }
+        },
+        divider = { HorizontalDivider(color = gray100) }
+    ) {
+        rewardTypes.forEachIndexed { index, rewardType ->
+            Tab(
+                modifier = Modifier
+                    .height(44.sp.value.dp),
+                selected = selectedRewardType.ordinal == index,
+                onClick = { onRewardTypeSelect(rewardType) },
+                content = {
+                    Text(
+                        text = rewardType.title,
+                        style = TextStyle(
+                            fontFamily = FontFamily(Font(pretendard_bold)),
+                            fontSize = 14.sp,
+                            lineHeight = 24.sp,
+                        )
+                    )
+                },
+                selectedContentColor = Color.Black,
+                unselectedContentColor = gray300
+            )
+        }
+    }
+}
+
+@Composable
+fun StatRankingTabContent(
+    selectedRewardType: RewardType,
+    userXpTypeRanks: List<UserXpTypeRank>
+) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(
+            start = 20.dp,
+            end = 20.dp,
+            top = 20.dp,
+            bottom = 56.dp
+        )
+    ) {
+        itemsIndexed(userXpTypeRanks) { index, userStatRank ->
+            StatRankingTabContentItem(
+                rank = index,
+                rewardType = selectedRewardType,
+                userXpTypeRank = userStatRank
+            )
+        }
+    }
+}
+
+@Composable
+fun StatRankingTabContentItem(
+    rank: Int,
+    rewardType: RewardType,
+    userXpTypeRank: UserXpTypeRank
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = Color.White)
+    ) {
+        Row(
+            modifier = Modifier.padding(
+                horizontal = 19.dp,
+                vertical = 21.dp
+            ),
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            UserRankIcon(rank)
+            if (userXpTypeRank.profileImage == null) {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFFF1F5FF)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("\uD83D\uDE0D")
+                }
+            } else {
+                AsyncImage(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFFF1F5FF)),
+                    contentScale = ContentScale.Crop,
+                    model = BuildConfig.IMAGE_URL + userXpTypeRank.profileImage,
+                    contentDescription = null
+                )
+            }
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(3.dp)
+            ) {
+                Text(
+                    text = userXpTypeRank.nickname,
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(pretendard_bold)),
+                        fontSize = 15.sp,
+                        lineHeight = 20.sp,
+                        lineHeightStyle = LineHeightStyle(
+                            alignment = LineHeightStyle.Alignment.Center,
+                            trim = LineHeightStyle.Trim.None
+                        ),
+                    ),
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1
+                )
+                Text(
+                    text = "${rewardType.title}: ${userXpTypeRank.xpPoint}p",
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(pretendard_regular)),
+                        fontSize = 13.sp,
+                        lineHeight = 16.sp,
+                        lineHeightStyle = LineHeightStyle(
+                            alignment = LineHeightStyle.Alignment.Center,
+                            trim = LineHeightStyle.Trim.None
+                        ),
+                        color = gray400
+                    ),
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(primary)
+                    .padding(horizontal = 12.dp)
+            ) {
+                Text(
+                    text = "LV.${XpLevelCalculator.getCurrentLevel(userXpTypeRank.xpPoint)}",
+                    style = TextStyle(
+                        fontFamily = FontFamily(Font(pretendard_bold)),
+                        fontSize = 13.sp,
+                        lineHeight = 20.sp,
+                        lineHeightStyle = LineHeightStyle(
+                            alignment = LineHeightStyle.Alignment.Center,
+                            trim = LineHeightStyle.Trim.None
+                        ),
+                        color = Color.White
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun UserRankIcon(rank: Int) {
+    when (rank) {
+        0 -> {
+            Box(
+                modifier = Modifier.size(30.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.rank_gold),
+                    tint = Color.Unspecified,
+                    contentDescription = null
+                )
+            }
+        }
+
+        1 -> {
+            Box(
+                modifier = Modifier.size(30.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.rank_silver),
+                    tint = Color.Unspecified,
+                    contentDescription = null
+                )
+            }
+        }
+
+        2 -> {
+            Box(
+                modifier = Modifier.size(30.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.rank_bronze),
+                    tint = Color.Unspecified,
+                    contentDescription = null
+                )
+            }
+        }
+
+        else -> {
+            Box(
+                modifier = Modifier.size(30.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = (rank + 1).toString(),
+                    style = heading02.copy(color = gray500)
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun StatRankingTabContentsPreview() {
+    val userXpTypeRanks = List(20) {
+        UserXpTypeRank(
+            customerId = "",
+            nickname = "닉네임",
+            profileImage = null,
+            xpPoint = 1340,
+            xpType = ""
+        )
+    }
+    StatRankingTabContent(
+        selectedRewardType = RewardType.CHARM,
+        userXpTypeRanks
+    )
+}


### PR DESCRIPTION
이슈 번호: resolves #28 
작업 사항:
- 랭킹 관련 API를 연동하여 랭킹 탭 UI를 구현하였습니다.

특이 사항:
- 없음

UI 화면:
<img width="382" alt="스크린샷 2025-05-12 오후 11 16 20" src="https://github.com/user-attachments/assets/69df8ee9-300b-4b0c-bb8f-fe7bd04f53dd" />
