### PR TITLE
[Feat] 랭킹 관련 API 연동 구현

### DIFF
--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -188,9 +188,10 @@ fun IlsangNavHost(
             submitNavigation(popBackStack = navController::popBackStack)
 
             rankingNavigation(
-                navigateToProfile = { id ->
-                    navController.navigate(ProfileRoute(id))
-                }
+                navigateToRankingDetail = { rankingDetailRoute ->
+                    navController.navigate(rankingDetailRoute)
+                },
+                onBackButtonClick = navController::popBackStack
             )
 
             approvalNavigation(navigateToProfile = { id ->

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
@@ -1,11 +1,11 @@
 package com.ilsangtech.ilsang.core.data.rank.datasource
 
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
-import com.ilsangtech.ilsang.core.network.model.rank.TotalTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankResponse
 
 interface RankDataSource {
-    suspend fun getTotalTopRankUsers(commercialAreaCode: String): TotalTopRankUsersResponse
+    suspend fun getTotalTopRankUsers(commercialAreaCode: String): List<UserRankNetworkModel>
 
     suspend fun getTopRankUsers(): TopUsersResponse
     suspend fun getXpTypeRank(

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
@@ -1,7 +1,9 @@
 package com.ilsangtech.ilsang.core.data.rank.datasource
 
+import com.ilsangtech.ilsang.core.network.model.rank.CommercialAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.MetroAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
@@ -23,6 +25,10 @@ interface RankDataSource {
     suspend fun getContributionTopRankUsers(
         seasonId: Int?
     ): ContributionTopRankUsersResponse
+
+    suspend fun getMetroTopRankAreas(seasonId: Int?): List<MetroAreaRankNetworkModel>
+
+    suspend fun getCommercialTopRankAreas(seasonId: Int?): List<CommercialAreaRankNetworkModel>
 
     suspend fun getTopRankUsers(): TopUsersResponse
     suspend fun getXpTypeRank(

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
@@ -1,6 +1,7 @@
 package com.ilsangtech.ilsang.core.data.rank.datasource
 
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
@@ -18,6 +19,10 @@ interface RankDataSource {
         seasonId: Int?,
         commercialAreaCode: String
     ): CommercialTopRankUsersResponse
+
+    suspend fun getContributionTopRankUsers(
+        seasonId: Int?
+    ): ContributionTopRankUsersResponse
 
     suspend fun getTopRankUsers(): TopUsersResponse
     suspend fun getXpTypeRank(

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
@@ -2,7 +2,6 @@ package com.ilsangtech.ilsang.core.data.rank.datasource
 
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
-import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
@@ -24,7 +23,7 @@ interface RankDataSource {
 
     suspend fun getContributionTopRankUsers(
         seasonId: Int?
-    ): ContributionTopRankUsersResponse
+    ): List<UserRankNetworkModel>
 
     suspend fun getMetroTopRankAreas(seasonId: Int?): List<MetroAreaRankNetworkModel>
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.core.data.rank.datasource
 
+import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
@@ -12,6 +13,11 @@ interface RankDataSource {
         seasonId: Int?,
         metroAreaCode: String
     ): MetroTopRankUsersResponse
+
+    suspend fun getCommercialTopRankUsers(
+        seasonId: Int?,
+        commercialAreaCode: String
+    ): CommercialTopRankUsersResponse
 
     suspend fun getTopRankUsers(): TopUsersResponse
     suspend fun getXpTypeRank(

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSource.kt
@@ -1,11 +1,17 @@
 package com.ilsangtech.ilsang.core.data.rank.datasource
 
+import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankResponse
 
 interface RankDataSource {
     suspend fun getTotalTopRankUsers(commercialAreaCode: String): List<UserRankNetworkModel>
+
+    suspend fun getMetroTopRankUsers(
+        seasonId: Int?,
+        metroAreaCode: String
+    ): MetroTopRankUsersResponse
 
     suspend fun getTopRankUsers(): TopUsersResponse
     suspend fun getXpTypeRank(

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
@@ -3,7 +3,6 @@ package com.ilsangtech.ilsang.core.data.rank.datasource
 import com.ilsangtech.ilsang.core.network.api.RankApiService
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
-import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
@@ -34,7 +33,7 @@ class RankDataSourceImpl @Inject constructor(
 
     override suspend fun getContributionTopRankUsers(
         seasonId: Int?
-    ): ContributionTopRankUsersResponse {
+    ): List<UserRankNetworkModel> {
         return rankApiService.getContributionTopRankUsers(seasonId)
     }
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.ilsangtech.ilsang.core.data.rank.datasource
 
 import com.ilsangtech.ilsang.core.network.api.RankApiService
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
@@ -27,6 +28,12 @@ class RankDataSourceImpl @Inject constructor(
         commercialAreaCode: String
     ): CommercialTopRankUsersResponse {
         return rankApiService.getCommercialTopRankUsers(seasonId, commercialAreaCode)
+    }
+
+    override suspend fun getContributionTopRankUsers(
+        seasonId: Int?
+    ): ContributionTopRankUsersResponse {
+        return rankApiService.getContributionTopRankUsers(seasonId)
     }
 
     override suspend fun getTopRankUsers(): TopUsersResponse {

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
@@ -1,8 +1,10 @@
 package com.ilsangtech.ilsang.core.data.rank.datasource
 
 import com.ilsangtech.ilsang.core.network.api.RankApiService
+import com.ilsangtech.ilsang.core.network.model.rank.CommercialAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.MetroAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
@@ -34,6 +36,18 @@ class RankDataSourceImpl @Inject constructor(
         seasonId: Int?
     ): ContributionTopRankUsersResponse {
         return rankApiService.getContributionTopRankUsers(seasonId)
+    }
+
+    override suspend fun getMetroTopRankAreas(
+        seasonId: Int?
+    ): List<MetroAreaRankNetworkModel> {
+        return rankApiService.getMetroTopRankAreas(seasonId)
+    }
+
+    override suspend fun getCommercialTopRankAreas(
+        seasonId: Int?
+    ): List<CommercialAreaRankNetworkModel> {
+        return rankApiService.getCommercialTopRankAreas(seasonId)
     }
 
     override suspend fun getTopRankUsers(): TopUsersResponse {

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.ilsangtech.ilsang.core.data.rank.datasource
 
 import com.ilsangtech.ilsang.core.network.api.RankApiService
+import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankResponse
@@ -11,6 +12,13 @@ class RankDataSourceImpl @Inject constructor(
 ) : RankDataSource {
     override suspend fun getTotalTopRankUsers(commercialAreaCode: String): List<UserRankNetworkModel> {
         return rankApiService.getTotalTopRankUsers(commercialAreaCode)
+    }
+
+    override suspend fun getMetroTopRankUsers(
+        seasonId: Int?,
+        metroAreaCode: String
+    ): MetroTopRankUsersResponse {
+        return rankApiService.getMetroTopRankUsers(seasonId, metroAreaCode)
     }
 
     override suspend fun getTopRankUsers(): TopUsersResponse {

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.ilsangtech.ilsang.core.data.rank.datasource
 
 import com.ilsangtech.ilsang.core.network.api.RankApiService
+import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
@@ -19,6 +20,13 @@ class RankDataSourceImpl @Inject constructor(
         metroAreaCode: String
     ): MetroTopRankUsersResponse {
         return rankApiService.getMetroTopRankUsers(seasonId, metroAreaCode)
+    }
+
+    override suspend fun getCommercialTopRankUsers(
+        seasonId: Int?,
+        commercialAreaCode: String
+    ): CommercialTopRankUsersResponse {
+        return rankApiService.getCommercialTopRankUsers(seasonId, commercialAreaCode)
     }
 
     override suspend fun getTopRankUsers(): TopUsersResponse {

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/datasource/RankDataSourceImpl.kt
@@ -2,14 +2,14 @@ package com.ilsangtech.ilsang.core.data.rank.datasource
 
 import com.ilsangtech.ilsang.core.network.api.RankApiService
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
-import com.ilsangtech.ilsang.core.network.model.rank.TotalTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankResponse
 import javax.inject.Inject
 
 class RankDataSourceImpl @Inject constructor(
     private val rankApiService: RankApiService
 ) : RankDataSource {
-    override suspend fun getTotalTopRankUsers(commercialAreaCode: String): TotalTopRankUsersResponse {
+    override suspend fun getTotalTopRankUsers(commercialAreaCode: String): List<UserRankNetworkModel> {
         return rankApiService.getTotalTopRankUsers(commercialAreaCode)
     }
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/AreaRankMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/AreaRankMapper.kt
@@ -1,0 +1,24 @@
+package com.ilsangtech.ilsang.core.data.rank.mapper
+
+import com.ilsangtech.ilsang.core.model.rank.CommercialAreaRank
+import com.ilsangtech.ilsang.core.model.rank.MetroAreaRank
+import com.ilsangtech.ilsang.core.network.model.rank.CommercialAreaRankNetworkModel
+import com.ilsangtech.ilsang.core.network.model.rank.MetroAreaRankNetworkModel
+
+internal fun MetroAreaRankNetworkModel.toMetroAreaRank(): MetroAreaRank {
+    return MetroAreaRank(
+        metroAreaCode = metroCode,
+        areaName = areaName,
+        point = point,
+        images = images
+    )
+}
+
+internal fun CommercialAreaRankNetworkModel.toCommercialAreaRank(): CommercialAreaRank {
+    return CommercialAreaRank(
+        commericalAreaCode = commercialCode,
+        areaName = areaName,
+        point = point,
+        images = images
+    )
+}

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/AreaRankMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/AreaRankMapper.kt
@@ -16,7 +16,7 @@ internal fun MetroAreaRankNetworkModel.toMetroAreaRank(): MetroAreaRank {
 
 internal fun CommercialAreaRankNetworkModel.toCommercialAreaRank(): CommercialAreaRank {
     return CommercialAreaRank(
-        commericalAreaCode = commercialCode,
+        commercialAreaCode = commercialCode,
         areaName = areaName,
         point = point,
         images = images

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/RankMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/RankMapper.kt
@@ -1,7 +1,7 @@
 package com.ilsangtech.ilsang.core.data.rank.mapper
 
 import com.ilsangtech.ilsang.core.data.title.mapper.toTitle
-import com.ilsangtech.ilsang.core.model.UserRank
+import com.ilsangtech.ilsang.core.model.rank.UserRank
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 
 internal fun UserRankNetworkModel.toUserRank(): UserRank {

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/UserRanksWithMyRankMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/UserRanksWithMyRankMapper.kt
@@ -1,0 +1,28 @@
+package com.ilsangtech.ilsang.core.data.rank.mapper
+
+import com.ilsangtech.ilsang.core.model.rank.UserRanksWithMyRank
+import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
+
+internal fun CommercialTopRankUsersResponse.toUserRanksWithMyRank(): UserRanksWithMyRank {
+    return UserRanksWithMyRank(
+        userRanks = ranks.map(UserRankNetworkModel::toUserRank),
+        myRank = user.toUserRank()
+    )
+}
+
+internal fun MetroTopRankUsersResponse.toUserRanksWithMyRank(): UserRanksWithMyRank {
+    return UserRanksWithMyRank(
+        userRanks = ranks.map(UserRankNetworkModel::toUserRank),
+        myRank = user.toUserRank()
+    )
+}
+
+internal fun ContributionTopRankUsersResponse.toUserRanksWithMyRank(): UserRanksWithMyRank {
+    return UserRanksWithMyRank(
+        userRanks = ranks.map(UserRankNetworkModel::toUserRank),
+        myRank = user.toUserRank()
+    )
+}

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
@@ -51,6 +51,15 @@ class RankRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getContributionTopRankUsers(seasonId: Int?): Flow<UserRanksWithMyRank> {
+        return flow {
+            emit(
+                rankDataSource.getContributionTopRankUsers(seasonId)
+                    .toUserRanksWithMyRank()
+            )
+        }
+    }
+
     override suspend fun getTopRankUsers(): List<UserRank> {
         return rankDataSource.getTopRankUsers()
             .data.map(UserRankNetworkModel::toUserRank)

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
@@ -39,6 +39,18 @@ class RankRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getCommercialTopRankUsers(
+        seasonId: Int?,
+        commercialAreaCode: String
+    ): Flow<UserRanksWithMyRank> {
+        return flow {
+            emit(
+                rankDataSource.getCommercialTopRankUsers(seasonId, commercialAreaCode)
+                    .toUserRanksWithMyRank()
+            )
+        }
+    }
+
     override suspend fun getTopRankUsers(): List<UserRank> {
         return rankDataSource.getTopRankUsers()
             .data.map(UserRankNetworkModel::toUserRank)

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
@@ -5,8 +5,8 @@ import com.ilsangtech.ilsang.core.data.rank.mapper.toUserRank
 import com.ilsangtech.ilsang.core.data.rank.toUserXpTypeRank
 import com.ilsangtech.ilsang.core.domain.RankRepository
 import com.ilsangtech.ilsang.core.model.RewardType
-import com.ilsangtech.ilsang.core.model.UserRank
 import com.ilsangtech.ilsang.core.model.UserXpTypeRank
+import com.ilsangtech.ilsang.core.model.rank.UserRank
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankNetworkModel
 import kotlinx.coroutines.flow.Flow

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
@@ -57,11 +57,11 @@ class RankRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getContributionTopRankUsers(seasonId: Int?): Flow<UserRanksWithMyRank> {
+    override fun getContributionTopRankUsers(seasonId: Int?): Flow<List<UserRank>> {
         return flow {
             emit(
                 rankDataSource.getContributionTopRankUsers(seasonId)
-                    .toUserRanksWithMyRank()
+                    .map(UserRankNetworkModel::toUserRank)
             )
         }
     }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
@@ -2,11 +2,13 @@ package com.ilsangtech.ilsang.core.data.rank.repository
 
 import com.ilsangtech.ilsang.core.data.rank.datasource.RankDataSource
 import com.ilsangtech.ilsang.core.data.rank.mapper.toUserRank
+import com.ilsangtech.ilsang.core.data.rank.mapper.toUserRanksWithMyRank
 import com.ilsangtech.ilsang.core.data.rank.toUserXpTypeRank
 import com.ilsangtech.ilsang.core.domain.RankRepository
 import com.ilsangtech.ilsang.core.model.RewardType
 import com.ilsangtech.ilsang.core.model.UserXpTypeRank
 import com.ilsangtech.ilsang.core.model.rank.UserRank
+import com.ilsangtech.ilsang.core.model.rank.UserRanksWithMyRank
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankNetworkModel
 import kotlinx.coroutines.flow.Flow
@@ -21,6 +23,18 @@ class RankRepositoryImpl @Inject constructor(
             emit(
                 rankDataSource.getTotalTopRankUsers(commercialAreaCode)
                     .map(UserRankNetworkModel::toUserRank)
+            )
+        }
+    }
+
+    override suspend fun getMetroTopRankUsers(
+        seasonId: Int?,
+        metroAreaCode: String
+    ): Flow<UserRanksWithMyRank> {
+        return flow {
+            emit(
+                rankDataSource.getMetroTopRankUsers(seasonId, metroAreaCode)
+                    .toUserRanksWithMyRank()
             )
         }
     }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
@@ -1,14 +1,17 @@
 package com.ilsangtech.ilsang.core.data.rank.repository
 
 import com.ilsangtech.ilsang.core.data.rank.datasource.RankDataSource
+import com.ilsangtech.ilsang.core.data.rank.mapper.toMetroAreaRank
 import com.ilsangtech.ilsang.core.data.rank.mapper.toUserRank
 import com.ilsangtech.ilsang.core.data.rank.mapper.toUserRanksWithMyRank
 import com.ilsangtech.ilsang.core.data.rank.toUserXpTypeRank
 import com.ilsangtech.ilsang.core.domain.RankRepository
 import com.ilsangtech.ilsang.core.model.RewardType
 import com.ilsangtech.ilsang.core.model.UserXpTypeRank
+import com.ilsangtech.ilsang.core.model.rank.MetroAreaRank
 import com.ilsangtech.ilsang.core.model.rank.UserRank
 import com.ilsangtech.ilsang.core.model.rank.UserRanksWithMyRank
+import com.ilsangtech.ilsang.core.network.model.rank.MetroAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankNetworkModel
 import kotlinx.coroutines.flow.Flow
@@ -56,6 +59,15 @@ class RankRepositoryImpl @Inject constructor(
             emit(
                 rankDataSource.getContributionTopRankUsers(seasonId)
                     .toUserRanksWithMyRank()
+            )
+        }
+    }
+
+    override suspend fun getMetroTopRankAreas(seasonId: Int?): Flow<List<MetroAreaRank>> {
+        return flow {
+            emit(
+                rankDataSource.getMetroTopRankAreas(seasonId)
+                    .map(MetroAreaRankNetworkModel::toMetroAreaRank)
             )
         }
     }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 class RankRepositoryImpl @Inject constructor(
     private val rankDataSource: RankDataSource
 ) : RankRepository {
-    override suspend fun getTotalTopRankUsers(commercialAreaCode: String): Flow<List<UserRank>> {
+    override fun getTotalTopRankUsers(commercialAreaCode: String): Flow<List<UserRank>> {
         return flow {
             emit(
                 rankDataSource.getTotalTopRankUsers(commercialAreaCode)
@@ -33,7 +33,7 @@ class RankRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getMetroTopRankUsers(
+    override fun getMetroTopRankUsers(
         seasonId: Int?,
         metroAreaCode: String
     ): Flow<UserRanksWithMyRank> {
@@ -45,7 +45,7 @@ class RankRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getCommercialTopRankUsers(
+    override fun getCommercialTopRankUsers(
         seasonId: Int?,
         commercialAreaCode: String
     ): Flow<UserRanksWithMyRank> {
@@ -57,7 +57,7 @@ class RankRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getContributionTopRankUsers(seasonId: Int?): Flow<UserRanksWithMyRank> {
+    override fun getContributionTopRankUsers(seasonId: Int?): Flow<UserRanksWithMyRank> {
         return flow {
             emit(
                 rankDataSource.getContributionTopRankUsers(seasonId)
@@ -66,7 +66,7 @@ class RankRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getMetroTopRankAreas(seasonId: Int?): Flow<List<MetroAreaRank>> {
+    override fun getMetroTopRankAreas(seasonId: Int?): Flow<List<MetroAreaRank>> {
         return flow {
             emit(
                 rankDataSource.getMetroTopRankAreas(seasonId)
@@ -75,7 +75,7 @@ class RankRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getCommercialTopRankAreas(seasonId: Int?): Flow<List<CommercialAreaRank>> {
+    override fun getCommercialTopRankAreas(seasonId: Int?): Flow<List<CommercialAreaRank>> {
         return flow {
             emit(
                 rankDataSource.getCommercialTopRankAreas(seasonId)

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/repository/RankRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.ilsangtech.ilsang.core.data.rank.repository
 
 import com.ilsangtech.ilsang.core.data.rank.datasource.RankDataSource
+import com.ilsangtech.ilsang.core.data.rank.mapper.toCommercialAreaRank
 import com.ilsangtech.ilsang.core.data.rank.mapper.toMetroAreaRank
 import com.ilsangtech.ilsang.core.data.rank.mapper.toUserRank
 import com.ilsangtech.ilsang.core.data.rank.mapper.toUserRanksWithMyRank
@@ -8,9 +9,11 @@ import com.ilsangtech.ilsang.core.data.rank.toUserXpTypeRank
 import com.ilsangtech.ilsang.core.domain.RankRepository
 import com.ilsangtech.ilsang.core.model.RewardType
 import com.ilsangtech.ilsang.core.model.UserXpTypeRank
+import com.ilsangtech.ilsang.core.model.rank.CommercialAreaRank
 import com.ilsangtech.ilsang.core.model.rank.MetroAreaRank
 import com.ilsangtech.ilsang.core.model.rank.UserRank
 import com.ilsangtech.ilsang.core.model.rank.UserRanksWithMyRank
+import com.ilsangtech.ilsang.core.network.model.rank.CommercialAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.MetroAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankNetworkModel
@@ -68,6 +71,15 @@ class RankRepositoryImpl @Inject constructor(
             emit(
                 rankDataSource.getMetroTopRankAreas(seasonId)
                     .map(MetroAreaRankNetworkModel::toMetroAreaRank)
+            )
+        }
+    }
+
+    override suspend fun getCommercialTopRankAreas(seasonId: Int?): Flow<List<CommercialAreaRank>> {
+        return flow {
+            emit(
+                rankDataSource.getCommercialTopRankAreas(seasonId)
+                    .map(CommercialAreaRankNetworkModel::toCommercialAreaRank)
             )
         }
     }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/season/repository/SeasonRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/season/repository/SeasonRepositoryImpl.kt
@@ -5,11 +5,25 @@ import com.ilsangtech.ilsang.core.data.season.mapper.toSeason
 import com.ilsangtech.ilsang.core.domain.SeasonRepository
 import com.ilsangtech.ilsang.core.model.season.Season
 import com.ilsangtech.ilsang.core.network.model.season.SeasonNetworkModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class SeasonRepositoryImpl(
     private val seasonDataSource: SeasonDataSource
 ) : SeasonRepository {
     override suspend fun getSeasonList(): List<Season> {
         return seasonDataSource.getSeasonList().map(SeasonNetworkModel::toSeason)
+    }
+
+    override suspend fun getCurrentSeason(): Season {
+        return getSeasonList().first {
+            val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
+            val start = simpleDateFormat.parse(it.startDate)
+            val end = simpleDateFormat.parse(it.endDate)
+            val current = Date()
+
+            current.after(start) && current.before(end)
+        }
     }
 }

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
@@ -23,7 +23,7 @@ interface RankRepository {
 
     fun getContributionTopRankUsers(
         seasonId: Int?
-    ): Flow<UserRanksWithMyRank>
+    ): Flow<List<UserRank>>
 
     fun getMetroTopRankAreas(
         seasonId: Int?

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
@@ -14,6 +14,11 @@ interface RankRepository {
         metroAreaCode: String
     ): Flow<UserRanksWithMyRank>
 
+    suspend fun getCommercialTopRankUsers(
+        seasonId: Int?,
+        commercialAreaCode: String
+    ): Flow<UserRanksWithMyRank>
+
     suspend fun getTopRankUsers(): List<UserRank>
     suspend fun getXpTypeRank(rewardType: RewardType): List<UserXpTypeRank>
 }

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
@@ -9,27 +9,27 @@ import com.ilsangtech.ilsang.core.model.rank.UserRanksWithMyRank
 import kotlinx.coroutines.flow.Flow
 
 interface RankRepository {
-    suspend fun getTotalTopRankUsers(commercialAreaCode: String): Flow<List<UserRank>>
+    fun getTotalTopRankUsers(commercialAreaCode: String): Flow<List<UserRank>>
 
-    suspend fun getMetroTopRankUsers(
+    fun getMetroTopRankUsers(
         seasonId: Int?,
         metroAreaCode: String
     ): Flow<UserRanksWithMyRank>
 
-    suspend fun getCommercialTopRankUsers(
+    fun getCommercialTopRankUsers(
         seasonId: Int?,
         commercialAreaCode: String
     ): Flow<UserRanksWithMyRank>
 
-    suspend fun getContributionTopRankUsers(
+    fun getContributionTopRankUsers(
         seasonId: Int?
     ): Flow<UserRanksWithMyRank>
 
-    suspend fun getMetroTopRankAreas(
+    fun getMetroTopRankAreas(
         seasonId: Int?
     ): Flow<List<MetroAreaRank>>
 
-    suspend fun getCommercialTopRankAreas(
+    fun getCommercialTopRankAreas(
         seasonId: Int?
     ): Flow<List<CommercialAreaRank>>
 

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
@@ -1,8 +1,8 @@
 package com.ilsangtech.ilsang.core.domain
 
 import com.ilsangtech.ilsang.core.model.RewardType
-import com.ilsangtech.ilsang.core.model.UserRank
 import com.ilsangtech.ilsang.core.model.UserXpTypeRank
+import com.ilsangtech.ilsang.core.model.rank.UserRank
 import kotlinx.coroutines.flow.Flow
 
 interface RankRepository {

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
@@ -18,6 +18,10 @@ interface RankRepository {
         seasonId: Int?,
         commercialAreaCode: String
     ): Flow<UserRanksWithMyRank>
+    
+    suspend fun getContributionTopRankUsers(
+        seasonId: Int?
+    ): Flow<UserRanksWithMyRank>
 
     suspend fun getTopRankUsers(): List<UserRank>
     suspend fun getXpTypeRank(rewardType: RewardType): List<UserXpTypeRank>

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
@@ -2,6 +2,7 @@ package com.ilsangtech.ilsang.core.domain
 
 import com.ilsangtech.ilsang.core.model.RewardType
 import com.ilsangtech.ilsang.core.model.UserXpTypeRank
+import com.ilsangtech.ilsang.core.model.rank.CommercialAreaRank
 import com.ilsangtech.ilsang.core.model.rank.MetroAreaRank
 import com.ilsangtech.ilsang.core.model.rank.UserRank
 import com.ilsangtech.ilsang.core.model.rank.UserRanksWithMyRank
@@ -27,6 +28,10 @@ interface RankRepository {
     suspend fun getMetroTopRankAreas(
         seasonId: Int?
     ): Flow<List<MetroAreaRank>>
+
+    suspend fun getCommercialTopRankAreas(
+        seasonId: Int?
+    ): Flow<List<CommercialAreaRank>>
 
     suspend fun getTopRankUsers(): List<UserRank>
     suspend fun getXpTypeRank(rewardType: RewardType): List<UserXpTypeRank>

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
@@ -2,6 +2,7 @@ package com.ilsangtech.ilsang.core.domain
 
 import com.ilsangtech.ilsang.core.model.RewardType
 import com.ilsangtech.ilsang.core.model.UserXpTypeRank
+import com.ilsangtech.ilsang.core.model.rank.MetroAreaRank
 import com.ilsangtech.ilsang.core.model.rank.UserRank
 import com.ilsangtech.ilsang.core.model.rank.UserRanksWithMyRank
 import kotlinx.coroutines.flow.Flow
@@ -18,10 +19,14 @@ interface RankRepository {
         seasonId: Int?,
         commercialAreaCode: String
     ): Flow<UserRanksWithMyRank>
-    
+
     suspend fun getContributionTopRankUsers(
         seasonId: Int?
     ): Flow<UserRanksWithMyRank>
+
+    suspend fun getMetroTopRankAreas(
+        seasonId: Int?
+    ): Flow<List<MetroAreaRank>>
 
     suspend fun getTopRankUsers(): List<UserRank>
     suspend fun getXpTypeRank(rewardType: RewardType): List<UserXpTypeRank>

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/RankRepository.kt
@@ -3,10 +3,17 @@ package com.ilsangtech.ilsang.core.domain
 import com.ilsangtech.ilsang.core.model.RewardType
 import com.ilsangtech.ilsang.core.model.UserXpTypeRank
 import com.ilsangtech.ilsang.core.model.rank.UserRank
+import com.ilsangtech.ilsang.core.model.rank.UserRanksWithMyRank
 import kotlinx.coroutines.flow.Flow
 
 interface RankRepository {
     suspend fun getTotalTopRankUsers(commercialAreaCode: String): Flow<List<UserRank>>
+
+    suspend fun getMetroTopRankUsers(
+        seasonId: Int?,
+        metroAreaCode: String
+    ): Flow<UserRanksWithMyRank>
+
     suspend fun getTopRankUsers(): List<UserRank>
     suspend fun getXpTypeRank(rewardType: RewardType): List<UserXpTypeRank>
 }

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/SeasonRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/SeasonRepository.kt
@@ -4,4 +4,6 @@ import com.ilsangtech.ilsang.core.model.season.Season
 
 interface SeasonRepository {
     suspend fun getSeasonList(): List<Season>
+
+    suspend fun getCurrentSeason(): Season
 }

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/UserRank.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/UserRank.kt
@@ -6,7 +6,7 @@ data class UserRank(
     val userId: String,
     val nickName: String,
     val point: Int,
-    val profileImageId: String,
+    val profileImageId: String?,
     val rank: Int,
     val title: Title
 )

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/CommercialAreaRank.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/CommercialAreaRank.kt
@@ -1,0 +1,8 @@
+package com.ilsangtech.ilsang.core.model.rank
+
+data class CommercialAreaRank(
+    val commericalAreaCode: String,
+    val areaName: String,
+    val point: Int,
+    val images: List<String>
+)

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/CommercialAreaRank.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/CommercialAreaRank.kt
@@ -1,7 +1,7 @@
 package com.ilsangtech.ilsang.core.model.rank
 
 data class CommercialAreaRank(
-    val commericalAreaCode: String,
+    val commercialAreaCode: String,
     val areaName: String,
     val point: Int,
     val images: List<String>

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/MetroAreaRank.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/MetroAreaRank.kt
@@ -1,0 +1,8 @@
+package com.ilsangtech.ilsang.core.model.rank
+
+data class MetroAreaRank(
+    val metroAreaCode: String,
+    val areaName: String,
+    val point: Int,
+    val images: List<String>
+)

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/UserRank.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/UserRank.kt
@@ -1,4 +1,4 @@
-package com.ilsangtech.ilsang.core.model
+package com.ilsangtech.ilsang.core.model.rank
 
 import com.ilsangtech.ilsang.core.model.title.Title
 

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/UserRanksWithMyRank.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/UserRanksWithMyRank.kt
@@ -1,0 +1,6 @@
+package com.ilsangtech.ilsang.core.model.rank
+
+data class UserRanksWithMyRank(
+    val userRanks: List<UserRank>,
+    val myRank: UserRank
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.core.network.api
 
+import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TotalTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankResponse
@@ -11,6 +12,12 @@ interface RankApiService {
     suspend fun getTotalTopRankUsers(
         @Query("commercialAreaCode") commercialAreaCode: String
     ): TotalTopRankUsersResponse
+
+    @GET("api/v1/rank/user/metro")
+    suspend fun getMetroTopRankUsers(
+        @Query("seasonId") seasonId: Int?,
+        @Query("metroAreaCode") metroAreaCode: String
+    ): MetroTopRankUsersResponse
 
     @GET("open/v1/rank/top-users")
     suspend fun getTopRankUsers(): TopUsersResponse

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
@@ -8,7 +8,9 @@ import retrofit2.http.Query
 
 interface RankApiService {
     @GET("api/v1/rank/user/total")
-    suspend fun getTotalTopRankUsers(commercialAreaCode: String): TotalTopRankUsersResponse
+    suspend fun getTotalTopRankUsers(
+        @Query("commercialAreaCode") commercialAreaCode: String
+    ): TotalTopRankUsersResponse
 
     @GET("open/v1/rank/top-users")
     suspend fun getTopRankUsers(): TopUsersResponse

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.core.network.api
 
+import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TotalTopRankUsersResponse
@@ -18,6 +19,12 @@ interface RankApiService {
         @Query("seasonId") seasonId: Int?,
         @Query("metroAreaCode") metroAreaCode: String
     ): MetroTopRankUsersResponse
+
+    @GET("api/v1/rank/user/commercial")
+    suspend fun getCommercialTopRankUsers(
+        @Query("seasonId") seasonId: Int?,
+        @Query("commercialAreaCode") commercialAreaCode: String
+    ): CommercialTopRankUsersResponse
 
     @GET("open/v1/rank/top-users")
     suspend fun getTopRankUsers(): TopUsersResponse

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
@@ -2,7 +2,6 @@ package com.ilsangtech.ilsang.core.network.api
 
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
-import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
@@ -32,7 +31,7 @@ interface RankApiService {
     @GET("api/v1/rank/user/contribution")
     suspend fun getContributionTopRankUsers(
         @Query("seasonId") seasonId: Int?
-    ): ContributionTopRankUsersResponse
+    ): List<UserRankNetworkModel>
 
     @GET("api/v1/rank/area/metro")
     suspend fun getMetroTopRankAreas(

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
@@ -4,7 +4,7 @@ import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersRespo
 import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
-import com.ilsangtech.ilsang.core.network.model.rank.TotalTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.XpTypeRankResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -13,7 +13,7 @@ interface RankApiService {
     @GET("api/v1/rank/user/total")
     suspend fun getTotalTopRankUsers(
         @Query("commercialAreaCode") commercialAreaCode: String
-    ): TotalTopRankUsersResponse
+    ): List<UserRankNetworkModel>
 
     @GET("api/v1/rank/user/metro")
     suspend fun getMetroTopRankUsers(

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
@@ -1,7 +1,9 @@
 package com.ilsangtech.ilsang.core.network.api
 
+import com.ilsangtech.ilsang.core.network.model.rank.CommercialAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.MetroAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
@@ -31,6 +33,16 @@ interface RankApiService {
     suspend fun getContributionTopRankUsers(
         @Query("seasonId") seasonId: Int?
     ): ContributionTopRankUsersResponse
+
+    @GET("api/v1/rank/area/metro")
+    suspend fun getMetroTopRankAreas(
+        @Query("seasonId") seasonId: Int?
+    ): List<MetroAreaRankNetworkModel>
+
+    @GET("api/v1/rank/area/commercial")
+    suspend fun getCommercialTopRankAreas(
+        @Query("seasonId") seasonId: Int?
+    ): List<CommercialAreaRankNetworkModel>
 
     @GET("open/v1/rank/top-users")
     suspend fun getTopRankUsers(): TopUsersResponse

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/RankApiService.kt
@@ -1,6 +1,7 @@
 package com.ilsangtech.ilsang.core.network.api
 
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
+import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TopUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.TotalTopRankUsersResponse
@@ -25,6 +26,11 @@ interface RankApiService {
         @Query("seasonId") seasonId: Int?,
         @Query("commercialAreaCode") commercialAreaCode: String
     ): CommercialTopRankUsersResponse
+
+    @GET("api/v1/rank/user/contribution")
+    suspend fun getContributionTopRankUsers(
+        @Query("seasonId") seasonId: Int?
+    ): ContributionTopRankUsersResponse
 
     @GET("open/v1/rank/top-users")
     suspend fun getTopRankUsers(): TopUsersResponse

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/SeasonApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/SeasonApiService.kt
@@ -5,5 +5,5 @@ import retrofit2.http.GET
 
 interface SeasonApiService {
     @GET("api/v1/season")
-    fun getSeasonList(): List<SeasonNetworkModel>
+    suspend fun getSeasonList(): List<SeasonNetworkModel>
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/CommercialAreaRankNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/CommercialAreaRankNetworkModel.kt
@@ -1,0 +1,11 @@
+package com.ilsangtech.ilsang.core.network.model.rank
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CommercialAreaRankNetworkModel(
+    val areaName: String,
+    val commercialCode: String,
+    val images: List<String>,
+    val point: Int
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/CommercialTopRankUsersResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/CommercialTopRankUsersResponse.kt
@@ -1,0 +1,9 @@
+package com.ilsangtech.ilsang.core.network.model.rank
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CommercialTopRankUsersResponse(
+    val ranks: List<UserRankNetworkModel>,
+    val user: UserRankNetworkModel
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/ContributionTopRankUsersResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/ContributionTopRankUsersResponse.kt
@@ -1,0 +1,9 @@
+package com.ilsangtech.ilsang.core.network.model.rank
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ContributionTopRankUsersResponse(
+    val ranks: List<UserRankNetworkModel>,
+    val user: UserRankNetworkModel
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/MetroAreaRankNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/MetroAreaRankNetworkModel.kt
@@ -1,0 +1,11 @@
+package com.ilsangtech.ilsang.core.network.model.rank
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MetroAreaRankNetworkModel(
+    val areaName: String,
+    val images: List<String>,
+    val metroCode: String,
+    val point: Int
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/MetroTopRankUsersResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/MetroTopRankUsersResponse.kt
@@ -1,0 +1,9 @@
+package com.ilsangtech.ilsang.core.network.model.rank
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MetroTopRankUsersResponse(
+    val ranks: List<UserRankNetworkModel>,
+    val user: UserRankNetworkModel
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/UserRankNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/UserRankNetworkModel.kt
@@ -8,7 +8,7 @@ data class UserRankNetworkModel(
     val userId: String,
     val nickName: String,
     val point: Int,
-    val profileImageId: String,
+    val profileImageId: String?,
     val rank: Int,
     val title: TitleNetworkModel
 )

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
@@ -19,12 +19,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ilsangtech.ilsang.core.model.NewQuestType
 import com.ilsangtech.ilsang.core.model.RewardPoint
-import com.ilsangtech.ilsang.core.model.UserRank
 import com.ilsangtech.ilsang.core.model.banner.Banner
 import com.ilsangtech.ilsang.core.model.quest.LargeRewardQuest
 import com.ilsangtech.ilsang.core.model.quest.PopularQuest
 import com.ilsangtech.ilsang.core.model.quest.QuestDetail
 import com.ilsangtech.ilsang.core.model.quest.RecommendedQuest
+import com.ilsangtech.ilsang.core.model.rank.UserRank
 import com.ilsangtech.ilsang.core.model.title.Title
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.core.model.title.TitleType

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/component/UserRankContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/component/UserRankContent.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
-import com.ilsangtech.ilsang.core.model.UserRank
+import com.ilsangtech.ilsang.core.model.rank.UserRank
 import com.ilsangtech.ilsang.core.model.title.Title
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.core.model.title.TitleType

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/model/HomeTabUiState.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/model/HomeTabUiState.kt
@@ -1,10 +1,10 @@
 package com.ilsangtech.ilsang.feature.home.model
 
-import com.ilsangtech.ilsang.core.model.UserRank
 import com.ilsangtech.ilsang.core.model.banner.Banner
 import com.ilsangtech.ilsang.core.model.quest.LargeRewardQuest
 import com.ilsangtech.ilsang.core.model.quest.PopularQuest
 import com.ilsangtech.ilsang.core.model.quest.RecommendedQuest
+import com.ilsangtech.ilsang.core.model.rank.UserRank
 
 sealed interface HomeTabUiState {
     data object Loading : HomeTabUiState

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
@@ -13,12 +13,15 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.designsystem.theme.heading02
@@ -28,10 +31,33 @@ import com.ilsangtech.ilsang.feature.ranking.component.RankingDetailHeader
 import com.ilsangtech.ilsang.feature.ranking.component.TimeRemainingCard
 import com.ilsangtech.ilsang.feature.ranking.component.UserRankItem
 import com.ilsangtech.ilsang.feature.ranking.model.AreaRankUiModel
+import com.ilsangtech.ilsang.feature.ranking.model.RankingDetailUiState
 import com.ilsangtech.ilsang.feature.ranking.model.SeasonUiModel
 import com.ilsangtech.ilsang.feature.ranking.model.UserRankUiModel
 import java.text.SimpleDateFormat
 import java.util.Locale
+
+@Composable
+fun RankingDetailScreen(
+    rankingDetailViewModel: RankingDetailViewModel = hiltViewModel(),
+    onBackButtonClick: () -> Unit
+) {
+    val rankingDetailUiState by
+    rankingDetailViewModel.rankingDetailUiState.collectAsStateWithLifecycle()
+
+    if (rankingDetailUiState is RankingDetailUiState.Success) {
+        val rankingDetailUiState = rankingDetailUiState as RankingDetailUiState.Success
+
+        RankingDetailScreen(
+            currentSeason = rankingDetailUiState.currentSeason,
+            areaRankUiModel = rankingDetailUiState.areaRankUiModel,
+            myRankUiModel = rankingDetailUiState.myRankUiModel,
+            userRankList = rankingDetailUiState.userRankList,
+            onBackButtonClick = onBackButtonClick,
+            onSeasonFinished = rankingDetailViewModel::refreshSeason
+        )
+    }
+}
 
 @Composable
 private fun RankingDetailScreen(

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
@@ -184,6 +184,7 @@ private fun RankingDetailScreenPreview() {
     )
     RankingDetailScreen(
         currentSeason = SeasonUiModel.Season(
+            seasonId = 1,
             seasonNumber = 1,
             startDate = "2023-01-01",
             endDate = "2025-10-31"

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailViewModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailViewModel.kt
@@ -32,6 +32,7 @@ class RankingDetailViewModel @Inject constructor(
 ) : ViewModel() {
     private val rankingDetailInfo = savedStateHandle.toRoute<RankingDetailRoute>()
     private val areaRankUiModel = AreaRankUiModel(
+        areaCode = rankingDetailInfo.areaCode,
         areaName = rankingDetailInfo.areaName,
         rank = rankingDetailInfo.rank,
         point = rankingDetailInfo.point,

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailViewModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailViewModel.kt
@@ -59,6 +59,7 @@ class RankingDetailViewModel @Inject constructor(
 
             RankingDetailUiState.Success(
                 currentSeason = SeasonUiModel.Season(
+                    seasonId = currentSeason.id,
                     seasonNumber = currentSeason.seasonNumber,
                     startDate = DateConverter.formatDate(
                         input = currentSeason.startDate,

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailViewModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailViewModel.kt
@@ -1,0 +1,92 @@
+package com.ilsangtech.ilsang.feature.ranking
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.ilsangtech.ilsang.core.domain.RankRepository
+import com.ilsangtech.ilsang.core.domain.SeasonRepository
+import com.ilsangtech.ilsang.core.model.rank.UserRanksWithMyRank
+import com.ilsangtech.ilsang.core.util.DateConverter
+import com.ilsangtech.ilsang.feature.ranking.model.AreaRankUiModel
+import com.ilsangtech.ilsang.feature.ranking.model.RankingDetailUiState
+import com.ilsangtech.ilsang.feature.ranking.model.SeasonUiModel
+import com.ilsangtech.ilsang.feature.ranking.model.toUserRankUiModel
+import com.ilsangtech.ilsang.feature.ranking.navigation.RankingDetailRoute
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RankingDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val seasonRepository: SeasonRepository,
+    rankRepository: RankRepository
+) : ViewModel() {
+    private val rankingDetailInfo = savedStateHandle.toRoute<RankingDetailRoute>()
+    private val areaRankUiModel = AreaRankUiModel(
+        areaName = rankingDetailInfo.areaName,
+        rank = rankingDetailInfo.rank,
+        point = rankingDetailInfo.point,
+        images = rankingDetailInfo.images
+    )
+
+    private val userRanks = if (rankingDetailInfo.isMetro) {
+        rankRepository.getMetroTopRankUsers(
+            seasonId = rankingDetailInfo.seasonId,
+            metroAreaCode = rankingDetailInfo.areaCode
+        )
+    } else {
+        rankRepository.getCommercialTopRankUsers(
+            seasonId = rankingDetailInfo.seasonId,
+            commercialAreaCode = rankingDetailInfo.areaCode
+        )
+    }
+
+    private val refreshTrigger = MutableSharedFlow<Unit>(replay = 1)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val rankingDetailUiState = refreshTrigger.flatMapLatest {
+        userRanks.map<UserRanksWithMyRank, RankingDetailUiState> {
+            val currentSeason = seasonRepository.getCurrentSeason()
+
+            RankingDetailUiState.Success(
+                currentSeason = SeasonUiModel.Season(
+                    seasonNumber = currentSeason.seasonNumber,
+                    startDate = DateConverter.formatDate(
+                        input = currentSeason.startDate,
+                        outputPattern = "yyyy-MM-dd"
+                    ),
+                    endDate = DateConverter.formatDate(
+                        input = currentSeason.endDate,
+                        outputPattern = "yyyy-MM-dd"
+                    )
+                ),
+                areaRankUiModel = areaRankUiModel,
+                myRankUiModel = it.myRank.toUserRankUiModel(),
+                userRankList = it.userRanks.map { userRank -> userRank.toUserRankUiModel() }
+            )
+        }
+    }
+        .catch { emit(RankingDetailUiState.Error) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = RankingDetailUiState.Loading
+        )
+
+    init {
+        refreshSeason()
+    }
+
+    fun refreshSeason() {
+        viewModelScope.launch { refreshTrigger.emit(Unit) }
+    }
+}

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
@@ -279,14 +279,50 @@ private fun RankingTabScreenPreview() {
     )
     val rankingTabUiState = RankingTabUiState.Success(
         metroRankAreas = listOf(
-            AreaRankUiModel(areaName = "강남구", rank = 1, point = 1000, images = emptyList()),
-            AreaRankUiModel(areaName = "서초구", rank = 2, point = 900, images = emptyList()),
-            AreaRankUiModel(areaName = "송파구", rank = 3, point = 800, images = emptyList())
+            AreaRankUiModel(
+                areaCode = "",
+                areaName = "강남구",
+                rank = 1,
+                point = 1000,
+                images = emptyList()
+            ),
+            AreaRankUiModel(
+                areaCode = "",
+                areaName = "서초구",
+                rank = 2,
+                point = 900,
+                images = emptyList()
+            ),
+            AreaRankUiModel(
+                areaCode = "",
+                areaName = "송파구",
+                rank = 3,
+                point = 800,
+                images = emptyList()
+            )
         ),
         commercialRankAreas = listOf(
-            AreaRankUiModel(areaName = "역삼동", rank = 1, point = 1200, images = emptyList()),
-            AreaRankUiModel(areaName = "삼성동", rank = 2, point = 1100, images = emptyList()),
-            AreaRankUiModel(areaName = "논현동", rank = 3, point = 1000, images = emptyList())
+            AreaRankUiModel(
+                areaCode = "",
+                areaName = "역삼동",
+                rank = 1,
+                point = 1200,
+                images = emptyList()
+            ),
+            AreaRankUiModel(
+                areaCode = "",
+                areaName = "삼성동",
+                rank = 2,
+                point = 1100,
+                images = emptyList()
+            ),
+            AreaRankUiModel(
+                areaCode = "",
+                areaName = "논현동",
+                rank = 3,
+                point = 1000,
+                images = emptyList()
+            )
         ),
         contributionRankUsers = listOf(
             UserRankUiModel(

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -22,16 +23,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
@@ -91,6 +96,18 @@ private fun RankingTabScreen(
                 .parse(currentSeason.endDate)
         }
     }
+    var popupOffset by remember { mutableStateOf(Offset(0f, 0f)) }
+
+    if (expanded) {
+        Popup {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .offset { IntOffset(popupOffset.x.toInt(), popupOffset.y.toInt()) }
+                    .background(Color.Black.copy(alpha = 0.3f))
+            )
+        }
+    }
 
     Surface(
         modifier = Modifier
@@ -101,20 +118,22 @@ private fun RankingTabScreen(
         Column(modifier = Modifier.fillMaxSize()) {
             RankingScreenHeader()
             SeasonSelector(
+                modifier = Modifier.onGloballyPositioned { coordinates ->
+                    popupOffset =
+                        Offset(
+                            x = 0f,
+                            y = coordinates.positionInWindow().y
+                                    + coordinates.size.height.toFloat()
+                        )
+
+                },
                 expanded = expanded,
                 seasonList = seasonList,
                 selectedSeason = selectedSeason,
                 onSeasonSelected = onSeasonSelected,
                 onExpandedChange = { expanded = it }
             )
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .drawWithContent {
-                        drawContent()
-                        if (expanded) drawRect(color = Color.Black.copy(alpha = 0.3f))
-                    }
-            ) {
+            Column(modifier = Modifier.weight(1f)) {
                 currentSeason?.let {
                     RankingTabBanner(
                         modifier = Modifier

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
@@ -54,13 +54,14 @@ import com.ilsangtech.ilsang.feature.ranking.model.RankingTabUiState
 import com.ilsangtech.ilsang.feature.ranking.model.RewardUiModel
 import com.ilsangtech.ilsang.feature.ranking.model.SeasonUiModel
 import com.ilsangtech.ilsang.feature.ranking.model.UserRankUiModel
+import com.ilsangtech.ilsang.feature.ranking.navigation.RankingDetailRoute
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 @Composable
 fun RankingTabScreen(
     rankingViewModel: RankingTabViewModel = hiltViewModel(),
-    navigateToProfile: (String) -> Unit
+    navigateToRankingDetail: (RankingDetailRoute) -> Unit
 ) {
     val seasonList by rankingViewModel.seasonList.collectAsStateWithLifecycle()
     val currentSeason by rankingViewModel.currentSeason.collectAsStateWithLifecycle()
@@ -74,6 +75,19 @@ fun RankingTabScreen(
         selectedSeason = selectedSeason,
         rankingTabUiState = rankingUiState,
         onSeasonSelected = rankingViewModel::updateSelectedSeason,
+        onAreaClick = { areaRankUiModel, isMetro ->
+            navigateToRankingDetail(
+                RankingDetailRoute(
+                    seasonId = currentSeason!!.seasonId,
+                    isMetro = isMetro,
+                    areaCode = areaRankUiModel.areaCode,
+                    areaName = areaRankUiModel.areaName,
+                    rank = areaRankUiModel.rank,
+                    point = areaRankUiModel.point,
+                    images = areaRankUiModel.images
+                )
+            )
+        },
         onSeasonFinished = rankingViewModel::refreshSeason
     )
 }
@@ -86,6 +100,7 @@ private fun RankingTabScreen(
     selectedSeason: SeasonUiModel,
     rankingTabUiState: RankingTabUiState,
     onSeasonSelected: (SeasonUiModel) -> Unit,
+    onAreaClick: (AreaRankUiModel, Boolean) -> Unit,
     onSeasonFinished: () -> Unit
 ) {
     var selectedReward by remember { mutableStateOf(RewardUiModel.Metro) }
@@ -171,7 +186,7 @@ private fun RankingTabScreen(
                                             areaName = metroRankArea.areaName,
                                             rank = metroRankArea.rank,
                                             point = metroRankArea.point,
-                                            onClick = {}
+                                            onClick = { onAreaClick(metroRankArea, true) }
                                         )
                                     }
                                 }
@@ -182,7 +197,7 @@ private fun RankingTabScreen(
                                             areaName = commercialRankArea.areaName,
                                             rank = commercialRankArea.rank,
                                             point = commercialRankArea.point,
-                                            onClick = {}
+                                            onClick = { onAreaClick(commercialRankArea, false) }
                                         )
                                     }
                                 }
@@ -352,6 +367,7 @@ private fun RankingTabScreenPreview() {
         selectedSeason = selectedSeason,
         rankingTabUiState = rankingTabUiState,
         onSeasonSelected = {},
+        onAreaClick = { _, _ -> },
         onSeasonFinished = {}
     )
 }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabViewModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabViewModel.kt
@@ -3,24 +3,108 @@ package com.ilsangtech.ilsang.feature.ranking
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ilsangtech.ilsang.core.domain.RankRepository
-import com.ilsangtech.ilsang.core.model.RewardType
+import com.ilsangtech.ilsang.core.domain.SeasonRepository
+import com.ilsangtech.ilsang.core.model.rank.CommercialAreaRank
+import com.ilsangtech.ilsang.core.model.rank.MetroAreaRank
+import com.ilsangtech.ilsang.core.model.rank.UserRank
+import com.ilsangtech.ilsang.core.model.season.Season
+import com.ilsangtech.ilsang.feature.ranking.model.RankingTabUiState
+import com.ilsangtech.ilsang.feature.ranking.model.SeasonUiModel
+import com.ilsangtech.ilsang.feature.ranking.model.toAreaRankUiModel
+import com.ilsangtech.ilsang.feature.ranking.model.toSeasonUiModel
+import com.ilsangtech.ilsang.feature.ranking.model.toUserRankUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class RankingTabViewModel @Inject constructor(
+    private val seasonRepository: SeasonRepository,
     private val rankRepository: RankRepository
 ) : ViewModel() {
-    val rankingUiState = flow {
-        emit(
-            RewardType.entries.associateWith { rankRepository.getXpTypeRank(it) }
+    private val refreshTrigger = MutableSharedFlow<Unit>(replay = 1)
+
+    private val _selectedSeason = MutableStateFlow<SeasonUiModel>(SeasonUiModel.Total)
+    val selectedSeason = _selectedSeason.asStateFlow()
+
+    val seasonList = refreshTrigger.map {
+        listOf(SeasonUiModel.Total) + seasonRepository.getSeasonList()
+            .map(Season::toSeasonUiModel)
+    }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyList()
         )
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5000),
-        initialValue = emptyMap()
-    )
+
+    val currentSeason = refreshTrigger.map {
+        seasonRepository.getCurrentSeason().toSeasonUiModel()
+    }
+        .catch { }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val rankingTabUiState =
+        selectedSeason.flatMapLatest { selectedSeason ->
+            val seasonId = (selectedSeason as? SeasonUiModel.Season)?.seasonId
+            val metroRankAreas = rankRepository.getMetroTopRankAreas(seasonId)
+            val commercialRankAreas = rankRepository.getCommercialTopRankAreas(seasonId)
+            val contributionRankUsers = rankRepository.getContributionTopRankUsers(seasonId)
+
+            combine(
+                metroRankAreas,
+                commercialRankAreas,
+                contributionRankUsers
+            ) { metroRankAreas, commercialRankAreas, contributionRankUsers ->
+                RankingTabUiState.Success(
+                    metroRankAreas = metroRankAreas.map(MetroAreaRank::toAreaRankUiModel),
+                    commercialRankAreas = commercialRankAreas.map(CommercialAreaRank::toAreaRankUiModel),
+                    contributionRankUsers = contributionRankUsers.map(UserRank::toUserRankUiModel)
+                ) as RankingTabUiState
+            }
+        }
+            .catch { emit(RankingTabUiState.Error) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = RankingTabUiState.Loading
+            )
+
+    init {
+        viewModelScope.launch {
+            try {
+                _selectedSeason.update {
+                    seasonRepository.getCurrentSeason().toSeasonUiModel()
+                }
+            } catch (_: Exception) {
+                _selectedSeason.update { SeasonUiModel.Total }
+            }
+            refreshTrigger.emit(Unit)
+        }
+    }
+
+    fun updateSelectedSeason(seasonUiModel: SeasonUiModel) {
+        _selectedSeason.update { seasonUiModel }
+    }
+
+    fun refreshSeason() {
+        viewModelScope.launch {
+            refreshTrigger.emit(Unit)
+        }
+    }
 }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/RankingDetailAreaInfoCard.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/RankingDetailAreaInfoCard.kt
@@ -163,6 +163,7 @@ internal fun RankingDetailAreaInfoCard(
 private fun RankingDetailAreaInfoCardPreview() {
     RankingDetailAreaInfoCard(
         areaRankUiModel = AreaRankUiModel(
+            areaCode = "",
             areaName = "경기 남부",
             rank = 1,
             point = 123456789,

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/RankingTabBanner.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/RankingTabBanner.kt
@@ -117,6 +117,7 @@ internal fun RankingTabBanner(
 @Composable
 private fun RankingTabBannerPreview() {
     val season = SeasonUiModel.Season(
+        seasonId = 1,
         seasonNumber = 1,
         startDate = "2023.01.01",
         endDate = "2023.03.31"

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/SeasonSelector.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/SeasonSelector.kt
@@ -106,11 +106,13 @@ private fun SeasonSelectorPreview() {
     val seasonList = listOf(
         SeasonUiModel.Total,
         SeasonUiModel.Season(
+            seasonId = 1,
             seasonNumber = 1,
             startDate = "2023-01-01",
             endDate = "2023-03-31"
         ),
         SeasonUiModel.Season(
+            seasonId = 1,
             seasonNumber = 2,
             startDate = "2023-04-01",
             endDate = "2023-06-30"

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/UserRankItem.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/UserRankItem.kt
@@ -47,7 +47,7 @@ import java.util.Locale
 @Composable
 internal fun UserRankItem(
     modifier: Modifier = Modifier,
-    imageId: String,
+    imageId: String?,
     nickname: String,
     titleName: String,
     titleGrade: TitleGrade,
@@ -100,7 +100,7 @@ internal fun UserRankItem(
 @Composable
 internal fun MyRankCard(
     modifier: Modifier = Modifier,
-    imageId: String,
+    imageId: String?,
     nickname: String,
     titleName: String,
     titleGrade: TitleGrade,
@@ -186,7 +186,7 @@ private fun DefaultUserRankCard(
 @Composable
 private fun DefaultUserRankContent(
     modifier: Modifier = Modifier,
-    imageId: String,
+    imageId: String?,
     nickname: String,
     titleName: String,
     titleGrade: TitleGrade,

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/AreaRankUiModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/AreaRankUiModel.kt
@@ -1,8 +1,29 @@
 package com.ilsangtech.ilsang.feature.ranking.model
 
+import com.ilsangtech.ilsang.core.model.rank.CommercialAreaRank
+import com.ilsangtech.ilsang.core.model.rank.MetroAreaRank
+
 data class AreaRankUiModel(
     val areaName: String,
     val rank: Int,
     val point: Int,
     val images: List<String>
 )
+
+internal fun MetroAreaRank.toAreaRankUiModel(): AreaRankUiModel {
+    return AreaRankUiModel(
+        areaName = areaName,
+        rank = 0, //TODO 수정 필요
+        point = point,
+        images = images
+    )
+}
+
+internal fun CommercialAreaRank.toAreaRankUiModel(): AreaRankUiModel {
+    return AreaRankUiModel(
+        areaName = areaName,
+        rank = 0, //TODO 수정 필요
+        point = point,
+        images = images
+    )
+}

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/AreaRankUiModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/AreaRankUiModel.kt
@@ -4,6 +4,7 @@ import com.ilsangtech.ilsang.core.model.rank.CommercialAreaRank
 import com.ilsangtech.ilsang.core.model.rank.MetroAreaRank
 
 data class AreaRankUiModel(
+    val areaCode: String,
     val areaName: String,
     val rank: Int,
     val point: Int,
@@ -12,6 +13,7 @@ data class AreaRankUiModel(
 
 internal fun MetroAreaRank.toAreaRankUiModel(): AreaRankUiModel {
     return AreaRankUiModel(
+        areaCode = metroAreaCode,
         areaName = areaName,
         rank = 0, //TODO 수정 필요
         point = point,
@@ -21,6 +23,7 @@ internal fun MetroAreaRank.toAreaRankUiModel(): AreaRankUiModel {
 
 internal fun CommercialAreaRank.toAreaRankUiModel(): AreaRankUiModel {
     return AreaRankUiModel(
+        areaCode = commercialAreaCode,
         areaName = areaName,
         rank = 0, //TODO 수정 필요
         point = point,

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/RankingDetailUiState.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/RankingDetailUiState.kt
@@ -1,0 +1,13 @@
+package com.ilsangtech.ilsang.feature.ranking.model
+
+sealed interface RankingDetailUiState {
+    data object Loading : RankingDetailUiState
+    data class Success(
+        val currentSeason: SeasonUiModel.Season,
+        val areaRankUiModel: AreaRankUiModel,
+        val myRankUiModel: UserRankUiModel,
+        val userRankList: List<UserRankUiModel>
+    ) : RankingDetailUiState
+
+    data object Error : RankingDetailUiState
+}

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/RankingTabUiState.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/RankingTabUiState.kt
@@ -1,0 +1,12 @@
+package com.ilsangtech.ilsang.feature.ranking.model
+
+sealed interface RankingTabUiState {
+    data object Loading : RankingTabUiState
+    data class Success(
+        val metroRankAreas: List<AreaRankUiModel>,
+        val commercialRankAreas: List<AreaRankUiModel>,
+        val contributionRankUsers: List<UserRankUiModel>
+    ) : RankingTabUiState
+
+    data object Error : RankingTabUiState
+}

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/SeasonUiModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/SeasonUiModel.kt
@@ -1,5 +1,7 @@
 package com.ilsangtech.ilsang.feature.ranking.model
 
+import com.ilsangtech.ilsang.core.model.season.Season
+
 sealed interface SeasonUiModel {
     data object Total : SeasonUiModel {
         override fun toString(): String {
@@ -17,4 +19,13 @@ sealed interface SeasonUiModel {
             return "시즌 $seasonNumber"
         }
     }
+}
+
+internal fun Season.toSeasonUiModel(): SeasonUiModel.Season {
+    return SeasonUiModel.Season(
+        seasonId = id,
+        seasonNumber = seasonNumber,
+        startDate = startDate,
+        endDate = endDate
+    )
 }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/SeasonUiModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/SeasonUiModel.kt
@@ -8,6 +8,7 @@ sealed interface SeasonUiModel {
     }
 
     data class Season(
+        val seasonId: Int,
         val seasonNumber: Int,
         val startDate: String,
         val endDate: String

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/UserRankUiModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/UserRankUiModel.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.feature.ranking.model
 
+import com.ilsangtech.ilsang.core.model.rank.UserRank
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 
 data class UserRankUiModel(
@@ -11,3 +12,15 @@ data class UserRankUiModel(
     val titleName: String,
     val titleGrade: TitleGrade
 )
+
+internal fun UserRank.toUserRankUiModel(): UserRankUiModel {
+    return UserRankUiModel(
+        userId = userId,
+        profileImageId = profileImageId,
+        nickname = nickName,
+        point = point,
+        rank = rank,
+        titleName = title.name,
+        titleGrade = title.grade
+    )
+}

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/UserRankUiModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/UserRankUiModel.kt
@@ -5,7 +5,7 @@ import com.ilsangtech.ilsang.core.model.title.TitleGrade
 
 data class UserRankUiModel(
     val userId: String,
-    val profileImageId: String,
+    val profileImageId: String?,
     val nickname: String,
     val point: Int,
     val rank: Int,

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/navigation/RankingNavigation.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/navigation/RankingNavigation.kt
@@ -3,6 +3,7 @@ package com.ilsangtech.ilsang.feature.ranking.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.ilsangtech.ilsang.feature.ranking.RankingDetailScreen
 import com.ilsangtech.ilsang.feature.ranking.RankingTabScreen
 import kotlinx.serialization.Serializable
 
@@ -24,13 +25,16 @@ data class RankingDetailRoute(
 )
 
 fun NavGraphBuilder.rankingNavigation(
-    navigateToProfile: (String) -> Unit
+    navigateToRankingDetail: (RankingDetailRoute) -> Unit,
+    onBackButtonClick: () -> Unit
 ) {
-    navigation<RankingBaseRoute>(
-        startDestination = RankingRoute
-    ) {
+    navigation<RankingBaseRoute>(startDestination = RankingRoute) {
         composable<RankingRoute> {
-            RankingTabScreen(navigateToProfile = navigateToProfile)
+            RankingTabScreen(navigateToRankingDetail = navigateToRankingDetail)
+        }
+
+        composable<RankingDetailRoute> {
+            RankingDetailScreen(onBackButtonClick = onBackButtonClick)
         }
     }
 }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/navigation/RankingNavigation.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/navigation/RankingNavigation.kt
@@ -12,6 +12,17 @@ data object RankingBaseRoute
 @Serializable
 data object RankingRoute
 
+@Serializable
+data class RankingDetailRoute(
+    val seasonId: Int?,
+    val isMetro: Boolean,
+    val areaCode: String,
+    val areaName: String,
+    val rank: Int,
+    val point: Int,
+    val images: List<String>
+)
+
 fun NavGraphBuilder.rankingNavigation(
     navigateToProfile: (String) -> Unit
 ) {


### PR DESCRIPTION
이슈 번호: resolves #93 
작업 사항:

- 랭킹과 관련된 API 연동
- 랭킹 탭 화면, 랭킹 상세 뷰모델 클래스 변경
- 뷰모델에서 관리하는 상태로 랭킹 탭, 랭킹 상세 화면 UI 적용

특이사항: 추가적으로 버그 발생 시 개선 필요

UI 화면: 없음