### PR TITLE
[Feaet] 프로필 이미지 변경 및 삭제 기능 구현

### DIFF
--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/challenge/repository/ChallengeRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/challenge/repository/ChallengeRepositoryImpl.kt
@@ -66,6 +66,7 @@ class ChallengeRepositoryImpl(
 
     override suspend fun submitChallenge(imageBytes: ByteArray, questId: String): String {
         val imageId = imageRepository.uploadImage(
+            authorization = userRepository.currentUser?.authorization!!,
             type = "RECEIPT",
             imageBytes = imageBytes
         )

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/image/di/ImageModule.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/image/di/ImageModule.kt
@@ -4,7 +4,6 @@ import com.ilsangtech.ilsang.core.data.image.datasource.ImageDataSource
 import com.ilsangtech.ilsang.core.data.image.datasource.ImageDataSourceImpl
 import com.ilsangtech.ilsang.core.data.image.repository.ImageRepositoryImpl
 import com.ilsangtech.ilsang.core.domain.ImageRepository
-import com.ilsangtech.ilsang.core.domain.UserRepository
 import com.ilsangtech.ilsang.core.network.api.ImageApiService
 import dagger.Module
 import dagger.Provides
@@ -24,11 +23,9 @@ object ImageModule {
     @Provides
     @Singleton
     fun provideImageRepository(
-        userRepository: UserRepository,
         imageDataSource: ImageDataSource
     ): ImageRepository {
         return ImageRepositoryImpl(
-            userRepository = userRepository,
             imageDataSource = imageDataSource
         )
     }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/image/repository/ImageRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/image/repository/ImageRepositoryImpl.kt
@@ -2,11 +2,9 @@ package com.ilsangtech.ilsang.core.data.image.repository
 
 import com.ilsangtech.ilsang.core.data.image.datasource.ImageDataSource
 import com.ilsangtech.ilsang.core.domain.ImageRepository
-import com.ilsangtech.ilsang.core.domain.UserRepository
 import javax.inject.Inject
 
 class ImageRepositoryImpl @Inject constructor(
-    private val userRepository: UserRepository,
     private val imageDataSource: ImageDataSource
 ) : ImageRepository {
     override suspend fun getImageUrl(imageId: String): String {
@@ -14,10 +12,10 @@ class ImageRepositoryImpl @Inject constructor(
     }
 
     override suspend fun uploadImage(
+        authorization: String,
         type: String,
         imageBytes: ByteArray
     ): String {
-        val authorization = userRepository.currentUser!!.authorization!!
         return imageDataSource.uploadImage(
             type = type,
             authorization = authorization,

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSource.kt
@@ -3,6 +3,7 @@ package com.ilsangtech.ilsang.core.data.user.datasource
 import com.ilsangtech.ilsang.core.network.model.auth.LoginRequest
 import com.ilsangtech.ilsang.core.network.model.auth.LoginResponse
 import com.ilsangtech.ilsang.core.network.model.user.NicknameUpdateResponse
+import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserXpStatsResponse
 
@@ -14,4 +15,6 @@ interface UserDataSource {
     suspend fun getUserXpStats(authorization: String, customerId: String?): UserXpStatsResponse
 
     suspend fun updateUserNickname(authorization: String, nickname: String): NicknameUpdateResponse
+
+    suspend fun updateUserImage(authorization: String, imageId: String): UserImageUpdateResponse
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSource.kt
@@ -3,6 +3,7 @@ package com.ilsangtech.ilsang.core.data.user.datasource
 import com.ilsangtech.ilsang.core.network.model.auth.LoginRequest
 import com.ilsangtech.ilsang.core.network.model.auth.LoginResponse
 import com.ilsangtech.ilsang.core.network.model.user.NicknameUpdateResponse
+import com.ilsangtech.ilsang.core.network.model.user.UserImageDeleteResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserXpStatsResponse
@@ -17,4 +18,6 @@ interface UserDataSource {
     suspend fun updateUserNickname(authorization: String, nickname: String): NicknameUpdateResponse
 
     suspend fun updateUserImage(authorization: String, imageId: String): UserImageUpdateResponse
+
+    suspend fun deleteUserImage(authorization: String): UserImageDeleteResponse
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSourceImpl.kt
@@ -6,6 +6,8 @@ import com.ilsangtech.ilsang.core.network.model.auth.LoginRequest
 import com.ilsangtech.ilsang.core.network.model.auth.LoginResponse
 import com.ilsangtech.ilsang.core.network.model.user.NicknameUpdateRequest
 import com.ilsangtech.ilsang.core.network.model.user.NicknameUpdateResponse
+import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateRequest
+import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserXpStatsResponse
 import javax.inject.Inject
@@ -36,6 +38,16 @@ class UserDataSourceImpl @Inject constructor(
         return userApiService.updateUserNickname(
             authorization,
             NicknameUpdateRequest(nickname)
+        )
+    }
+
+    override suspend fun updateUserImage(
+        authorization: String,
+        imageId: String
+    ): UserImageUpdateResponse {
+        return userApiService.updateUserImage(
+            authorization,
+            UserImageUpdateRequest(imageId)
         )
     }
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.ilsangtech.ilsang.core.network.model.auth.LoginRequest
 import com.ilsangtech.ilsang.core.network.model.auth.LoginResponse
 import com.ilsangtech.ilsang.core.network.model.user.NicknameUpdateRequest
 import com.ilsangtech.ilsang.core.network.model.user.NicknameUpdateResponse
+import com.ilsangtech.ilsang.core.network.model.user.UserImageDeleteResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateRequest
 import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
@@ -49,5 +50,9 @@ class UserDataSourceImpl @Inject constructor(
             authorization,
             UserImageUpdateRequest(imageId)
         )
+    }
+
+    override suspend fun deleteUserImage(authorization: String): UserImageDeleteResponse {
+        return userApiService.deleteUserImage(authorization)
     }
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/di/UserDataModule.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/di/UserDataModule.kt
@@ -4,6 +4,7 @@ import com.ilsangtech.ilsang.core.data.user.datasource.UserDataSource
 import com.ilsangtech.ilsang.core.data.user.datasource.UserDataSourceImpl
 import com.ilsangtech.ilsang.core.data.user.repository.UserRepositoryImpl
 import com.ilsangtech.ilsang.core.datastore.UserDataStore
+import com.ilsangtech.ilsang.core.domain.ImageRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
 import com.ilsangtech.ilsang.core.network.api.AuthApiService
 import com.ilsangtech.ilsang.core.network.api.UserApiService
@@ -32,8 +33,13 @@ object UserDataModule {
     @Singleton
     fun provideUserRepository(
         userDataSource: UserDataSource,
-        userDataStore: UserDataStore
+        userDataStore: UserDataStore,
+        imageRepository: ImageRepository
     ): UserRepository {
-        return UserRepositoryImpl(userDataSource, userDataStore)
+        return UserRepositoryImpl(
+            userDataSource = userDataSource,
+            userDataStore = userDataStore,
+            imageRepository = imageRepository
+        )
     }
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -98,6 +98,16 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun deleteUserImage(): Result<Unit> {
+        return runCatching {
+            currentUser?.authorization?.let {
+                userDataSource.deleteUserImage(
+                    authorization = it
+                )
+            } ?: throw Exception("User is not logged in")
+        }
+    }
+
     override suspend fun completeOnBoarding() {
         userDataStore.setShouldShowOnBoarding(false)
     }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.ilsangtech.ilsang.core.data.user.repository
 import com.ilsangtech.ilsang.core.data.user.datasource.UserDataSource
 import com.ilsangtech.ilsang.core.data.user.toUserXpStats
 import com.ilsangtech.ilsang.core.datastore.UserDataStore
+import com.ilsangtech.ilsang.core.domain.ImageRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
 import com.ilsangtech.ilsang.core.model.UserInfo
 import com.ilsangtech.ilsang.core.model.UserXpStats
@@ -12,7 +13,8 @@ import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
     private val userDataSource: UserDataSource,
-    private val userDataStore: UserDataStore
+    private val userDataStore: UserDataStore,
+    private val imageRepository: ImageRepository
 ) : UserRepository {
     override var currentUser: UserInfo? = null
 
@@ -77,6 +79,22 @@ class UserRepositoryImpl @Inject constructor(
                 authorization = it,
                 nickname = nickname
             )
+        }
+    }
+
+    override suspend fun updateUserImage(imageData: ByteArray): Result<Unit> {
+        return runCatching {
+            currentUser?.authorization?.let {
+                val imageId = imageRepository.uploadImage(
+                    authorization = it,
+                    type = "USER_PROFILE_IMAGE",
+                    imageBytes = imageData
+                )
+                userDataSource.updateUserImage(
+                    authorization = it,
+                    imageId = imageId
+                )
+            } ?: throw Exception("User is not logged in")
         }
     }
 

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/ImageRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/ImageRepository.kt
@@ -4,6 +4,7 @@ interface ImageRepository {
     suspend fun getImageUrl(imageId: String): String
 
     suspend fun uploadImage(
+        authorization: String,
         type: String,
         imageBytes: ByteArray
     ): String

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
@@ -19,5 +19,7 @@ interface UserRepository {
 
     suspend fun updateUserImage(imageData: ByteArray): Result<Unit>
 
+    suspend fun deleteUserImage(): Result<Unit>
+
     suspend fun completeOnBoarding()
 }

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
@@ -17,5 +17,7 @@ interface UserRepository {
 
     suspend fun updateUserNickname(nickname: String)
 
+    suspend fun updateUserImage(imageData: ByteArray): Result<Unit>
+
     suspend fun completeOnBoarding()
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/UserApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/UserApiService.kt
@@ -2,11 +2,13 @@ package com.ilsangtech.ilsang.core.network.api
 
 import com.ilsangtech.ilsang.core.network.model.user.NicknameUpdateRequest
 import com.ilsangtech.ilsang.core.network.model.user.NicknameUpdateResponse
+import com.ilsangtech.ilsang.core.network.model.user.UserImageDeleteResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateRequest
 import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserXpStatsResponse
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.PUT
@@ -36,4 +38,9 @@ interface UserApiService {
         @Header("authorization") authorization: String,
         @Body imageUpdateRequest: UserImageUpdateRequest
     ): UserImageUpdateResponse
+
+    @DELETE("customer/user/image")
+    suspend fun deleteUserImage(
+        @Header("authorization") authorization: String
+    ): UserImageDeleteResponse
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/UserApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/UserApiService.kt
@@ -2,6 +2,8 @@ package com.ilsangtech.ilsang.core.network.api
 
 import com.ilsangtech.ilsang.core.network.model.user.NicknameUpdateRequest
 import com.ilsangtech.ilsang.core.network.model.user.NicknameUpdateResponse
+import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateRequest
+import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserXpStatsResponse
 import retrofit2.http.Body
@@ -28,4 +30,10 @@ interface UserApiService {
         @Header("authorization") authorization: String,
         @Body nicknameUpdateRequest: NicknameUpdateRequest
     ): NicknameUpdateResponse
+
+    @PUT("customer/user/image")
+    suspend fun updateUserImage(
+        @Header("authorization") authorization: String,
+        @Body imageUpdateRequest: UserImageUpdateRequest
+    ): UserImageUpdateResponse
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserImageDeleteResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserImageDeleteResponse.kt
@@ -1,0 +1,11 @@
+package com.ilsangtech.ilsang.core.network.model.user
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+data class UserImageDeleteResponse(
+    val data: JsonObject,
+    val status: String,
+    val message: String
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserImageUpdateRequest.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserImageUpdateRequest.kt
@@ -1,0 +1,8 @@
+package com.ilsangtech.ilsang.core.network.model.user
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserImageUpdateRequest(
+    val imageId: String
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserImageUpdateResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserImageUpdateResponse.kt
@@ -1,0 +1,11 @@
+package com.ilsangtech.ilsang.core.network.model.user
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+data class UserImageUpdateResponse(
+    val data: JsonObject,
+    val status: Boolean,
+    val message: String
+)

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
@@ -230,6 +230,19 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    fun deleteUserProfileImage() {
+        viewModelScope.launch {
+            userRepository.deleteUserImage()
+                .onSuccess {
+                    userRepository.updateUserInfo()
+                    _userInfo.update { userRepository.currentUser }
+                    _isUserProfileEditSuccess.update { true }
+                }.onFailure {
+                    _isUserProfileEditSuccess.update { false }
+                }
+        }
+    }
+
     fun resetUserProfileEditSuccess() {
         _editNickname.value = _userInfo.value?.nickname ?: ""
         _nicknameEditErrorMessage.update { null }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/home/HomeTapScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
@@ -57,6 +58,7 @@ fun HomeTapScreen(
 ) {
     val context = LocalContext.current
     val homeTabUiState by homeViewModel.homeTapUiState.collectAsStateWithLifecycle()
+    val userInfo by homeViewModel.userInfo.collectAsStateWithLifecycle()
     val capturedImageFile = homeViewModel.capturedImageFile.collectAsStateWithLifecycle().value
     val capturedImageUri =
         remember(capturedImageFile) { FileManager.getUriForFile(capturedImageFile, context) }
@@ -96,6 +98,7 @@ fun HomeTapScreen(
             LazyColumn {
                 item {
                     HomeTapTopBar(
+                        imageId = userInfo?.profileImage,
                         onClickProfile = navigateToMyTab
                     )
                 }
@@ -156,6 +159,7 @@ fun HomeTapScreen(
 @Composable
 fun HomeTapTopBar(
     modifier: Modifier = Modifier,
+    imageId: String?,
     onClickProfile: () -> Unit
 ) {
     Row(
@@ -176,16 +180,18 @@ fun HomeTapTopBar(
             contentDescription = null
         )
         Spacer(Modifier.weight(1f))
-        Icon(
+        AsyncImage(
             modifier = Modifier
                 .size(36.dp)
+                .clip(CircleShape)
                 .clickable(
                     onClick = onClickProfile,
                     indication = null,
                     interactionSource = null
                 ),
-            painter = painterResource(id = R.drawable.default_user_profile),
-            tint = Color.Unspecified,
+            model = BuildConfig.IMAGE_URL + imageId,
+            contentScale = ContentScale.Crop,
+            error = painterResource(id = R.drawable.default_user_profile),
             contentDescription = null
         )
     }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/UserProfileEditScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/UserProfileEditScreen.kt
@@ -33,7 +33,7 @@ import com.ilsangtech.ilsang.feature.home.my.component.NicknameEditContent
 import com.ilsangtech.ilsang.feature.home.my.component.NicknameEditHeader
 
 @Composable
-fun NicknameEditScreen(
+fun UserProfileEditScreen(
     homeViewModel: HomeViewModel,
     navigateToMyTabMain: () -> Unit
 ) {
@@ -63,7 +63,7 @@ fun NicknameEditScreen(
 }
 
 @Composable
-fun NicknameEditScreen(
+fun UserProfileEditScreen(
     originNickname: String,
     nickname: String,
     nicknameEditErrorMessage: String?,
@@ -131,8 +131,8 @@ private val editButtonTextStyle = TextStyle(
 
 @Preview(showBackground = true)
 @Composable
-fun NicknameEditScreenPreview() {
-    NicknameEditScreen(
+fun UserProfileEditScreenPreview() {
+    UserProfileEditScreen(
         originNickname = "닉네임",
         nickname = "닉네임",
         nicknameEditErrorMessage = null,

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/UserProfileEditScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/UserProfileEditScreen.kt
@@ -64,6 +64,7 @@ fun UserProfileEditScreen(
         nicknameEditErrorMessage = nicknameEditErrorMessage,
         onNicknameChange = homeViewModel::changeNickname,
         onEditButtonClick = homeViewModel::updateUserProfile,
+        onDeleteUserImage = homeViewModel::deleteUserProfileImage,
         navigateToMyTabMain = {
             navigateToMyTabMain()
             homeViewModel.resetUserProfileEditSuccess()
@@ -79,6 +80,7 @@ fun UserProfileEditScreen(
     nicknameEditErrorMessage: String?,
     onNicknameChange: (String) -> Unit,
     onEditButtonClick: (Uri?) -> Unit,
+    onDeleteUserImage: () -> Unit,
     navigateToMyTabMain: () -> Unit
 ) {
     var updatedImage by remember { mutableStateOf<Uri?>(null) }
@@ -97,7 +99,7 @@ fun UserProfileEditScreen(
             UserImageEditContent(
                 model = updatedImage ?: (BuildConfig.IMAGE_URL + imageId),
                 onSelectImage = { updatedImage = it },
-                onDeleteImage = {}
+                onDeleteImage = onDeleteUserImage
             )
             Spacer(Modifier.height(36.dp))
             NicknameEditContent(
@@ -160,6 +162,7 @@ fun UserProfileEditScreenPreview() {
         nicknameEditErrorMessage = null,
         onNicknameChange = {},
         onEditButtonClick = {},
+        onDeleteUserImage = {},
         navigateToMyTabMain = {}
     )
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/component/UserImageDeleteDialog.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/component/UserImageDeleteDialog.kt
@@ -1,0 +1,33 @@
+package com.ilsangtech.ilsang.feature.home.my.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.ilsangtech.ilsang.designsystem.component.ILSANGDialog
+
+@Composable
+internal fun UserImageDeleteDialog(
+    onDeleteButtonClick: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    ILSANGDialog(
+        title = "프로필 사진 삭제을 삭제하시겠습니까?",
+        content = "기본 사진으로 변경됩니다.",
+        positiveButtonText = "확인",
+        negativeButtonText = "취소",
+        onClickPositiveButton = {
+            onDismissRequest()
+            onDeleteButtonClick()
+        },
+        onClickNegativeButton = onDismissRequest,
+        onDismissRequest = onDismissRequest
+    )
+}
+
+@Preview
+@Composable
+private fun UserImageDeleteDialogPreview() {
+    UserImageDeleteDialog(
+        onDeleteButtonClick = {},
+        onDismissRequest = {}
+    )
+}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/component/UserImageEditBottomSheet.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/component/UserImageEditBottomSheet.kt
@@ -1,0 +1,134 @@
+package com.ilsangtech.ilsang.feature.home.my.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_bold
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.subTitle02
+import com.ilsangtech.ilsang.feature.home.R
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun UserImageEditBottomSheet(
+    onDismissRequest: () -> Unit,
+    onSelectImage: () -> Unit,
+    onDeleteImage: () -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val bottomSheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = bottomSheetState,
+        dragHandle = null,
+        containerColor = Color.White
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 26.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "프로필 사진 수정",
+                style = TextStyle(
+                    fontFamily = FontFamily(Font(pretendard_bold)),
+                    fontSize = 17.sp,
+                )
+            )
+            Spacer(Modifier.height(15.dp))
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                color = Color.Transparent,
+                onClick = {
+                    coroutineScope.launch {
+                        bottomSheetState.hide()
+                    }.invokeOnCompletion {
+                        onSelectImage()
+                        onDismissRequest()
+                    }
+                }
+            ) {
+                Row(
+                    modifier = Modifier.padding(vertical = 20.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        modifier = Modifier.padding(start = 18.dp),
+                        painter = painterResource(id = R.drawable.image_select_icon),
+                        contentDescription = null,
+                        tint = Color.Unspecified
+                    )
+                    Text(
+                        text = "갤러리에서 선택",
+                        style = subTitle02.copy(color = gray500)
+                    )
+                }
+            }
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                color = Color.Transparent,
+                onClick = {
+                    coroutineScope.launch {
+                        bottomSheetState.hide()
+                    }.invokeOnCompletion {
+                        onDeleteImage()
+                        onDismissRequest()
+                    }
+                }
+            ) {
+                Row(
+                    modifier = Modifier.padding(vertical = 20.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        modifier = Modifier.padding(start = 18.dp),
+                        painter = painterResource(id = R.drawable.image_delete_icon),
+                        contentDescription = null,
+                        tint = Color.Unspecified
+                    )
+                    Text(
+                        text = "프로필 삭제",
+                        style = subTitle02.copy(color = Color.Red)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun UserImageEditBottomSheetPreview() {
+    UserImageEditBottomSheet(
+        onDismissRequest = {},
+        onSelectImage = {},
+        onDeleteImage = {}
+    )
+}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/component/UserImageEditContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/component/UserImageEditContent.kt
@@ -1,0 +1,116 @@
+package com.ilsangtech.ilsang.feature.home.my.component
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.ilsangtech.ilsang.designsystem.R.font.pretendard_bold
+import com.ilsangtech.ilsang.feature.home.R
+
+@Composable
+internal fun UserImageEditContent(
+    model: Any?,
+    onSelectImage: (Uri) -> Unit,
+    onDeleteImage: () -> Unit
+) {
+    val imagePicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        uri?.let {
+            onSelectImage(it)
+        }
+    }
+
+    var showImageEditBottomSheet by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showImageEditBottomSheet) {
+        UserImageEditBottomSheet(
+            onDismissRequest = { showImageEditBottomSheet = false },
+            onSelectImage = {
+                imagePicker.launch(
+                    PickVisualMediaRequest(
+                        ActivityResultContracts.PickVisualMedia.ImageOnly
+                    )
+                )
+            },
+            onDeleteImage = { showDeleteDialog = true }
+        )
+    }
+
+    if (showDeleteDialog) {
+        UserImageDeleteDialog(
+            onDeleteButtonClick = {
+                showDeleteDialog = false
+                onDeleteImage()
+            },
+            onDismissRequest = { showDeleteDialog = false }
+        )
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        AsyncImage(
+            modifier = Modifier
+                .size(80.dp)
+                .clip(CircleShape),
+            contentScale = ContentScale.Crop,
+            model = model,
+            error = painterResource(R.drawable.default_user_profile),
+            contentDescription = null
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            modifier = Modifier.clickable(
+                indication = null,
+                interactionSource = null,
+                onClick = { showImageEditBottomSheet = true }
+            ),
+            text = "프로필 사진 수정",
+            style = TextStyle(
+                fontFamily = FontFamily(Font(pretendard_bold)),
+                fontSize = 17.sp,
+                color = Color(0xFF528BFF)
+            ),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UserImageEditContentPreview() {
+    UserImageEditContent(
+        model = null,
+        onSelectImage = {},
+        onDeleteImage = {}
+    )
+}
+
+
+

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/component/UserProfileContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/component/UserProfileContent.kt
@@ -15,16 +15,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -35,9 +33,8 @@ import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import com.ilsangtech.ilsang.core.model.UserInfo
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_bold
-import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
 import com.ilsangtech.ilsang.designsystem.theme.gray100
-import com.ilsangtech.ilsang.designsystem.theme.gray200
+import com.ilsangtech.ilsang.designsystem.theme.gray100
 import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.designsystem.theme.primary
 import com.ilsangtech.ilsang.feature.home.BuildConfig
@@ -56,82 +53,6 @@ fun UserProfileContent(
 }
 
 @Composable
-fun DefaultProfileCardContent(userInfo: UserInfo) {
-    Row(
-        modifier = Modifier.padding(18.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Column(modifier = Modifier.padding(top = 13.dp)) {
-            AsyncImage(
-                modifier = Modifier.size(57.dp),
-                model = userInfo.profileImage?.let { BuildConfig.IMAGE_URL + it },
-                error = painterResource(R.drawable.default_user_profile),
-                placeholder = painterResource(R.drawable.default_user_profile),
-                contentDescription = "프로필 이미지"
-            )
-            Box(
-                modifier = Modifier
-                    .width(57.dp)
-                    .offset(y = (-13).dp)
-                    .clip(RoundedCornerShape(20.dp))
-                    .background(Color.White)
-                    .border(
-                        width = 1.dp,
-                        color = primary,
-                        shape = RoundedCornerShape(20.dp)
-                    )
-                    .padding(
-                        vertical = 4.dp,
-                        horizontal = 6.dp
-                    ),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = "Lv. " + XpLevelCalculator.getCurrentLevel(userInfo.xpPoint),
-                    style = userProfileCardLevelTextStyle
-                )
-            }
-        }
-        Spacer(Modifier.width(19.dp))
-        Column {
-            NicknameWithUnderline(userInfo.nickname!!)
-            Spacer(Modifier.height(6.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                LinearProgressIndicator(
-                    modifier = Modifier
-                        .height(8.dp)
-                        .weight(1f),
-                    color = primary,
-                    trackColor = Color(0xFFEDEBEB),
-                    progress = {
-                        0.3f
-                    },
-                    gapSize = (-5).dp,
-                    drawStopIndicator = {}
-                )
-                Spacer(Modifier.width(7.dp))
-                Text(
-                    text = "${XpLevelCalculator.getXpPointInCurrentLevel(userInfo.xpPoint)}XP",
-                    style = userProfileCardXpTextStyle,
-                    color = primary
-                )
-            }
-            Spacer(Modifier.height(8.dp))
-            Text(
-                text = "다음 레벨까지 "
-                        + XpLevelCalculator.getRequiredXpPointForNextLevel(userInfo.xpPoint)
-                        + "XP 남았어요!",
-                style = userProfileCardLevelDescriptionTextStyle
-            )
-        }
-    }
-}
-
-
-@Composable
 fun MyInfoProfileContent(
     userInfo: UserInfo,
     navigateToNicknameEdit: () -> Unit
@@ -148,8 +69,11 @@ fun MyInfoProfileContent(
     ) {
         Box(modifier = Modifier.padding(bottom = 4.dp)) {
             AsyncImage(
-                modifier = Modifier.size(57.dp),
+                modifier = Modifier
+                    .size(57.dp)
+                    .clip(CircleShape),
                 model = userInfo.profileImage?.let { BuildConfig.IMAGE_URL + it },
+                contentScale = ContentScale.Crop,
                 placeholder = painterResource(R.drawable.default_user_profile),
                 error = painterResource(R.drawable.default_user_profile),
                 contentDescription = "프로필 이미지"
@@ -178,44 +102,6 @@ fun MyInfoProfileContent(
             )
             Spacer(Modifier.height(4.dp))
             UserLevelBadge(xpPoint = userInfo.xpPoint)
-        }
-    }
-}
-
-@Composable
-fun NicknameWithUnderline(nickname: String) {
-    SubcomposeLayout { constraints ->
-
-        val nicknameMeasurables = subcompose("nickname") {
-            Text(
-                text = nickname,
-                style = profileNicknameTextStyle
-            )
-        }
-        val nicknamePlaceables = nicknameMeasurables.map { it.measure(constraints) }
-        val nicknameWidth = nicknamePlaceables.maxOf { it.width }
-        val nicknameHeight = nicknamePlaceables.maxOf { it.height }
-
-        val dividerMeasurables = subcompose("divider") {
-            HorizontalDivider(
-                modifier = Modifier.width(nicknameWidth.toDp()),
-                color = gray200
-            )
-        }
-        val dividerPlaceables = dividerMeasurables.map { it.measure(constraints) }
-        val dividerHeight = dividerPlaceables.maxOf { it.height }
-
-        val totalHeight = nicknameHeight + dividerHeight
-
-        layout(nicknameWidth, totalHeight) {
-            var y = 0
-            nicknamePlaceables.forEach {
-                it.placeRelative(0, y)
-                y += it.height
-            }
-            dividerPlaceables.forEach {
-                it.placeRelative(0, y + 1.dp.roundToPx())
-            }
         }
     }
 }
@@ -259,20 +145,6 @@ private val profileNicknameTextStyle = TextStyle(
     fontFamily = FontFamily(Font(pretendard_bold)),
     fontSize = 16.sp,
     lineHeight = 18.sp,
-    color = gray500
-)
-
-private val userProfileCardXpTextStyle = TextStyle(
-    fontFamily = FontFamily(Font(pretendard_bold)),
-    fontSize = 13.sp,
-    lineHeight = 12.sp,
-    color = primary
-)
-
-private val userProfileCardLevelDescriptionTextStyle = TextStyle(
-    fontFamily = FontFamily(Font(pretendard_regular)),
-    fontSize = 13.sp,
-    lineHeight = 12.sp,
     color = gray500
 )
 

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/navigation/MyTapNavigation.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/my/navigation/MyTapNavigation.kt
@@ -9,7 +9,7 @@ import com.ilsangtech.ilsang.feature.home.HomeTap
 import com.ilsangtech.ilsang.feature.home.HomeViewModel
 import com.ilsangtech.ilsang.feature.home.my.MyChallengeScreen
 import com.ilsangtech.ilsang.feature.home.my.MyTabScreen
-import com.ilsangtech.ilsang.feature.home.my.NicknameEditScreen
+import com.ilsangtech.ilsang.feature.home.my.UserProfileEditScreen
 
 fun NavGraphBuilder.myTabNavigation(
     homeViewModel: HomeViewModel,
@@ -43,7 +43,7 @@ fun NavGraphBuilder.myTabNavigation(
                 )
             }
         ) {
-            NicknameEditScreen(
+            UserProfileEditScreen(
                 homeViewModel = homeViewModel,
                 navigateToMyTabMain = navigateToMyTabMain
             )

--- a/feature/home/src/main/res/drawable/image_delete_icon.xml
+++ b/feature/home/src/main/res/drawable/image_delete_icon.xml
@@ -1,0 +1,34 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M3,6H5H21"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF0000"
+      android:strokeLineCap="square"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M19,6V20C19,20.53 18.789,21.039 18.414,21.414C18.039,21.789 17.53,22 17,22H7C6.47,22 5.961,21.789 5.586,21.414C5.211,21.039 5,20.53 5,20V6M8,6V4C8,3.47 8.211,2.961 8.586,2.586C8.961,2.211 9.47,2 10,2H14C14.53,2 15.039,2.211 15.414,2.586C15.789,2.961 16,3.47 16,4V6"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF0000"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M10,11V17"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF0000"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M14,11V17"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF0000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/home/src/main/res/drawable/image_select_icon.xml
+++ b/feature/home/src/main/res/drawable/image_select_icon.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M19,4H5C3.895,4 3,4.846 3,5.889V19.111C3,20.154 3.895,21 5,21H19C20.105,21 21,20.154 21,19.111V5.889C21,4.846 20.105,4 19,4Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#575B6C"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M8.5,11C9.328,11 10,10.328 10,9.5C10,8.672 9.328,8 8.5,8C7.672,8 7,8.672 7,9.5C7,10.328 7.672,11 8.5,11Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#575B6C"
+      android:strokeLineCap="round"/>
+  <path
+      android:strokeWidth="1"
+      android:pathData="M21,15.545L16,11L5,21"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#575B6C"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
이슈 번호: resolves #42 
작업 사항:
- 현재 프로필 사진과 수정 버튼 UI를 추가하고, 이미지 변경 및 삭제 기능을 수행하는 하단시트 UI를 추가하였습니다.
- 프로필 이미지 변경 기능을 구현하였습니다.
- 프로필 이미지 삭제 기능을 구현하였습니다.
- 홈 화면 우측 상단에 설정한 프로필 이미지가 나타나토록 수정하였습니다.

특이 사항: 없음

UI 화면:
<img width="383" alt="스크린샷 2025-06-03 오후 11 17 39" src="https://github.com/user-attachments/assets/f51c87a8-4559-4975-a9a8-3e66b074c82d" />
<img width="383" alt="스크린샷 2025-06-03 오후 11 18 01" src="https://github.com/user-attachments/assets/017c9ccf-3b18-40ec-b1c2-d9ce0a1b7c38" />
<img width="383" alt="스크린샷 2025-06-03 오후 11 18 10" src="https://github.com/user-attachments/assets/b5de49be-e2ea-4426-b211-2b0a9629e608" />
<img width="383" alt="스크린샷 2025-06-03 오후 11 18 59" src="https://github.com/user-attachments/assets/32aaecae-3363-4b7b-b584-f6e601ee5832" />
<img width="383" alt="스크린샷 2025-06-03 오후 11 19 11" src="https://github.com/user-attachments/assets/6996c951-54ea-4bbc-bae2-4c42d66dacba" />

