### PR TITLE
[Fix] 인증 탭 화면의 인증 아이템 날짜 표기 버그 수정

### DIFF
--- a/core/util/src/main/java/com/ilsangtech/ilsang/core/util/DateConverter.kt
+++ b/core/util/src/main/java/com/ilsangtech/ilsang/core/util/DateConverter.kt
@@ -38,9 +38,10 @@ object DateConverter {
 
     fun formatDate(input: String, outputPattern: String = "yyyy.MM.dd"): String {
         return try {
-            val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
+            val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
             val outputFormat = SimpleDateFormat(outputPattern, Locale.getDefault())
-
             val date = inputFormat.parse(input)
             outputFormat.format(date!!)
         } catch (_: Exception) {

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/RandomMissionHistoryUiModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/RandomMissionHistoryUiModel.kt
@@ -22,7 +22,7 @@ internal fun RandomMissionHistory.toUiModel(areaName: String): RandomMissionHist
         commercialAreaName = areaName,
         createdAt = DateConverter.formatDate(
             input = createdAt,
-            outputPattern = "yyyy.MM.dd hh:mm"
+            outputPattern = "yyyy.MM.dd HH:mm"
         ),
         currentUserEmojis = currentUserEmojis,
         hateCount = hateCount,


### PR DESCRIPTION
이슈 번호: resolves #121 
작업 사항:
- 인증 아이템 날짜 표기 버그 수정

UI 화면:
<img width="349" height="575" alt="스크린샷 2025-08-27 오후 2 06 10" src="https://github.com/user-attachments/assets/d6bee8f3-3fb5-4378-b5d1-bce9276565ea" />
