### PR TITLE
[Feat] 칭호 획득 다이얼로그 UI 구현

### DIFF
--- a/core/designsystem/src/main/res/drawable/icon_title_obtainment.xml
+++ b/core/designsystem/src/main/res/drawable/icon_title_obtainment.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="33dp"
+    android:height="36dp"
+    android:viewportWidth="33"
+    android:viewportHeight="36">
+    <path
+        android:pathData="M6.875,29.899C6.031,30.304 5.151,29.413 5.552,28.559L17.226,3.641C17.52,3.012 18.341,2.869 18.826,3.361L31.767,16.461C32.253,16.952 32.111,17.783 31.49,18.081L6.875,29.899Z"
+        android:fillColor="#7C25EB" />
+    <group>
+        <clip-path android:pathData="M6.875,29.899C6.031,30.304 5.151,29.413 5.552,28.559L17.226,3.641C17.52,3.012 18.341,2.869 18.826,3.361L31.767,16.461C32.253,16.952 32.111,17.783 31.49,18.081L6.875,29.899Z" />
+        <path
+            android:pathData="M14.015,6.438l1.896,-1.919l15.688,15.881l-1.896,1.919z"
+            android:fillColor="#FFF152" />
+        <path
+            android:pathData="M9.664,10.148l1.896,-1.919l15.688,15.881l-1.896,1.919z"
+            android:fillColor="#FFF152" />
+        <path
+            android:pathData="M3.857,12.5l1.896,-1.919l15.688,15.881l-1.896,1.919z"
+            android:fillColor="#FFF152" />
+        <path
+            android:pathData="M-2.667,13.833l1.896,-1.919l15.688,15.881l-1.896,1.919z"
+            android:fillColor="#FFF152" />
+    </group>
+    <path
+        android:pathData="M25.341,0L25.834,1.265L27.083,1.763L25.834,2.262L25.341,3.527L24.849,2.262L23.6,1.763L24.849,1.265L25.341,0Z"
+        android:fillColor="#FFA6A6" />
+    <path
+        android:pathData="M29.987,8.229L30.48,9.494L31.729,9.993L30.48,10.492L29.987,11.756L29.494,10.492L28.245,9.993L29.494,9.494L29.987,8.229Z"
+        android:fillColor="#FFA6A6" />
+    <path
+        android:pathData="M30.567,2.351a1.161,1.176 0,1 0,2.323 0a1.161,1.176 0,1 0,-2.323 0z"
+        android:fillColor="#FF6A00" />
+    <path
+        android:pathData="M24.761,7.054a1.161,1.176 0,1 0,2.323 0a1.161,1.176 0,1 0,-2.323 0z"
+        android:fillColor="#FF6A00" />
+</vector>

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/title/TitleObtainmentDialog.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/title/TitleObtainmentDialog.kt
@@ -1,0 +1,152 @@
+package com.ilsangtech.ilsang.core.ui.title
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.ilsangtech.ilsang.core.model.title.Title
+import com.ilsangtech.ilsang.core.model.title.TitleGrade
+import com.ilsangtech.ilsang.core.model.title.TitleType
+import com.ilsangtech.ilsang.designsystem.R
+import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.designsystem.theme.caption01
+import com.ilsangtech.ilsang.designsystem.theme.gray400
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.primary100
+import com.ilsangtech.ilsang.designsystem.theme.toSp
+
+@Composable
+fun TitleObtainmentDialog(
+    modifier: Modifier = Modifier,
+    title: Title,
+    onDismissRequest: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismissRequest) {
+        Card(
+            modifier = modifier.width(260.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Column(
+                    modifier = Modifier.height(86.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(55.dp)
+                            .clip(CircleShape)
+                            .background(primary100),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            modifier = Modifier.padding(top = 4.dp, end = 7.11.dp),
+                            painter = painterResource(R.drawable.icon_title_obtainment),
+                            contentDescription = "칭호 획득 아이콘",
+                            tint = Color.Unspecified
+                        )
+                    }
+                    Text(
+                        text = "칭호를 획득했어요!",
+                        style = TextStyle(
+                            fontFamily = pretendardFontFamily,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 17.dp.toSp(),
+                            lineHeight = 18.dp.toSp(),
+                            color = gray500
+                        )
+                    )
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(background)
+                        .padding(vertical = 8.dp, horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TitleGradeIcon(
+                        modifier = Modifier.size(24.dp),
+                        titleGrade = title.grade
+                    )
+                    Text(
+                        modifier = Modifier.padding(start = 8.dp),
+                        text = title.name,
+                        style = caption01.copy(
+                            fontSize = 13.dp.toSp(),
+                            lineHeight = 20.dp.toSp(),
+                            color = gray400
+                        )
+                    )
+                }
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = primary,
+                        contentColor = Color.White
+                    ),
+                    shape = RoundedCornerShape(12.dp),
+                    contentPadding = PaddingValues(vertical = 16.dp),
+                    onClick = onDismissRequest
+                ) {
+                    Text(
+                        text = "확인",
+                        style = TextStyle(
+                            fontFamily = pretendardFontFamily,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 16.dp.toSp(),
+                            lineHeight = 18.dp.toSp()
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun TitleObtainmentDialogPreview() {
+    val title = Title(
+        name = "강철 육체를 가진 자",
+        grade = TitleGrade.Standard,
+        type = TitleType.Metro
+    )
+    TitleObtainmentDialog(title = title, onDismissRequest = {})
+}


### PR DESCRIPTION
이슈 번호: resolves #117 
작업 사항:
- 칭호 획득 다이얼로그 UI 구현

UI 화면:
<img width="409" height="371" alt="스크린샷 2025-08-26 오후 4 30 24" src="https://github.com/user-attachments/assets/a436f738-69b5-4c59-afd5-af44b1b2b4f4" />
