### PR TITLE
[Feat] 인증 관련 기능 및 UX 개선 

### DIFF
--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
@@ -1,7 +1,10 @@
 package com.ilsangtech.ilsang.feature.home
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -57,6 +60,7 @@ fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
                 start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
                 end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
                 bottom = paddingValues.calculateBottomPadding()
+                        - WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
             ),
             navController = navController,
             startDestination = HomeTap.Home.name

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
@@ -36,7 +36,6 @@ import com.ilsangtech.ilsang.feature.home.submit.SubmitScreen
 fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
     val navController = rememberNavController()
     val userInfo by homeViewModel.userInfo.collectAsStateWithLifecycle()
-    val homeTapUiState by homeViewModel.homeTapUiState.collectAsStateWithLifecycle()
 
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = currentBackStackEntry?.destination
@@ -68,7 +67,7 @@ fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
             composable(HomeTap.Home.name) {
                 HomeTapScreen(
                     userNickname = userInfo?.nickname,
-                    homeTapUiState = homeTapUiState,
+                    homeViewModel = homeViewModel,
                     onApproveButtonClick = {
                         homeViewModel.selectQuest(it)
                     },
@@ -90,8 +89,7 @@ fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
                             launchSingleTop = true
                         }
                     },
-                    navigateToSubmit = { uri ->
-                        homeViewModel.setCapturedImageUri(uri)
+                    navigateToSubmit = {
                         navController.navigate("Submit")
                     },
                     navigateToRankingTab = {

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/approval/ApprovalScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/approval/ApprovalScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Surface
@@ -20,7 +21,9 @@ fun ApprovalScreen(approvalViewModel: ApprovalViewModel = hiltViewModel()) {
     val randomChallenges = approvalViewModel.randomChallenges.collectAsLazyPagingItems()
 
     Surface(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding(),
         color = background
     ) {
         LazyColumn(

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -61,7 +62,9 @@ fun HomeTapScreen(
         }
 
     Surface(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding()
     ) {
         var bottomSheetQuest by remember { mutableStateOf<Quest?>(null) }
         var showBottomSheet by remember { mutableStateOf(false) }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
@@ -1,6 +1,5 @@
 package com.ilsangtech.ilsang.feature.home.home
 
-import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -32,10 +31,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.ilsangtech.ilsang.core.model.Banner
 import com.ilsangtech.ilsang.core.model.Quest
 import com.ilsangtech.ilsang.feature.home.BuildConfig
+import com.ilsangtech.ilsang.feature.home.HomeViewModel
 import com.ilsangtech.ilsang.feature.home.R
 import com.ilsangtech.ilsang.feature.home.quest.QuestBottomSheet
 import com.ilsangtech.ilsang.feature.home.util.FileManager
@@ -43,21 +45,23 @@ import com.ilsangtech.ilsang.feature.home.util.FileManager
 @Composable
 fun HomeTapScreen(
     userNickname: String?,
-    homeTapUiState: HomeTapUiState,
+    homeViewModel: HomeViewModel,
     onApproveButtonClick: (Quest) -> Unit,
     navigateToQuestTab: () -> Unit,
     navigateToMyTab: () -> Unit,
-    navigateToSubmit: (Uri) -> Unit,
+    navigateToSubmit: () -> Unit,
     navigateToRankingTab: () -> Unit
 ) {
     val context = LocalContext.current
-    var imageUri by remember { mutableStateOf<Uri?>(null) }
+    val homeTabUiState by homeViewModel.homeTapUiState.collectAsStateWithLifecycle()
+    val capturedImageFile = homeViewModel.capturedImageFile.collectAsStateWithLifecycle().value
+    val capturedImageUri =
+        remember(capturedImageFile) { FileManager.getUriForFile(capturedImageFile, context) }
+
     val imageCaptureLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { isSuccess ->
             if (isSuccess) {
-                imageUri?.let {
-                    navigateToSubmit(it)
-                }
+                navigateToSubmit()
             }
         }
 
@@ -79,26 +83,25 @@ fun HomeTapScreen(
                         bottomSheetQuest = null
                     },
                     onApproveButtonClick = {
-                        if (imageUri == null) {
-                            imageUri = FileManager.createCacheFile(context)
-                        }
-                        imageCaptureLauncher.launch(imageUri!!)
+                        imageCaptureLauncher.launch(capturedImageUri)
                     }
                 )
             }
         }
 
-        if (homeTapUiState is HomeTapUiState.Success) {
+        if (homeTabUiState is HomeTapUiState.Success) {
             LazyColumn {
                 item {
                     HomeTapTopBar(
                         onClickProfile = navigateToMyTab
                     )
                 }
-                items(homeTapUiState.data.banners) { banner -> BannerView(banner) }
+                items((homeTabUiState as HomeTapUiState.Success).data.banners) { banner ->
+                    BannerView(banner)
+                }
                 item { Spacer(Modifier.height(36.dp)) }
                 popularQuestsContent(
-                    popularQuests = homeTapUiState.data.popularQuests,
+                    popularQuests = (homeTabUiState as HomeTapUiState.Success).data.popularQuests,
                     onPopularQuestClick = {
                         bottomSheetQuest = it
                         showBottomSheet = true
@@ -109,7 +112,7 @@ fun HomeTapScreen(
                 item {
                     RecommendedQuestsContent(
                         userNickname = userNickname,
-                        recommendedQuests = homeTapUiState.data.recommendedQuests,
+                        recommendedQuests = (homeTabUiState as HomeTapUiState.Success).data.recommendedQuests,
                         onRecommendedQuestClick = {
                             bottomSheetQuest = it
                             showBottomSheet = true
@@ -120,13 +123,11 @@ fun HomeTapScreen(
                 item { Spacer(Modifier.height(36.dp)) }
                 item {
                     LargeRewardQuestsContent(
-                        largeRewardQuests = homeTapUiState.data.largeRewardQuests,
+                        largeRewardQuests = (homeTabUiState as HomeTapUiState.Success).data.largeRewardQuests,
                         navigateToQuestTab = navigateToQuestTab,
                         onApproveButtonClick = {
-                            if (imageUri == null) {
-                                imageUri = FileManager.createCacheFile(context)
-                            }
-                            imageCaptureLauncher.launch(imageUri!!)
+                            val imageUri = FileManager.getUriForFile(capturedImageFile, context)
+                            imageCaptureLauncher.launch(imageUri)
                             onApproveButtonClick(it)
                         }
                     )
@@ -134,7 +135,7 @@ fun HomeTapScreen(
                 item { Spacer(Modifier.height(36.dp)) }
                 item {
                     UserRankContent(
-                        rankList = homeTapUiState.data.topRankUsers,
+                        rankList = (homeTabUiState as HomeTapUiState.Success).data.topRankUsers,
                         navigateToRankingTab = navigateToRankingTab
                     )
                 }
@@ -199,7 +200,7 @@ fun BannerView(banner: Banner) {
 fun HomeTapScreenPreview() {
     HomeTapScreen(
         "누구누구",
-        HomeTapUiState.Loading,
+        hiltViewModel(),
         {}, {}, {}, {}, {}
     )
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/MyTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/MyTabScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,6 +41,10 @@ fun MyTabScreen(
     val userInfo by homeViewModel.userInfo.collectAsStateWithLifecycle()
     val userXpStats by homeViewModel.userXpStats.collectAsStateWithLifecycle()
     val challengePager = homeViewModel.challengePager.collectAsLazyPagingItems()
+
+    LaunchedEffect(Unit) {
+        challengePager.refresh()
+    }
 
     MyTabScreen(
         userInfo = userInfo,

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/MyTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/MyTabScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Surface
@@ -61,7 +62,9 @@ fun MyTabScreen(
     navigateToMyChallenge: (Challenge) -> Unit
 ) {
     Surface(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding()
     ) {
         var selectedMenu by remember { mutableStateOf(MyTabMenu.CHALLENGE) }
         Column(

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/NicknameEditScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/NicknameEditScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
@@ -47,6 +48,7 @@ fun NicknameEditScreen(
             homeViewModel.clearNicknameEditResult()
         }
     }
+
     NicknameEditScreen(
         originNickname = originUserInfo?.nickname ?: "",
         nickname = nickname,
@@ -70,7 +72,9 @@ fun NicknameEditScreen(
     navigateToMyTabMain: () -> Unit
 ) {
     Surface(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding(),
         color = Color.White
     ) {
         Column(modifier = Modifier.fillMaxSize()) {

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
@@ -1,6 +1,5 @@
 package com.ilsangtech.ilsang.feature.home.quest
 
-import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -19,9 +18,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -48,14 +45,14 @@ fun QuestTabScreen(
     val questTabUiState by homeViewModel.questTabUiState.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
-    var imageUri by remember { mutableStateOf<Uri?>(null) }
+    val tempFile by homeViewModel.capturedImageFile.collectAsStateWithLifecycle()
+    val tempFileUri = remember(tempFile) { FileManager.getUriForFile(tempFile, context) }
     val imageCaptureLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { isSuccess ->
             if (isSuccess) {
-                imageUri?.let {
-                    homeViewModel.setCapturedImageUri(imageUri!!)
-                    navigateToSubmit()
-                }
+                val imageUri = FileManager.getUriForFile(tempFile, context)
+                homeViewModel.setCapturedImageUri(imageUri)
+                navigateToSubmit()
             }
         }
 
@@ -71,10 +68,7 @@ fun QuestTabScreen(
         onSelectSortType = homeViewModel::selectSortType,
         onApproveButtonClick = {
             homeViewModel.selectQuest(it)
-            if (imageUri == null) {
-                imageUri = FileManager.createCacheFile(context)
-            }
-            imageCaptureLauncher.launch(imageUri!!)
+            imageCaptureLauncher.launch(tempFileUri)
         }
     )
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestTabScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -95,6 +96,7 @@ fun QuestTabScreen(
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
+            .navigationBarsPadding()
     ) {
         Column {
             QuestTapHeader(

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/ranking/RankingTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/ranking/RankingTabScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Surface
@@ -40,7 +41,9 @@ fun RankingScreen(homeViewModel: HomeViewModel) {
 fun RankingScreen(rankingUiState: Map<RewardType, List<UserXpTypeRank>>) {
     var selectedRewardType by remember { mutableStateOf(RewardType.entries.first()) }
     Surface(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding(),
         color = background
     ) {
         Column {

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/submit/SubmitScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/submit/SubmitScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -109,6 +110,11 @@ fun SubmitScreen(
 
     Column(modifier = Modifier.fillMaxSize()) {
         SubmitScreenHeader { }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding()
+    ) {
         Box(modifier = Modifier.weight(1f)) {
             AsyncImage(
                 model = ImageRequest.Builder(context)

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/util/FileManager.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/util/FileManager.kt
@@ -7,67 +7,81 @@ import android.graphics.Matrix
 import androidx.exifinterface.media.ExifInterface
 import android.net.Uri
 import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
 import java.io.File
 
 object FileManager {
-    fun createCacheFile(context: Context): Uri {
+    fun createCacheFile(context: Context): File {
+        return File.createTempFile("cache", ".jpg", context.cacheDir)
+    }
+
+    fun getUriForFile(tempFile: File, context: Context): Uri {
         return FileProvider.getUriForFile(
             context,
             "${context.packageName}.fileprovider",
-            File.createTempFile("cache", ".jpg", context.cacheDir)
+            tempFile
         )
     }
 
-    fun getBytesFromUri(context: Context, uri: Uri): ByteArray {
-        var bitmap = rotateBitmapIfRequired(context, uri)
+    suspend fun getBytesFromUri(context: Context, uri: Uri): ByteArray {
+        return withContext(Dispatchers.IO) {
+            var bitmap = rotateBitmapIfRequired(context, uri)
 
-        val maxSizeBytes = 1 * 1024 * 100 // 100KB
-        var quality = 100
-        val outputStream = ByteArrayOutputStream()
+            val maxSizeBytes = 1 * 1024 * 100 // 100KB
+            var quality = 95
+            val minQuality = 60
+            val outputStream = ByteArrayOutputStream()
 
-        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, outputStream)
-
-        while (outputStream.toByteArray().size > maxSizeBytes) {
-            if (quality > 10) {
+            // 1. 품질만 낮추면서 압축
+            bitmap.compress(Bitmap.CompressFormat.JPEG, quality, outputStream)
+            while (outputStream.toByteArray().size > maxSizeBytes && quality > minQuality) {
                 quality -= 5
-            } else {
+                outputStream.reset()
+                bitmap.compress(Bitmap.CompressFormat.JPEG, quality, outputStream)
+            }
+
+            // 2. 그래도 크면 이미지 크기를 줄여서 재시도 (점진적 다운스케일)
+            while (outputStream.toByteArray().size > maxSizeBytes) {
                 bitmap = Bitmap.createScaledBitmap(
                     bitmap,
-                    (bitmap.width * 0.8f).toInt(),
-                    (bitmap.height * 0.8f).toInt(),
+                    (bitmap.width * 0.9f).toInt(),
+                    (bitmap.height * 0.9f).toInt(),
                     true
                 )
-                quality = 100
+                quality = 90 // 다시 적절한 품질로 리셋
+                outputStream.reset()
+                bitmap.compress(Bitmap.CompressFormat.JPEG, quality, outputStream)
             }
-            outputStream.reset()
-            bitmap.compress(Bitmap.CompressFormat.JPEG, quality, outputStream)
-        }
 
-        return outputStream.toByteArray()
+            outputStream.toByteArray()
+        }
     }
 
-    private fun rotateBitmapIfRequired(context: Context, uri: Uri): Bitmap {
-        val inputStream = context.contentResolver.openInputStream(uri)!!
-        val bitmap = BitmapFactory.decodeStream(inputStream)
-        inputStream.close()
+    private suspend fun rotateBitmapIfRequired(context: Context, uri: Uri): Bitmap {
+        return withContext(Dispatchers.IO) {
+            val inputStream = context.contentResolver.openInputStream(uri)!!
+            val bitmap = BitmapFactory.decodeStream(inputStream)
+            inputStream.close()
 
-        val inputStreamForExif = context.contentResolver.openInputStream(uri)!!
-        val exif = ExifInterface(inputStreamForExif)
-        inputStreamForExif.close()
+            val inputStreamForExif = context.contentResolver.openInputStream(uri)!!
+            val exif = ExifInterface(inputStreamForExif)
+            inputStreamForExif.close()
 
-        val orientation = exif.getAttributeInt(
-            ExifInterface.TAG_ORIENTATION,
-            ExifInterface.ORIENTATION_NORMAL
-        )
+            val orientation = exif.getAttributeInt(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_NORMAL
+            )
 
-        val matrix = Matrix()
-        when (orientation) {
-            ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
-            ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
-            ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+            val matrix = Matrix()
+            when (orientation) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
+                ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
+                ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+            }
+
+            Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
         }
-
-        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
     }
 }


### PR DESCRIPTION
이슈 번호: resolves #32 
작업 사항: 
- 이미지 리사이징 함수을 변경해 이미지 해상도 개선
- 인증 챌린지 전체 화면에서 하단 패딩값이 적용되지 않도록 수정
- 마이탭 진입 시 새롭게 데이터를 리프레쉬하도록 적용
- 뷰모델에서 전송할 이미지 파일을 관리하고, 전송 이후 혹은 뷰모델 객체가 정리될 때 파일도 삭제할 수 있도록 구현

특이 사항: 없음

UI 화면: 
<img width="382" alt="스크린샷 2025-05-21 오후 9 54 42" src="https://github.com/user-attachments/assets/f0714640-08f7-44c4-944d-cd2005864283" />
