### PR TITLE
[Fx] 홈 탭 버그 수정 및 UX 개선

### DIFF
--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeScreen.kt
@@ -87,13 +87,20 @@ fun HomeScreen(homeViewModel: HomeViewModel = hiltViewModel()) {
                                 saveState = true
                             }
                             launchSingleTop = true
+                            restoreState = true
                         }
                     },
                     navigateToSubmit = {
                         navController.navigate("Submit")
                     },
                     navigateToRankingTab = {
-                        navController.navigate(HomeTap.Ranking.name)
+                        navController.navigate(HomeTap.Ranking.name) {
+                            popUpTo(navController.graph.startDestinationId) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
                     }
                 )
             }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/DefaultQuestCard.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/DefaultQuestCard.kt
@@ -17,9 +17,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -72,7 +70,8 @@ fun DefaultQuestCard(
         modifier = modifier,
         colors = CardDefaults.cardColors(
             containerColor = Color.White
-        )
+        ),
+        onClick = { showBottomSheet = true }
     ) {
         Row(
             modifier = Modifier
@@ -124,21 +123,14 @@ fun DefaultQuestCard(
                 RewardChips(quest.rewardList)
             }
             Spacer(Modifier.weight(1f))
-            FilledIconButton(
+            Icon(
                 modifier = Modifier
                     .size(26.dp)
                     .align(Alignment.CenterVertically),
-                colors = IconButtonDefaults.filledIconButtonColors(
-                    containerColor = Color(0x1A929292),
-                ),
-                onClick = { showBottomSheet = true }
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.large_reward_quest_right_icon),
-                    tint = gray500,
-                    contentDescription = null
-                )
-            }
+                painter = painterResource(R.drawable.large_reward_quest_right_icon),
+                tint = gray500,
+                contentDescription = null
+            )
         }
     }
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestBottomSheet.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/quest/QuestBottomSheet.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -57,6 +56,7 @@ import com.ilsangtech.ilsang.designsystem.theme.heading01
 import com.ilsangtech.ilsang.designsystem.theme.heading02
 import com.ilsangtech.ilsang.designsystem.theme.primary
 import com.ilsangtech.ilsang.designsystem.theme.primary100
+import com.ilsangtech.ilsang.feature.home.BuildConfig
 import com.ilsangtech.ilsang.feature.home.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -138,7 +138,7 @@ fun QuestBottomSheetHeader(quest: Quest) {
                     .size(80.dp)
                     .clip(CircleShape)
                     .background(Color(0xFFF1F5FF)),
-                model = quest.imageId,
+                model = BuildConfig.IMAGE_URL + quest.imageId,
                 contentDescription = quest.missionTitle
             )
             Spacer(Modifier.width(8.dp))
@@ -147,9 +147,9 @@ fun QuestBottomSheetHeader(quest: Quest) {
             ) {
                 Text(
                     text =
-                        (QuestType.entries.find {
-                            it.name == quest.type
-                        }?.title ?: "기본") + " 퀘스트",
+                    (QuestType.entries.find {
+                        it.name == quest.type
+                    }?.title ?: "기본") + " 퀘스트",
                     style = questBottomSheetQuestTypeTextStyle
                 )
                 Text(


### PR DESCRIPTION
이슈 번호: resolves #40 
작업 사항:
- 홈 -> 유저랭킹 클릭 후 홈 탭을 클릭 시 홈 탭으로 이동하지 못하는 버그 수정
- 홈탭 큰 보상 퀘스트 카드 클릭 이벤트를 카드 전체에 적용
- 퀘스트 하단 시트에 퀘스트 이미지가 나올 수 있도록 수정

특이 사항: 없음

UI 화면:
<img width="382" alt="스크린샷 2025-05-27 오후 9 46 52" src="https://github.com/user-attachments/assets/ae0c5d0f-63ef-44e3-a559-7e9ae7ff357a" />
