### PR TITLE
[Feat] 홈 화면 UI/UX 개선

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -21,6 +24,18 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    val keystorePropertiesFile = rootProject.file("keystore.properties")
+    val keystoreProperties = Properties()
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+
+    signingConfigs {
+        create("release") {
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
+            storeFile = file(keystoreProperties["storeFile"] as String)
+            storePassword = keystoreProperties["storePassword"] as String
+        }
+    }
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -28,6 +43,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("release")
         }
     }
     compileOptions {

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -18,19 +18,22 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
-
-        val properties = Properties()
-        properties.load(FileInputStream("local.properties"))
-        buildConfigField("String", "SERVER_URL", properties.getProperty("SERVER_URL"))
     }
 
     buildTypes {
+        val properties = Properties()
+        properties.load(FileInputStream("local.properties"))
+
         release {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            buildConfigField("String", "SERVER_URL", properties.getProperty("RELEASE_SERVER_URL"))
+        }
+        debug {
+            buildConfigField("String", "SERVER_URL", properties.getProperty("DEBUG_SERVER_URL"))
         }
     }
 

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/challenge/RandomChallengeNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/challenge/RandomChallengeNetworkModel.kt
@@ -16,5 +16,5 @@ data class RandomChallengeNetworkModel(
     val userNickName: String,
     val userProfileImage: String?,
     val viewCount: Int,
-    val title: TitleNetworkModel?
+    val title: TitleNetworkModel? = null
 )

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/UserRankNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/UserRankNetworkModel.kt
@@ -10,5 +10,5 @@ data class UserRankNetworkModel(
     val nickname: String,
     val profileImage: String?,
     val xpSum: Int,
-    val title: TitleNetworkModel?
+    val title: TitleNetworkModel? = null
 )

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/XpTypeRankNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/XpTypeRankNetworkModel.kt
@@ -10,6 +10,6 @@ data class XpTypeRankNetworkModel(
     val profileImage: String?,
     val xpPoint: Int,
     val xpType: String,
-    val title: TitleNetworkModel?,
-    val xpTotalPoint: Int
+    val title: TitleNetworkModel? = null,
+    val xpTotalPoint: Int? = null
 )

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserInfoNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserInfoNetworkModel.kt
@@ -11,5 +11,5 @@ data class UserInfoNetworkModel(
     val profileImage: String?,
     val status: String,
     val xpPoint: Int,
-    val title: TitleNetworkModel?
+    val title: TitleNetworkModel? = null
 )

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -18,19 +18,22 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
-
-        val properties = Properties()
-        properties.load(FileInputStream("local.properties"))
-        buildConfigField("String", "IMAGE_URL", properties.getProperty("IMAGE_URL"))
     }
 
     buildTypes {
+        val properties = Properties()
+        properties.load(FileInputStream("local.properties"))
+
         release {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            buildConfigField("String", "IMAGE_URL", properties.getProperty("RELEASE_IMAGE_URL"))
+        }
+        debug {
+            buildConfigField("String", "IMAGE_URL", properties.getProperty("DEBUG_IMAGE_URL"))
         }
     }
     compileOptions {

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -14,7 +15,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
@@ -27,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -96,8 +99,11 @@ fun HomeTapScreen(
                         onClickProfile = navigateToMyTab
                     )
                 }
-                items((homeTabUiState as HomeTapUiState.Success).data.banners) { banner ->
-                    BannerView(banner)
+                item {
+                    BannerView(
+                        banners = (homeTabUiState as HomeTapUiState.Success).data.banners,
+                        onClick = navigateToQuestTab
+                    )
                 }
                 item { Spacer(Modifier.height(36.dp)) }
                 item {
@@ -185,16 +191,34 @@ fun HomeTapTopBar(
     }
 }
 
-
 @Composable
-fun BannerView(banner: Banner) {
-    AsyncImage(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp)),
-        model = BuildConfig.IMAGE_URL + banner.imageId,
-        contentDescription = banner.description
-    )
+fun BannerView(
+    banners: List<Banner>,
+    onClick: () -> Unit
+) {
+    val pagerState = rememberPagerState { banners.size }
+    HorizontalPager(
+        state = pagerState
+    ) { page ->
+        AsyncImage(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(11 / 10f)
+                .clip(RoundedCornerShape(12.dp))
+                .clickable(
+                    onClick = {
+                        if (banners[page].description.contains("quest")) {
+                            onClick()
+                        }
+                    },
+                    indication = null,
+                    interactionSource = null
+                ),
+            contentScale = ContentScale.Crop,
+            model = BuildConfig.IMAGE_URL + banners[page].imageId,
+            contentDescription = banners[page].description
+        )
+    }
 }
 
 @Preview

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
@@ -100,14 +100,16 @@ fun HomeTapScreen(
                     BannerView(banner)
                 }
                 item { Spacer(Modifier.height(36.dp)) }
