### PR TITLE
[Feat] OX, 서술형 퀘스트 제출 화면 UI 구현

### DIFF
--- a/core/designsystem/src/main/res/drawable/icon_exclamation_mark.xml
+++ b/core/designsystem/src/main/res/drawable/icon_exclamation_mark.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="38dp"
+    android:height="38dp"
+    android:viewportWidth="38"
+    android:viewportHeight="38">
+    <path
+        android:pathData="M16.233,7.492C16.107,5.602 17.606,4 19.5,4C21.394,4 22.893,5.602 22.767,7.492L21.74,22.905C21.661,24.084 20.682,25 19.5,25C18.318,25 17.339,24.084 17.26,22.905L16.233,7.492Z"
+        android:fillColor="#FF8928" />
+    <path
+        android:pathData="M19.633,31.033m-3.167,0a3.167,3.167 0,1 1,6.333 0a3.167,3.167 0,1 1,-6.333 0"
+        android:fillColor="#FF8928" />
+</vector>

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/mission/MissionType.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/mission/MissionType.kt
@@ -1,0 +1,9 @@
+package com.ilsangtech.ilsang.core.model.mission
+
+sealed interface MissionType {
+    data object Photo : MissionType
+    sealed interface Quiz : MissionType {
+        data object Ox : Quiz
+        data object Words : Quiz
+    }
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/QuizScreen.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/QuizScreen.kt
@@ -1,0 +1,187 @@
+package com.ilsangtech.ilsang.feature.submit
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.core.model.NewQuestType
+import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.designsystem.theme.gray300
+import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.feature.submit.component.OxQuizGuideCard
+import com.ilsangtech.ilsang.feature.submit.component.OxQuizSubmitCard
+import com.ilsangtech.ilsang.feature.submit.component.QuizQuestInfoCard
+import com.ilsangtech.ilsang.feature.submit.component.QuizScreenHeader
+import com.ilsangtech.ilsang.feature.submit.component.WordsQuizGuideCard
+import com.ilsangtech.ilsang.feature.submit.component.WordsQuizSubmitCard
+
+@Composable
+private fun QuizScreen(
+    submitQuestUiState: SubmitQuestUiState,
+    quizUiState: QuizUiState,
+    onBackButtonClick: () -> Unit,
+    onCorrectButtonClick: () -> Unit,
+    onIncorrectButtonClick: () -> Unit,
+    onSubmitButtonClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = background
+    ) {
+        Column {
+            QuizScreenHeader(onBackButtonClick = onBackButtonClick)
+            LazyColumn(contentPadding = PaddingValues(horizontal = 20.dp)) {
+                item { Spacer(Modifier.height(30.dp)) }
+                item {
+                    QuizQuestInfoCard(
+                        questImageId = submitQuestUiState.questImageId,
+                        title = submitQuestUiState.title,
+                        locationName = submitQuestUiState.locationName,
+                        questType = submitQuestUiState.questType,
+                        point = submitQuestUiState.point
+                    )
+                }
+                item { Spacer(Modifier.height(16.dp)) }
+                item {
+                    if (quizUiState is QuizUiState.WordsQuizUiState) {
+                        WordsQuizGuideCard()
+                    } else {
+                        OxQuizGuideCard()
+                    }
+                }
+                item { Spacer(Modifier.height(16.dp)) }
+                item {
+                    if (quizUiState is QuizUiState.OxQuizUiState) {
+                        OxQuizSubmitCard(
+                            oxQuizUiState = quizUiState,
+                            onCorrectButtonClick = onCorrectButtonClick,
+                            onIncorrectButtonClick = onIncorrectButtonClick
+                        )
+                    } else {
+                        WordsQuizSubmitCard(
+                            wordsQuizUiState = quizUiState as QuizUiState.WordsQuizUiState
+                        )
+                    }
+                }
+                item { Spacer(Modifier.height(40.dp)) }
+                item {
+                    Button(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 72.dp),
+                        contentPadding = PaddingValues(vertical = 16.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = primary,
+                            disabledContainerColor = gray300,
+                            contentColor = Color.White,
+                            disabledContentColor = Color.White
+                        ),
+                        shape = RoundedCornerShape(12.dp),
+                        enabled = (quizUiState is QuizUiState.OxQuizUiState &&
+                                quizUiState.submitState !is OxQuizSubmitUiState.NotSelected) ||
+                                (quizUiState is QuizUiState.WordsQuizUiState &&
+                                        quizUiState.answer.text.isNotEmpty()),
+                        onClick = onSubmitButtonClick
+                    ) {
+                        Text(
+                            text = "퀘스트 인증하기",
+                            style = TextStyle(
+                                fontFamily = pretendardFontFamily,
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 16.sp,
+                                lineHeight = 18.sp
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OxQuizScreenPreview() {
+    val submitQuestUiState = SubmitQuestUiState(
+        questImageId = "",
+        title = "정자동 최고의 돈까스 가게 가기",
+        locationName = "야미돈까스 정자동점",
+        questType = NewQuestType.Event,
+        point = 10
+    )
+
+    var quizUiState by remember {
+        mutableStateOf(
+            QuizUiState.OxQuizUiState(
+                question = "야미돈까스에서 파는 메뉴 중 ‘치킨까스' 는 케첩소스와 함께 제공된다.",
+                submitState = OxQuizSubmitUiState.NotSelected
+            )
+        )
+    }
+    QuizScreen(
+        submitQuestUiState = submitQuestUiState,
+        quizUiState = quizUiState,
+        onBackButtonClick = {},
+        onCorrectButtonClick = {
+            quizUiState = quizUiState.copy(
+                submitState = OxQuizSubmitUiState.Correct
+            )
+        },
+        onIncorrectButtonClick = {
+            quizUiState = quizUiState.copy(
+                submitState = OxQuizSubmitUiState.Incorrect
+            )
+        },
+        onSubmitButtonClick = {}
+    )
+}
+
+@Preview
+@Composable
+private fun WordsQuizScreenPreview() {
+    val answerTextFieldState = rememberTextFieldState()
+    val submitQuestUiState = SubmitQuestUiState(
+        questImageId = "",
+        title = "정자동 최고의 돈까스 가게 가기",
+        locationName = "야미돈까스 정자동점",
+        questType = NewQuestType.Event,
+        point = 10
+    )
+
+    val quizUiState = QuizUiState.WordsQuizUiState(
+        question = "야미돈까스 정자동점의 베스트셀러 메뉴는?",
+        hint = "등심",
+        answer = answerTextFieldState
+    )
+    QuizScreen(
+        submitQuestUiState = submitQuestUiState,
+        quizUiState = quizUiState,
+        onBackButtonClick = {},
+        onCorrectButtonClick = {},
+        onIncorrectButtonClick = {},
+        onSubmitButtonClick = {}
+    )
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/QuizUiState.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/QuizUiState.kt
@@ -1,0 +1,22 @@
+package com.ilsangtech.ilsang.feature.submit
+
+import androidx.compose.foundation.text.input.TextFieldState
+
+sealed interface QuizUiState {
+    data class OxQuizUiState(
+        val question: String,
+        val submitState: OxQuizSubmitUiState
+    ) : QuizUiState
+
+    data class WordsQuizUiState(
+        val question: String,
+        val hint: String,
+        val answer: TextFieldState
+    ) : QuizUiState
+}
+
+sealed interface OxQuizSubmitUiState {
+    data object NotSelected : OxQuizSubmitUiState
+    data object Correct : OxQuizSubmitUiState
+    data object Incorrect : OxQuizSubmitUiState
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/SubmitQuestUiState.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/SubmitQuestUiState.kt
@@ -1,0 +1,11 @@
+package com.ilsangtech.ilsang.feature.submit
+
+import com.ilsangtech.ilsang.core.model.NewQuestType
+
+data class SubmitQuestUiState(
+    val questImageId: String,
+    val title: String,
+    val locationName: String,
+    val questType: NewQuestType,
+    val point: Int
+)

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/InCorrectAnswerDialog.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/InCorrectAnswerDialog.kt
@@ -1,0 +1,121 @@
+package com.ilsangtech.ilsang.feature.submit.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.ilsangtech.ilsang.designsystem.R
+import com.ilsangtech.ilsang.designsystem.theme.gray400
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.toSp
+
+@Composable
+internal fun InCorrectAnswerDialog(
+    onDismissRequest: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismissRequest) {
+        Card(
+            modifier = Modifier.width(260.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 30.dp, bottom = 16.dp)
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(60.dp)
+                        .clip(CircleShape)
+                        .background(Color(0x1AFF7300)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.icon_exclamation_mark),
+                        contentDescription = null,
+                        tint = Color.Unspecified
+                    )
+                }
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    text = "다시 한번 생각해 보세요!",
+                    style = TextStyle(
+                        fontFamily = pretendardFontFamily,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 17.dp.toSp(),
+                        lineHeight = 18.dp.toSp()
+                    ),
+                    color = gray500
+                )
+                Spacer(Modifier.height(10.dp))
+                Text(
+                    text = "계속해서 도전할 수 있어요!",
+                    style = TextStyle(
+                        fontFamily = pretendardFontFamily,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 15.dp.toSp(),
+                        lineHeight = 20.dp.toSp()
+                    ),
+                    color = gray400
+                )
+                Spacer(Modifier.height(20.dp))
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = primary,
+                        contentColor = Color.White
+                    ),
+                    shape = RoundedCornerShape(8.dp),
+                    contentPadding = PaddingValues(vertical = 16.dp),
+                    onClick = onDismissRequest
+                ) {
+                    Text(
+                        text = "확인",
+                        style = TextStyle(
+                            fontFamily = pretendardFontFamily,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 16.dp.toSp(),
+                            lineHeight = 18.dp.toSp()
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun InCorrectAnswerDialogPreview() {
+    InCorrectAnswerDialog(onDismissRequest = {})
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/OxQuizSubmitCard.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/OxQuizSubmitCard.kt
@@ -1,0 +1,172 @@
+package com.ilsangtech.ilsang.feature.submit.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.subTitle02
+import com.ilsangtech.ilsang.designsystem.theme.title01
+import com.ilsangtech.ilsang.designsystem.theme.toSp
+import com.ilsangtech.ilsang.feature.submit.OxQuizSubmitUiState
+import com.ilsangtech.ilsang.feature.submit.QuizUiState
+
+@Composable
+internal fun OxQuizSubmitCard(
+    modifier: Modifier = Modifier,
+    oxQuizUiState: QuizUiState.OxQuizUiState,
+    onCorrectButtonClick: () -> Unit,
+    onIncorrectButtonClick: () -> Unit,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(
+                vertical = 20.dp,
+                horizontal = 16.dp
+            )
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(45.dp)
+                        .clip(CircleShape)
+                        .background(primary),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "Q",
+                        style = title01.copy(
+                            fontSize = 23.dp.toSp(),
+                            lineHeight = 24.dp.toSp()
+                        ),
+                        color = Color.White
+                    )
+                }
+                Text(
+                    text = "QUIZ",
+                    style = title01,
+                    color = primary
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = oxQuizUiState.question,
+                style = subTitle02,
+                color = Color.Black
+            )
+            Spacer(Modifier.height(16.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                OxQuizButton(
+                    modifier = Modifier.weight(1f),
+                    text = "O",
+                    isSelected = oxQuizUiState.submitState is OxQuizSubmitUiState.Correct,
+                    onClick = onCorrectButtonClick
+                )
+                OxQuizButton(
+                    modifier = Modifier.weight(1f),
+                    text = "X",
+                    isSelected = oxQuizUiState.submitState is OxQuizSubmitUiState.Incorrect,
+                    onClick = onIncorrectButtonClick
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OxQuizButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Button(
+        modifier = modifier,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = if (isSelected) primary else gray100,
+            contentColor = if (isSelected) Color.White else Color.Black
+        ),
+        shape = RoundedCornerShape(12.dp),
+        contentPadding = PaddingValues(vertical = 20.dp),
+        onClick = onClick
+    ) {
+        Text(
+            text = text,
+            style = title01
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun OxQuizSubmitCardPreview() {
+    var oxQuizUiState by remember {
+        mutableStateOf(
+            QuizUiState.OxQuizUiState(
+                question = "야미돈까스에서 파는 메뉴 중 ‘치킨까스' 는 케첩소스와 함께 제공된다.",
+                submitState = OxQuizSubmitUiState.NotSelected
+            )
+        )
+    }
+    OxQuizSubmitCard(
+        oxQuizUiState = oxQuizUiState,
+        onCorrectButtonClick = {
+            if (oxQuizUiState.submitState == OxQuizSubmitUiState.Correct) {
+                oxQuizUiState = oxQuizUiState.copy(
+                    submitState = OxQuizSubmitUiState.NotSelected
+                )
+            } else {
+                oxQuizUiState = oxQuizUiState.copy(
+                    submitState = OxQuizSubmitUiState.Correct
+                )
+            }
+        },
+        onIncorrectButtonClick = {
+            if (oxQuizUiState.submitState == OxQuizSubmitUiState.Incorrect) {
+                oxQuizUiState = oxQuizUiState.copy(
+                    submitState = OxQuizSubmitUiState.NotSelected
+                )
+            } else {
+                oxQuizUiState = oxQuizUiState.copy(
+                    submitState = OxQuizSubmitUiState.Incorrect
+                )
+            }
+        }
+    )
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/QuizGuideCard.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/QuizGuideCard.kt
@@ -1,0 +1,116 @@
+package com.ilsangtech.ilsang.feature.submit.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ilsangtech.ilsang.designsystem.theme.caption01
+import com.ilsangtech.ilsang.designsystem.theme.heading01
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.subTitle02
+
+@Composable
+internal fun OxQuizGuideCard(modifier: Modifier = Modifier) {
+    QuizGuideCard(
+        modifier = modifier,
+        title = "OX 퀘스트 인증 참여 방법",
+        steps =
+            listOf(
+                "내용을 읽고, O/X 중 정답을 선택해 주세요.",
+                "‘퀘스트 인증하기' 버튼을 눌러 인증을 해 주세요.",
+                "정답일 경우 보상을 받을 수 있어요."
+            )
+    )
+}
+
+@Composable
+internal fun WordsQuizGuideCard(modifier: Modifier = Modifier) {
+    QuizGuideCard(
+        modifier = modifier,
+        title = "서술형 퀘스트 인증 참여 방법",
+        steps = listOf(
+            "내용을 읽고, 정답을 입력해 주세요.",
+            "‘퀘스트 인증하기' 버튼을 눌러 인증을 해 주세요.",
+            "정답일 경우 보상을 받을 수 있어요."
+        )
+    )
+}
+
+@Composable
+private fun QuizGuideCard(
+    modifier: Modifier = Modifier,
+    title: String,
+    steps: List<String>
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White)
+    ) {
+        Column(
+            modifier = Modifier.padding(vertical = 20.dp, horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = title,
+                style = heading01,
+                color = Color.Black
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                steps.forEachIndexed { index, step ->
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(20.dp)
+                                .clip(CircleShape)
+                                .background(primary),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "${index + 1}",
+                                style = caption01,
+                                color = Color.White
+                            )
+                        }
+                        Text(
+                            text = step,
+                            style = subTitle02,
+                            color = Color.Black
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OxQuizGuideCardPreview() {
+    OxQuizGuideCard()
+}
+
+@Preview
+@Composable
+private fun WordsQuizGuideCardPreview() {
+    WordsQuizGuideCard()
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/QuizQuestInfoCard.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/QuizQuestInfoCard.kt
@@ -1,0 +1,121 @@
+package com.ilsangtech.ilsang.feature.submit.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.ilsangtech.ilsang.core.model.NewQuestType
+import com.ilsangtech.ilsang.core.ui.quest.EventQuestTypeBadge
+import com.ilsangtech.ilsang.core.ui.quest.RepeatQuestTypeBadge
+import com.ilsangtech.ilsang.designsystem.theme.bodyTextStyle
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.heading01
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.primary100
+import com.ilsangtech.ilsang.designsystem.theme.title02
+import com.ilsangtech.ilsang.feature.submit.BuildConfig
+
+@Composable
+internal fun QuizQuestInfoCard(
+    modifier: Modifier = Modifier,
+    questImageId: String,
+    title: String,
+    locationName: String,
+    questType: NewQuestType,
+    point: Int
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    vertical = 20.dp,
+                    horizontal = 16.dp
+                ),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFFF1F5FF)),
+                model = BuildConfig.IMAGE_URL + questImageId,
+                contentDescription = null
+            )
+            Spacer(Modifier.width(8.dp))
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                Text(
+                    text = locationName,
+                    style = bodyTextStyle,
+                    color = gray500,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = title,
+                    style = title02,
+                    color = gray500,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (questType is NewQuestType.Event) {
+                    EventQuestTypeBadge()
+                } else if (questType is NewQuestType.Repeat) {
+                    RepeatQuestTypeBadge(repeatType = questType)
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(primary100)
+                    .padding(10.dp)
+            ) {
+                Text(
+                    text = "${point}P",
+                    style = heading01,
+                    color = primary
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun QuizQuestInfoCardPreview() {
+    QuizQuestInfoCard(
+        modifier = Modifier,
+        questImageId = "some_image_id",
+        title = "정자동 최고의 돈까스 가게 가기",
+        locationName = "야미돈까스 정자동점",
+        questType = NewQuestType.Repeat.Daily,
+        point = 100
+    )
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/QuizScreenHeader.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/QuizScreenHeader.kt
@@ -1,0 +1,63 @@
+package com.ilsangtech.ilsang.feature.submit.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.designsystem.R
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
+
+@Composable
+internal fun QuizScreenHeader(
+    modifier: Modifier = Modifier,
+    onBackButtonClick: () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(start = 15.dp)
+            .padding(top = 12.dp, bottom = 11.dp)
+    ) {
+        Icon(
+            modifier = Modifier.clickable(
+                onClick = onBackButtonClick,
+                interactionSource = null,
+                indication = null
+            ),
+            painter = painterResource(R.drawable.icon_chevron_back),
+            tint = gray500,
+            contentDescription = "뒤로 가기"
+        )
+        Text(
+            modifier = Modifier.align(Alignment.Center),
+            text = "퀘스트 참여",
+            style = TextStyle(
+                fontFamily = pretendardFontFamily,
+                fontWeight = FontWeight.Bold,
+                fontSize = 17.sp,
+                lineHeight = 22.sp
+            ),
+            color = gray500
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun QuizScreenHeaderPreview() {
+    QuizScreenHeader(onBackButtonClick = {})
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/WordsQuizSubmitCard.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/WordsQuizSubmitCard.kt
@@ -1,0 +1,143 @@
+package com.ilsangtech.ilsang.feature.submit.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ilsangtech.ilsang.designsystem.theme.caption01
+import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.gray300
+import com.ilsangtech.ilsang.designsystem.theme.heading02
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.subTitle02
+import com.ilsangtech.ilsang.designsystem.theme.title01
+import com.ilsangtech.ilsang.designsystem.theme.toSp
+import com.ilsangtech.ilsang.feature.submit.QuizUiState
+
+@Composable
+internal fun WordsQuizSubmitCard(
+    modifier: Modifier = Modifier,
+    wordsQuizUiState: QuizUiState.WordsQuizUiState
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    vertical = 24.dp,
+                    horizontal = 16.dp
+                ),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Column {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(45.dp)
+                            .clip(CircleShape)
+                            .background(primary),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Q",
+                            style = title01.copy(
+                                fontSize = 23.dp.toSp(),
+                                lineHeight = 24.dp.toSp()
+                            ),
+                            color = Color.White
+                        )
+                    }
+                    Text(
+                        text = "QUIZ",
+                        style = title01,
+                        color = primary
+                    )
+                }
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = wordsQuizUiState.question,
+                    style = subTitle02,
+                    color = Color.Black
+                )
+            }
+            Column {
+                Text(
+                    text = "힌트",
+                    style = heading02,
+                    color = primary
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = wordsQuizUiState.hint,
+                    style = subTitle02,
+                    color = gray300
+                )
+            }
+            BasicTextField(
+                modifier = Modifier.fillMaxWidth(),
+                state = wordsQuizUiState.answer,
+                textStyle = caption01.copy(color = Color.Black),
+                decorator = { innerTextField ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(gray100)
+                            .padding(
+                                vertical = 15.dp,
+                                horizontal = 16.dp
+                            )
+                    ) {
+                        if (wordsQuizUiState.answer.text.isEmpty()) {
+                            Text(
+                                text = "정답을 입력해 주세요.",
+                                style = caption01,
+                                color = gray300
+                            )
+                        }
+                        innerTextField()
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun WordsQuizSubmitCardPreview() {
+    WordsQuizSubmitCard(
+        wordsQuizUiState = QuizUiState.WordsQuizUiState(
+            question = "야미돈까스 정자동점의 베스트셀러 메뉴는?",
+            hint = "등심",
+            answer = TextFieldState(initialText = "등심 돈까스")
+        )
+    )
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/WordsQuizSubmitCard.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/component/WordsQuizSubmitCard.kt
@@ -105,7 +105,7 @@ internal fun WordsQuizSubmitCard(
                 state = wordsQuizUiState.answer,
                 textStyle = caption01.copy(color = Color.Black),
                 decorator = { innerTextField ->
-                    Row(
+                    Box(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clip(RoundedCornerShape(12.dp))


### PR DESCRIPTION
이슈 번호: resolves #79 

작업 사항:
- OX, 서술형 퀘스트 화면 UI 구현
- 제출 오답 다이얼로그 UI 구현

UI 화면:
<img width="296" height="640" alt="스크린샷 2025-08-17 오후 9 48 47" src="https://github.com/user-attachments/assets/745f4a8a-0298-4fe4-a45b-8010b8c23606" />
<img width="296" height="640" alt="스크린샷 2025-08-17 오후 9 49 07" src="https://github.com/user-attachments/assets/3e22909e-42f3-48ff-bab1-1ee5c3e16978" />
<img width="289" height="262" alt="스크린샷 2025-08-17 오후 9 47 45" src="https://github.com/user-attachments/assets/98a35ba7-409b-41ef-898e-231100f5611a" />
