### PR TITLE
[Feat] 지역 선택 API 연동 구현

### DIFF
--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/area/datasource/AreaDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/area/datasource/AreaDataSource.kt
@@ -1,0 +1,7 @@
+package com.ilsangtech.ilsang.core.data.area.datasource
+
+import com.ilsangtech.ilsang.core.network.model.area.AreaListResponse
+
+interface AreaDataSource {
+    suspend fun getAreaList(): AreaListResponse
+}

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/area/datasource/AreaDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/area/datasource/AreaDataSourceImpl.kt
@@ -1,0 +1,12 @@
+package com.ilsangtech.ilsang.core.data.area.datasource
+
+import com.ilsangtech.ilsang.core.network.api.AreaApiService
+import com.ilsangtech.ilsang.core.network.model.area.AreaListResponse
+
+class AreaDataSourceImpl(
+    private val areaApiService: AreaApiService
+) : AreaDataSource {
+    override suspend fun getAreaList(): AreaListResponse {
+        return areaApiService.getAreaList()
+    }
+}

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/area/di/AreaDataModule.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/area/di/AreaDataModule.kt
@@ -1,0 +1,28 @@
+package com.ilsangtech.ilsang.core.data.area.di
+
+import com.ilsangtech.ilsang.core.data.area.datasource.AreaDataSource
+import com.ilsangtech.ilsang.core.data.area.datasource.AreaDataSourceImpl
+import com.ilsangtech.ilsang.core.data.area.repository.AreaRepositoryImpl
+import com.ilsangtech.ilsang.core.domain.AreaRepository
+import com.ilsangtech.ilsang.core.network.api.AreaApiService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AreaDataModule {
+    @Singleton
+    @Provides
+    fun provideAreaDataSource(areaApiService: AreaApiService): AreaDataSource {
+        return AreaDataSourceImpl(areaApiService)
+    }
+
+    @Singleton
+    @Provides
+    fun provideAreaRepository(areaDataSource: AreaDataSource): AreaRepository {
+        return AreaRepositoryImpl(areaDataSource)
+    }
+}

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/area/mapper/AreaMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/area/mapper/AreaMapper.kt
@@ -1,0 +1,23 @@
+package com.ilsangtech.ilsang.core.data.area.mapper
+
+import com.ilsangtech.ilsang.core.model.area.CommercialArea
+import com.ilsangtech.ilsang.core.model.area.MetroArea
+import com.ilsangtech.ilsang.core.network.model.area.CommercialAreaNetworkModel
+import com.ilsangtech.ilsang.core.network.model.area.MetroAreaNetworkModel
+
+fun CommercialAreaNetworkModel.toCommercialArea(): CommercialArea {
+    return CommercialArea(
+        code = code,
+        areaName = areaName,
+        description = description,
+        metroAreaCode = metroAreaCode
+    )
+}
+
+fun MetroAreaNetworkModel.toMetroArea(): MetroArea {
+    return MetroArea(
+        code = code,
+        areaName = areaName,
+        commercialAreaList = commercialAreaNetworkModel.map { it.toCommercialArea() }
+    )
+}

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/area/repository/AreaRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/area/repository/AreaRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.ilsangtech.ilsang.core.data.area.repository
+
+import com.ilsangtech.ilsang.core.data.area.datasource.AreaDataSource
+import com.ilsangtech.ilsang.core.data.area.mapper.toMetroArea
+import com.ilsangtech.ilsang.core.domain.AreaRepository
+import com.ilsangtech.ilsang.core.model.area.MetroArea
+import com.ilsangtech.ilsang.core.network.model.area.MetroAreaNetworkModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+
+class AreaRepositoryImpl(
+    private val areaDataSource: AreaDataSource
+) : AreaRepository {
+    private var areaList: List<MetroArea> = emptyList()
+
+    override fun getAreaList(): Flow<List<MetroArea>> = flow {
+        if (areaList.isEmpty()) {
+            areaDataSource.getAreaList().metroAreaList
+                .map(MetroAreaNetworkModel::toMetroArea)
+        }
+        emit(areaList)
+    }
+
+    override fun getCommercialName(commericalCode: String): Flow<String> {
+        return getAreaList().map { areaList ->
+            val commericalAreaList = areaList.flatMap { it.commercialAreaList }
+            commericalAreaList.first { it.code == commericalCode }.areaName
+        }
+    }
+}

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSource.kt
@@ -29,4 +29,6 @@ interface UserDataSource {
     suspend fun deleteUserImage(): UserImageDeleteResponse
 
     suspend fun updateUserTitle(titleHistoryId: String): UserTitleUpdateResponse
+
+    suspend fun updateUserIsZone(commericalAreaCode: String): UserInfoResponse
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSourceImpl.kt
@@ -12,6 +12,7 @@ import com.ilsangtech.ilsang.core.network.model.user.UserImageDeleteResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateRequest
 import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
+import com.ilsangtech.ilsang.core.network.model.user.UserIsZoneUpdateRequest
 import com.ilsangtech.ilsang.core.network.model.user.UserTitleUpdateResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserXpStatsResponse
 import javax.inject.Inject
@@ -54,5 +55,9 @@ class UserDataSourceImpl @Inject constructor(
 
     override suspend fun updateUserTitle(titleHistoryId: String): UserTitleUpdateResponse {
         return userApiService.updateUserTitle(titleHistoryId)
+    }
+
+    override suspend fun updateUserIsZone(commericalAreaCode: String): UserInfoResponse {
+        return userApiService.updateUserIsZone(UserIsZoneUpdateRequest(commericalAreaCode))
     }
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -23,6 +23,8 @@ class UserRepositoryImpl @Inject constructor(
 
     override val shouldShowOnBoarding: Flow<Boolean> = userDataStore.shouldShowOnBoarding
 
+    override val myZone: Flow<String?> = userDataStore.userMyZone
+
     override suspend fun login(idToken: String) {
         val loginResponse = userDataSource.login(
             OAuthLoginRequest(
@@ -111,6 +113,12 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun updateUserTitle(titleHistoryId: String): Result<Unit> {
         return runCatching {
             userDataSource.updateUserTitle(titleHistoryId)
+        }
+    }
+
+    override suspend fun updateUserMyZone(commericalAreaCode: String): Result<Unit> {
+        return runCatching {
+            userDataStore.setUserMyZone(commericalAreaCode)
         }
     }
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -113,4 +113,10 @@ class UserRepositoryImpl @Inject constructor(
             userDataSource.updateUserTitle(titleHistoryId)
         }
     }
+
+    override suspend fun updateUserIsZone(commericalAreaCode: String): Result<Unit> {
+        return runCatching {
+            userDataSource.updateUserIsZone(commericalAreaCode)
+        }
+    }
 }

--- a/core/datastore/src/main/java/com/ilsangtech/ilsang/core/datastore/UserDataStore.kt
+++ b/core/datastore/src/main/java/com/ilsangtech/ilsang/core/datastore/UserDataStore.kt
@@ -19,6 +19,11 @@ class UserDataStore(context: Context) {
         preferences[shouldShowOnBoardingKey] ?: true
     }
 
+    private val userMyZoneKey = stringPreferencesKey("user_my_zone")
+    val userMyZone = userDataStore.data.map { preferences ->
+        preferences[userMyZoneKey]
+    }
+
     private val accessTokenKey = stringPreferencesKey("access_token")
     val accessToken = userDataStore.data.map { preferences ->
         preferences[accessTokenKey]
@@ -32,6 +37,12 @@ class UserDataStore(context: Context) {
     suspend fun setShouldShowOnBoarding(shouldShow: Boolean) {
         userDataStore.edit { preferences ->
             preferences[shouldShowOnBoardingKey] = shouldShow
+        }
+    }
+
+    suspend fun setUserMyZone(commericalAreaCode: String) {
+        userDataStore.edit { preferences ->
+            preferences[userMyZoneKey] = commericalAreaCode
         }
     }
 

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/AreaRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/AreaRepository.kt
@@ -1,0 +1,10 @@
+package com.ilsangtech.ilsang.core.domain
+
+import com.ilsangtech.ilsang.core.model.area.MetroArea
+import kotlinx.coroutines.flow.Flow
+
+interface AreaRepository {
+    fun getAreaList(): Flow<List<MetroArea>>
+
+    fun getCommercialName(commericalCode: String): Flow<String>
+}

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
@@ -31,4 +31,6 @@ interface UserRepository {
     suspend fun completeOnBoarding()
 
     suspend fun updateUserTitle(titleHistoryId: String): Result<Unit>
+
+    suspend fun updateUserIsZone(commericalAreaCode: String): Result<Unit>
 }

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
@@ -10,6 +10,8 @@ interface UserRepository {
 
     val shouldShowOnBoarding: Flow<Boolean>
 
+    val myZone: Flow<String?>
+
     suspend fun login(idToken: String)
 
     suspend fun logout(): Result<Unit>
@@ -31,6 +33,8 @@ interface UserRepository {
     suspend fun completeOnBoarding()
 
     suspend fun updateUserTitle(titleHistoryId: String): Result<Unit>
+
+    suspend fun updateUserMyZone(commericalAreaCode: String): Result<Unit>
 
     suspend fun updateUserIsZone(commericalAreaCode: String): Result<Unit>
 }

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/area/MetroArea.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/area/MetroArea.kt
@@ -3,6 +3,5 @@ package com.ilsangtech.ilsang.core.model.area
 data class MetroArea(
     val code: String,
     val areaName: String,
-    val description: String,
-    val commericalAreaList: List<CommercialArea>
+    val commercialAreaList: List<CommercialArea>
 )

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/AreaApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/AreaApiService.kt
@@ -1,0 +1,9 @@
+package com.ilsangtech.ilsang.core.network.api
+
+import com.ilsangtech.ilsang.core.network.model.area.AreaListResponse
+import retrofit2.http.GET
+
+interface AreaApiService {
+    @GET("api/v1/area")
+    suspend fun getAreaList(): AreaListResponse
+}

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/UserApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/UserApiService.kt
@@ -6,6 +6,7 @@ import com.ilsangtech.ilsang.core.network.model.user.UserImageDeleteResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateRequest
 import com.ilsangtech.ilsang.core.network.model.user.UserImageUpdateResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
+import com.ilsangtech.ilsang.core.network.model.user.UserIsZoneUpdateRequest
 import com.ilsangtech.ilsang.core.network.model.user.UserTitleUpdateResponse
 import com.ilsangtech.ilsang.core.network.model.user.UserXpStatsResponse
 import retrofit2.http.Body
@@ -42,4 +43,9 @@ interface UserApiService {
     suspend fun updateUserTitle(
         @Query("titleHistoryId") titleHistoryId: String
     ): UserTitleUpdateResponse
+
+    @PUT("api/v1/user/profile/area-zone")
+    suspend fun updateUserIsZone(
+        @Body userIsZoneUpdateRequest: UserIsZoneUpdateRequest
+    ): UserInfoResponse
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.ilsangtech.ilsang.core.network.di
 
 import com.ilsangtech.ilsang.core.datastore.UserDataStore
 import com.ilsangtech.ilsang.core.network.BuildConfig
+import com.ilsangtech.ilsang.core.network.api.AreaApiService
 import com.ilsangtech.ilsang.core.network.api.AuthApiService
 import com.ilsangtech.ilsang.core.network.api.BannerApiService
 import com.ilsangtech.ilsang.core.network.api.ChallengeApiService
@@ -216,5 +217,11 @@ object NetworkModule {
     @Singleton
     fun provideTitleApiService(retrofit: Retrofit): TitleApiService {
         return retrofit.create(TitleApiService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideAreaApiService(retrofit: Retrofit): AreaApiService {
+        return retrofit.create(AreaApiService::class.java)
     }
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/area/AreaListResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/area/AreaListResponse.kt
@@ -1,0 +1,8 @@
+package com.ilsangtech.ilsang.core.network.model.area
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AreaListResponse(
+    val metroAreaList: List<MetroAreaNetworkModel>
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/area/CommercialAreaNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/area/CommercialAreaNetworkModel.kt
@@ -1,0 +1,11 @@
+package com.ilsangtech.ilsang.core.network.model.area
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CommercialAreaNetworkModel(
+    val areaName: String,
+    val code: String,
+    val description: String,
+    val metroAreaCode: String
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/area/MetroAreaNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/area/MetroAreaNetworkModel.kt
@@ -1,0 +1,10 @@
+package com.ilsangtech.ilsang.core.network.model.area
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MetroAreaNetworkModel(
+    val areaName: String,
+    val code: String,
+    val commercialAreaNetworkModel: List<CommercialAreaNetworkModel>
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserIsZoneUpdateRequest.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserIsZoneUpdateRequest.kt
@@ -1,0 +1,8 @@
+package com.ilsangtech.ilsang.core.network.model.user
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserIsZoneUpdateRequest(
+    val commercialAreaCode: String
+)

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/zone/ZoneListContent.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/zone/ZoneListContent.kt
@@ -150,7 +150,7 @@ private fun CommercialAreaList(
         }
         LazyColumn(modifier = Modifier.weight(1f)) {
             items(
-                items = selectedMetroArea?.commericalAreaList.orEmpty(),
+                items = selectedMetroArea?.commercialAreaList.orEmpty(),
                 key = { commercialArea -> commercialArea.code }
             ) {
                 CommercialAreaItem(
@@ -264,14 +264,12 @@ private fun MyZoneListContentPreview() {
     val sampleMetroArea1 = MetroArea(
         code = "MA001",
         areaName = "서울",
-        description = "Capital of South Korea",
-        commericalAreaList = listOf(sampleCommercialArea1, sampleCommercialArea2)
+        commercialAreaList = listOf(sampleCommercialArea1, sampleCommercialArea2)
     )
     val sampleMetroArea2 = MetroArea(
         code = "MA002",
         areaName = "부산",
-        description = "Second largest city in South Korea",
-        commericalAreaList = emptyList()
+        commercialAreaList = emptyList()
     )
 
     ZoneListContent(

--- a/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneScreen.kt
+++ b/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneScreen.kt
@@ -36,7 +36,7 @@ internal fun IsZoneScreen(
     isZoneViewModel: IsZoneViewModel = hiltViewModel(),
     onBackButtonClick: () -> Unit
 ) {
-    val isZoneUiState by isZoneViewModel.myZoneUiState.collectAsStateWithLifecycle()
+    val isZoneUiState by isZoneViewModel.isZoneUiState.collectAsStateWithLifecycle()
     IsZoneScreen(
         selectedMetroArea = isZoneUiState.selectedMetroArea,
         selectedCommercialArea = isZoneUiState.selectedCommercialArea,

--- a/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneScreen.kt
+++ b/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneScreen.kt
@@ -125,14 +125,12 @@ private fun IsZoneScreenPreview() {
     val sampleMetroArea1 = MetroArea(
         code = "MA001",
         areaName = "서울",
-        description = "Capital of South Korea",
-        commericalAreaList = listOf(sampleCommercialArea1, sampleCommercialArea2)
+        commercialAreaList = listOf(sampleCommercialArea1, sampleCommercialArea2)
     )
     val sampleMetroArea2 = MetroArea(
         code = "MA002",
         areaName = "부산",
-        description = "Second largest city in South Korea",
-        commericalAreaList = emptyList()
+        commercialAreaList = emptyList()
     )
 
     IsZoneScreen(

--- a/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneScreen.kt
+++ b/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneScreen.kt
@@ -29,7 +29,9 @@ import com.ilsangtech.ilsang.core.model.area.MetroArea
 import com.ilsangtech.ilsang.core.ui.zone.ZoneListContent
 import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
 import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.feature.iszone.component.IsZoneFailureDialog
 import com.ilsangtech.ilsang.feature.iszone.component.IsZoneHeader
+import com.ilsangtech.ilsang.feature.iszone.component.IsZoneSuccessDialog
 
 @Composable
 internal fun IsZoneScreen(
@@ -37,6 +39,16 @@ internal fun IsZoneScreen(
     onBackButtonClick: () -> Unit
 ) {
     val isZoneUiState by isZoneViewModel.isZoneUiState.collectAsStateWithLifecycle()
+
+    if (isZoneUiState.isIsZoneUpdateSuccess == true) {
+        IsZoneSuccessDialog(onDismissRequest = {
+            isZoneViewModel.resetIsZoneUpdateStatus()
+            onBackButtonClick()
+        })
+    } else if (isZoneUiState.isIsZoneUpdateSuccess == false) {
+        IsZoneFailureDialog(onDismissRequest = isZoneViewModel::resetIsZoneUpdateStatus)
+    }
+
     IsZoneScreen(
         selectedMetroArea = isZoneUiState.selectedMetroArea,
         selectedCommercialArea = isZoneUiState.selectedCommercialArea,

--- a/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneUiState.kt
+++ b/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneUiState.kt
@@ -6,5 +6,6 @@ import com.ilsangtech.ilsang.core.model.area.MetroArea
 data class IsZoneUiState(
     val selectedMetroArea: MetroArea?,
     val selectedCommercialArea: CommercialArea?,
-    val areaList: List<MetroArea>
+    val areaList: List<MetroArea>,
+    val isIsZoneUpdateSuccess: Boolean? = null
 )

--- a/feature/myzone/src/main/java/com/ilsangtech/ilsang/feature/myzone/MyZoneScreen.kt
+++ b/feature/myzone/src/main/java/com/ilsangtech/ilsang/feature/myzone/MyZoneScreen.kt
@@ -29,7 +29,9 @@ import com.ilsangtech.ilsang.core.model.area.MetroArea
 import com.ilsangtech.ilsang.core.ui.zone.ZoneListContent
 import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
 import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.feature.myzone.component.MyZoneFailureDialog
 import com.ilsangtech.ilsang.feature.myzone.component.MyZoneHeader
+import com.ilsangtech.ilsang.feature.myzone.component.MyZoneSuccessDialog
 
 @Composable
 fun MyZoneScreen(
@@ -37,6 +39,15 @@ fun MyZoneScreen(
     onBackButtonClick: () -> Unit
 ) {
     val myZoneUiState by myZoneViewModel.myZoneUiState.collectAsStateWithLifecycle()
+
+    if (myZoneUiState.isMyZoneUpdateSuccess == true) {
+        MyZoneSuccessDialog(onDismissRequest = {
+            myZoneViewModel.resetMyZoneUpdateStatus()
+            onBackButtonClick()
+        })
+    } else if (myZoneUiState.isMyZoneUpdateSuccess == false) {
+        MyZoneFailureDialog(onDismissRequest = myZoneViewModel::resetMyZoneUpdateStatus)
+    }
 
     MyZoneScreen(
         areaList = myZoneUiState.areaList,

--- a/feature/myzone/src/main/java/com/ilsangtech/ilsang/feature/myzone/MyZoneScreen.kt
+++ b/feature/myzone/src/main/java/com/ilsangtech/ilsang/feature/myzone/MyZoneScreen.kt
@@ -126,14 +126,12 @@ private fun MyZoneScreenPreview() {
     val sampleMetroArea1 = MetroArea(
         code = "MA001",
         areaName = "서울",
-        description = "Capital of South Korea",
-        commericalAreaList = listOf(sampleCommercialArea1, sampleCommercialArea2)
+        commercialAreaList = listOf(sampleCommercialArea1, sampleCommercialArea2)
     )
     val sampleMetroArea2 = MetroArea(
         code = "MA002",
         areaName = "부산",
-        description = "Second largest city in South Korea",
-        commericalAreaList = emptyList()
+        commercialAreaList = emptyList()
     )
 
     MyZoneScreen(

--- a/feature/myzone/src/main/java/com/ilsangtech/ilsang/feature/myzone/MyZoneUiState.kt
+++ b/feature/myzone/src/main/java/com/ilsangtech/ilsang/feature/myzone/MyZoneUiState.kt
@@ -6,5 +6,6 @@ import com.ilsangtech.ilsang.core.model.area.MetroArea
 data class MyZoneUiState(
     val selectedMetroArea: MetroArea?,
     val selectedCommercialArea: CommercialArea?,
-    val areaList: List<MetroArea>
+    val areaList: List<MetroArea>,
+    val isMyZoneUpdateSuccess: Boolean? = null
 )


### PR DESCRIPTION
이슈 번호: resolves #83 

작업 사항:

- 지역 정보 API 연동
- 내 지역 정보 로컬 저장
- 일상 지역, 내 지역 업데이트 결과에 따라 다이얼로그 표시

특이사항: 없음

UI 화면: 없음