-                popularQuestsContent(
-                    popularQuests = (homeTabUiState as HomeTapUiState.Success).data.popularQuests,
-                    onPopularQuestClick = {
-                        bottomSheetQuest = it
-                        showBottomSheet = true
-                        onApproveButtonClick(it)
-                    }
-                )
+                item {
+                    PopularQuestsContent(
+                        popularQuests = (homeTabUiState as HomeTapUiState.Success).data.popularQuests,
+                        onPopularQuestClick = {
+                            bottomSheetQuest = it
+                            showBottomSheet = true
+                            onApproveButtonClick(it)
+                        }
+                    )
+                }
                 item { Spacer(Modifier.height(36.dp)) }
                 item {
                     RecommendedQuestsContent(

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/PopularQuestsContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/PopularQuestsContent.kt
@@ -1,5 +1,7 @@
 package com.ilsangtech.ilsang.feature.home.home
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,10 +9,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -33,7 +36,9 @@ import com.ilsangtech.ilsang.core.model.Quest
 import com.ilsangtech.ilsang.core.model.QuestType
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_semibold
+import com.ilsangtech.ilsang.designsystem.theme.gray100
 import com.ilsangtech.ilsang.designsystem.theme.gray400
+import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.feature.home.BuildConfig
 import com.ilsangtech.ilsang.feature.home.quest.QuestTypeBadge
 
@@ -106,11 +111,15 @@ fun PopularQuestCard(
     }
 }
 
-fun LazyListScope.popularQuestsContent(
+@Composable
+fun PopularQuestsContent(
     popularQuests: List<Quest>,
     onPopularQuestClick: (Quest) -> Unit
 ) {
-    item {
+    val pageCount = popularQuests.size / 4
+    val pagerState = rememberPagerState { pageCount }
+
+    Column {
         Text(
             modifier = Modifier.padding(horizontal = 20.dp),
             text = "이번달 인기 퀘스트 모음",
@@ -120,14 +129,7 @@ fun LazyListScope.popularQuestsContent(
                 fontFamily = FontFamily(Font(pretendard_semibold)),
             )
         )
-    }
-    item {
         Spacer(Modifier.height(12.dp))
-    }
-    item {
-        val pageCount = popularQuests.size / 4
-        val pagerState = rememberPagerState { pageCount }
-
         HorizontalPager(
             state = pagerState
         ) {
@@ -154,6 +156,27 @@ fun LazyListScope.popularQuestsContent(
                         Spacer(Modifier.height(8.dp))
                     }
                 }
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+        Row(
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            repeat(pageCount) {
+                val color = if (pagerState.currentPage == it) {
+                    gray500
+                } else {
+                    gray100
+                }
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .background(
+                            color = color,
+                            shape = CircleShape
+                        )
+                )
             }
         }
     }


### PR DESCRIPTION
이슈 번호: resolves #38
작업 사항:
- 배너 리스트 가로로 배치, 클릭 이벤트 지정
- 인기 퀘스트 모음 하단에 인디케이터 추가

특이 사항: 
- 디버그/배포 타입 별로 분리해 BuildConfig 적용

UI 화면: 
<img width="382" alt="스크린샷 2025-05-26 오후 9 57 28" src="https://github.com/user-attachments/assets/4cb9833d-d31e-4c78-9fc1-831b3ff4da21" />
