### PR TITLE
[Feat] 퀘스트탭 화면 임박순 정렬 타입 추가

### DIFF
--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/TypedQuestPagingSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/TypedQuestPagingSource.kt
@@ -10,6 +10,7 @@ class TypedQuestPagingSource(
     private val commercialAreaCode: String,
     private val type: String?,
     private val repeatFrequency: String?,
+    private val orderExpiredDesc: Boolean?,
     private val orderRewardDesc: Boolean?,
     private val favoriteYn: Boolean?,
     private val completeYn: Boolean
@@ -21,6 +22,7 @@ class TypedQuestPagingSource(
                 commercialAreaCode = commercialAreaCode,
                 type = type,
                 repeatFrequency = repeatFrequency,
+                orderExpiredDesc = orderExpiredDesc,
                 orderRewardDesc = orderRewardDesc,
                 favoriteYn = favoriteYn,
                 completeYn = completeYn,

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/datasource/QuestDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/datasource/QuestDataSource.kt
@@ -53,6 +53,7 @@ interface QuestDataSource {
         commercialAreaCode: String,
         type: String? = null,
         repeatFrequency: String? = null,
+        orderExpiredDesc: Boolean? = null,
         orderRewardDesc: Boolean? = null,
         favoriteYn: Boolean? = null,
         completeYn: Boolean = false

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/datasource/QuestDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/datasource/QuestDataSourceImpl.kt
@@ -103,6 +103,7 @@ class QuestDataSourceImpl @Inject constructor(
         commercialAreaCode: String,
         type: String?,
         repeatFrequency: String?,
+        orderExpiredDesc: Boolean?,
         orderRewardDesc: Boolean?,
         favoriteYn: Boolean?,
         completeYn: Boolean
@@ -115,6 +116,7 @@ class QuestDataSourceImpl @Inject constructor(
                     commercialAreaCode = commercialAreaCode,
                     type = type,
                     repeatFrequency = repeatFrequency,
+                    orderExpiredDesc = orderExpiredDesc,
                     orderRewardDesc = orderRewardDesc,
                     favoriteYn = favoriteYn,
                     completeYn = completeYn

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/repository/QuestRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/repository/QuestRepositoryImpl.kt
@@ -76,6 +76,7 @@ class QuestRepositoryImpl(
     override fun getTypedQuests(
         commercialAreaCode: String,
         questType: NewQuestType?,
+        orderExpiredDesc: Boolean?,
         orderRewardDesc: Boolean?,
         favoriteYn: Boolean?,
         completeYn: Boolean
@@ -95,6 +96,7 @@ class QuestRepositoryImpl(
             commercialAreaCode = commercialAreaCode,
             type = type,
             repeatFrequency = repeatFrequency,
+            orderExpiredDesc = orderExpiredDesc,
             orderRewardDesc = orderRewardDesc,
             favoriteYn = favoriteYn,
             completeYn = completeYn

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/QuestRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/QuestRepository.kt
@@ -28,6 +28,7 @@ interface QuestRepository {
     fun getTypedQuests(
         commercialAreaCode: String,
         questType: NewQuestType? = null,
+        orderExpiredDesc: Boolean? = null,
         orderRewardDesc: Boolean? = null,
         favoriteYn: Boolean? = null,
         completeYn: Boolean = false

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/QuestApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/QuestApiService.kt
@@ -49,6 +49,7 @@ interface QuestApiService {
         @Query("commercialAreaCode") commercialAreaCode: String,
         @Query("questType") type: String? = null,
         @Query("repeatFrequency") repeatFrequency: String? = null,
+        @Query("orderExpiredDesc") orderExpiredDesc: Boolean? = null,
         @Query("orderRewardDesc") orderRewardDesc: Boolean? = null,
         @Query("favoriteYn") favoriteYn: Boolean? = null,
         @Query("completeYn") completeYn: Boolean = false,

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/QuestDetailResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/QuestDetailResponse.kt
@@ -12,7 +12,7 @@ data class QuestDetailResponse(
     val mainImageId: String,
     val missions: List<MissionNetworkModel>,
     val questType: String,
-    val repeatFrequency: String,
+    val repeatFrequency: String?,
     val rewards: List<RewardPointNetworkModel>,
     val title: String,
     val userRank: Int?,

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabViewModel.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabViewModel.kt
@@ -2,13 +2,12 @@ package com.ilsangtech.ilsang.feature.quest
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.ilsangtech.ilsang.core.domain.AreaRepository
 import com.ilsangtech.ilsang.core.domain.QuestRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
 import com.ilsangtech.ilsang.core.model.NewQuestType
-import com.ilsangtech.ilsang.core.model.quest.TypedQuest
+import com.ilsangtech.ilsang.feature.quest.model.QuestFilterCondition
 import com.ilsangtech.ilsang.feature.quest.model.QuestTabUiModel
 import com.ilsangtech.ilsang.feature.quest.model.RepeatQuestTypeUiModel
 import com.ilsangtech.ilsang.feature.quest.model.SortTypeUiModel
@@ -98,19 +97,23 @@ class QuestTabViewModel @Inject constructor(
             SortTypeUiModel.PointAsc -> false
             else -> null
         }
+        val orderExpiredDesc = if (sortType == SortTypeUiModel.ExpireDate) true else null
         val completeYn = questTab == QuestTabUiModel.COMPLETED
 
-        areaCode to Triple(questType, orderRewardDesc, completeYn)
-    }.onStart {
-        PagingData.from(emptyList<TypedQuest>())
-    }.flatMapLatest {
-        val (areaCode, typedQuestsCondition) = it
-        val (questType, orderRewardDesc, completeYn) = typedQuestsCondition
-        questRepository.getTypedQuests(
-            commercialAreaCode = areaCode,
+        QuestFilterCondition(
+            areaCode = areaCode,
             questType = questType,
+            orderExpiredDesc = orderExpiredDesc,
             orderRewardDesc = orderRewardDesc,
-            completeYn = completeYn
+            completeYn = completeYn,
+        )
+    }.flatMapLatest { questFilterCondition ->
+        questRepository.getTypedQuests(
+            commercialAreaCode = questFilterCondition.areaCode,
+            questType = questFilterCondition.questType,
+            orderExpiredDesc = questFilterCondition.orderExpiredDesc,
+            orderRewardDesc = questFilterCondition.orderRewardDesc,
+            completeYn = questFilterCondition.completeYn
         )
     }.cachedIn(viewModelScope)
 

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/component/SortTypeMenuContent.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/component/SortTypeMenuContent.kt
@@ -64,6 +64,7 @@ internal fun SortTypeMenuContent(
         }
         Spacer(Modifier.width(8.dp))
         QuestSortTypeMenu(
+            questTab = questTab,
             selectedSortType = selectedSortType,
             onSelectSortType = onSelectSortType
         )
@@ -85,12 +86,19 @@ private fun RepeatQuestSortTypeMenu(
 
 @Composable
 private fun QuestSortTypeMenu(
+    questTab: QuestTabUiModel,
     selectedSortType: SortTypeUiModel,
     onSelectSortType: (SortTypeUiModel) -> Unit
 ) {
     QuestFilterDropDownMenu(
         width = 150.dp,
-        typeList = SortTypeUiModel.entries,
+        typeList = if (questTab != QuestTabUiModel.EVENT) {
+            SortTypeUiModel.entries.filterNot { type ->
+                type == SortTypeUiModel.ExpireDate
+            }
+        } else {
+            SortTypeUiModel.entries
+        },
         selectedType = selectedSortType,
         onTypeSelected = onSelectSortType
     )

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/model/QuestFilterCondition.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/model/QuestFilterCondition.kt
@@ -1,0 +1,11 @@
+package com.ilsangtech.ilsang.feature.quest.model
+
+import com.ilsangtech.ilsang.core.model.NewQuestType
+
+data class QuestFilterCondition(
+    val areaCode: String,
+    val questType: NewQuestType?,
+    val orderExpiredDesc: Boolean?,
+    val orderRewardDesc: Boolean?,
+    val completeYn: Boolean
+)

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/model/SortTypeUiModel.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/model/SortTypeUiModel.kt
@@ -9,5 +9,8 @@ enum class SortTypeUiModel {
     },
     PointAsc {
         override fun toString(): String = "포인트 낮은순"
+    },
+    ExpireDate {
+        override fun toString(): String = "임박순"
     }
 }


### PR DESCRIPTION
이슈 번호: resolves #116 
작업 사항:
- 유형별 퀘스트 조회 함수 파라미터에 임박순 정렬 타입 추가
- 임박순 정렬 타입 UI 추가

UI 화면:
<img width="392" height="834" alt="스크린샷 2025-08-26 오후 5 43 15" src="https://github.com/user-attachments/assets/6b754791-1b1c-417f-bef7-1595789019df" />
