### PR TITLE
[Feat] 사진 인증 예시 API 연동, 기능 구현

### DIFF
--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -197,9 +197,12 @@ fun IlsangNavHost(
                 onBackButtonClick = navController::popBackStack
             )
 
-            approvalNavigation(navigateToProfile = { id ->
-                navController.navigate(ProfileRoute(id))
-            })
+            approvalNavigation(
+                popBackStack = navController::popBackStack,
+                navigateToProfile = { id ->
+                    navController.navigate(ProfileRoute(id))
+                }
+            )
 
             myZoneNavigation(onBackButtonClick = navController::popBackStack)
 

--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -27,6 +27,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.ilsangtech.ilsang.designsystem.component.ILSANGNavigationBar
 import com.ilsangtech.ilsang.designsystem.component.IlsangNavigationBarItem
+import com.ilsangtech.ilsang.feature.approval.navigation.ApprovalExampleRoute
 import com.ilsangtech.ilsang.feature.approval.navigation.approvalNavigation
 import com.ilsangtech.ilsang.feature.banner.navigation.bannerNavigation
 import com.ilsangtech.ilsang.feature.banner.navigation.navigateToBannerDetail
@@ -115,15 +116,21 @@ fun IlsangNavHost(
                 },
                 onIsZoneClick = {
                     navController.navigate(IsZoneBaseRoute)
+                },
+                onMissionImageClick = { missionId ->
+                    navController.navigate(ApprovalExampleRoute(missionId))
                 }
             )
 
             questNavigation(
                 onNavigateToSubmit = { questId ->
-                    navController.navigate(SubmitRoute(questId))
+                    navController.navigate(SubmitRoute("questId"))
                 },
                 onNavigateToMyZone = {
                     navController.navigate(MyZoneBaseRoute)
+                },
+                onMissionImageClick = { missionId ->
+                    navController.navigate(ApprovalExampleRoute(missionId))
                 }
             )
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/ExampleMissionHistoryPagingSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/ExampleMissionHistoryPagingSource.kt
@@ -1,0 +1,41 @@
+package com.ilsangtech.ilsang.core.data.mission
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.ilsangtech.ilsang.core.network.api.MissionApiService
+import com.ilsangtech.ilsang.core.network.model.mission.ExampleMissionHistoryNetworkModel
+
+class ExampleMissionHistoryPagingSource(
+    private val missionId: Int,
+    private val missionApiService: MissionApiService
+) : PagingSource<Int, ExampleMissionHistoryNetworkModel>() {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, ExampleMissionHistoryNetworkModel> {
+        return try {
+            val pageNumber = params.key ?: 0
+
+            val response = missionApiService.getExampleMissionHistory(
+                missionId = missionId,
+                page = pageNumber,
+                size = params.loadSize
+            )
+
+            val prevKey = if (pageNumber == 0) null else pageNumber - 1
+            val nextKey = if (response.isLast) null else pageNumber + 1
+
+            LoadResult.Page(
+                data = response.content,
+                prevKey = prevKey,
+                nextKey = nextKey
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, ExampleMissionHistoryNetworkModel>): Int? {
+        return state.anchorPosition?.let {
+            state.closestPageToPosition(it)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(it)?.nextKey?.minus(1)
+        }
+    }
+}

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/datasource/MissionDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/datasource/MissionDataSource.kt
@@ -1,11 +1,14 @@
 package com.ilsangtech.ilsang.core.data.mission.datasource
 
 import androidx.paging.PagingData
+import com.ilsangtech.ilsang.core.network.model.mission.ExampleMissionHistoryNetworkModel
 import com.ilsangtech.ilsang.core.network.model.mission.RandomMissionHistoryNetworkModel
 import kotlinx.coroutines.flow.Flow
 
 interface MissionDataSource {
     fun getRandomMissionHistory(): Flow<PagingData<RandomMissionHistoryNetworkModel>>
+
+    fun exampleMissionHistory(missionId: Int): Flow<PagingData<ExampleMissionHistoryNetworkModel>>
 
     suspend fun registerMissionHistoryEmoji(missionHistoryId: Int, emojiType: String)
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/datasource/MissionDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/datasource/MissionDataSourceImpl.kt
@@ -3,8 +3,10 @@ package com.ilsangtech.ilsang.core.data.mission.datasource
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import com.ilsangtech.ilsang.core.data.mission.ExampleMissionHistoryPagingSource
 import com.ilsangtech.ilsang.core.data.mission.RandomMissionHistoryPagingSource
 import com.ilsangtech.ilsang.core.network.api.MissionApiService
+import com.ilsangtech.ilsang.core.network.model.mission.ExampleMissionHistoryNetworkModel
 import com.ilsangtech.ilsang.core.network.model.mission.MissionHistoryEmojiRegistrationRequest
 import com.ilsangtech.ilsang.core.network.model.mission.RandomMissionHistoryNetworkModel
 import kotlinx.coroutines.flow.Flow
@@ -17,6 +19,15 @@ class MissionDataSourceImpl(
             config = PagingConfig(pageSize = 10),
             pagingSourceFactory = {
                 RandomMissionHistoryPagingSource(missionApiService)
+            }
+        ).flow
+    }
+
+    override fun exampleMissionHistory(missionId: Int): Flow<PagingData<ExampleMissionHistoryNetworkModel>> {
+        return Pager(
+            config = PagingConfig(pageSize = 10),
+            pagingSourceFactory = {
+                ExampleMissionHistoryPagingSource(missionId, missionApiService)
             }
         ).flow
     }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/mapper/MissionHistoryMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/mapper/MissionHistoryMapper.kt
@@ -1,8 +1,8 @@
 package com.ilsangtech.ilsang.core.data.mission.mapper
 
 import com.ilsangtech.ilsang.core.data.title.mapper.toTitle
+import com.ilsangtech.ilsang.core.model.mission.MissionHistoryUser
 import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistory
-import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistoryUser
 import com.ilsangtech.ilsang.core.network.model.mission.MissionHistoryUserNetworkModel
 import com.ilsangtech.ilsang.core.network.model.mission.RandomMissionHistoryNetworkModel
 
@@ -16,13 +16,13 @@ internal fun RandomMissionHistoryNetworkModel.toRandomMissionHistory(): RandomMi
         missionHistoryId = missionHistoryId,
         submitImageId = submitImageId,
         title = title,
-        user = user.toRandomMissionHistoryUser(),
+        user = user.toMissionHistoryUser(),
         viewCount = viewCount
     )
 }
 
-private fun MissionHistoryUserNetworkModel.toRandomMissionHistoryUser(): RandomMissionHistoryUser {
-    return RandomMissionHistoryUser(
+private fun MissionHistoryUserNetworkModel.toMissionHistoryUser(): MissionHistoryUser {
+    return MissionHistoryUser(
         userId = userId,
         nickname = nickname,
         profileImageId = profileImageId,

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/mapper/MissionHistoryMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/mapper/MissionHistoryMapper.kt
@@ -3,8 +3,8 @@ package com.ilsangtech.ilsang.core.data.mission.mapper
 import com.ilsangtech.ilsang.core.data.title.mapper.toTitle
 import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistory
 import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistoryUser
+import com.ilsangtech.ilsang.core.network.model.mission.MissionHistoryUserNetworkModel
 import com.ilsangtech.ilsang.core.network.model.mission.RandomMissionHistoryNetworkModel
-import com.ilsangtech.ilsang.core.network.model.mission.RandomMissionHistoryUserNetworkModel
 
 internal fun RandomMissionHistoryNetworkModel.toRandomMissionHistory(): RandomMissionHistory {
     return RandomMissionHistory(
@@ -21,7 +21,7 @@ internal fun RandomMissionHistoryNetworkModel.toRandomMissionHistory(): RandomMi
     )
 }
 
-private fun RandomMissionHistoryUserNetworkModel.toRandomMissionHistoryUser(): RandomMissionHistoryUser {
+private fun MissionHistoryUserNetworkModel.toRandomMissionHistoryUser(): RandomMissionHistoryUser {
     return RandomMissionHistoryUser(
         userId = userId,
         nickname = nickname,

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/mapper/MissionHistoryMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/mapper/MissionHistoryMapper.kt
@@ -1,13 +1,30 @@
 package com.ilsangtech.ilsang.core.data.mission.mapper
 
 import com.ilsangtech.ilsang.core.data.title.mapper.toTitle
+import com.ilsangtech.ilsang.core.model.mission.ExampleMissionHistory
 import com.ilsangtech.ilsang.core.model.mission.MissionHistoryUser
 import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistory
+import com.ilsangtech.ilsang.core.network.model.mission.ExampleMissionHistoryNetworkModel
 import com.ilsangtech.ilsang.core.network.model.mission.MissionHistoryUserNetworkModel
 import com.ilsangtech.ilsang.core.network.model.mission.RandomMissionHistoryNetworkModel
 
 internal fun RandomMissionHistoryNetworkModel.toRandomMissionHistory(): RandomMissionHistory {
     return RandomMissionHistory(
+        commercialAreaCode = commercialAreaCode,
+        createdAt = createdAt,
+        currentUserEmojis = currentUserEmojis,
+        hateCount = hateCount,
+        likeCount = likeCount,
+        missionHistoryId = missionHistoryId,
+        submitImageId = submitImageId,
+        title = title,
+        user = user.toMissionHistoryUser(),
+        viewCount = viewCount
+    )
+}
+
+internal fun ExampleMissionHistoryNetworkModel.toExampleMissionHistory(): ExampleMissionHistory {
+    return ExampleMissionHistory(
         commercialAreaCode = commercialAreaCode,
         createdAt = createdAt,
         currentUserEmojis = currentUserEmojis,

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/repository/MissionRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/mission/repository/MissionRepositoryImpl.kt
@@ -3,9 +3,12 @@ package com.ilsangtech.ilsang.core.data.mission.repository
 import androidx.paging.PagingData
 import androidx.paging.map
 import com.ilsangtech.ilsang.core.data.mission.datasource.MissionDataSource
+import com.ilsangtech.ilsang.core.data.mission.mapper.toExampleMissionHistory
 import com.ilsangtech.ilsang.core.data.mission.mapper.toRandomMissionHistory
 import com.ilsangtech.ilsang.core.domain.MissionRepository
+import com.ilsangtech.ilsang.core.model.mission.ExampleMissionHistory
 import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistory
+import com.ilsangtech.ilsang.core.network.model.mission.ExampleMissionHistoryNetworkModel
 import com.ilsangtech.ilsang.core.network.model.mission.RandomMissionHistoryNetworkModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -16,6 +19,12 @@ class MissionRepositoryImpl(
     override fun getRandomMissionHistory(): Flow<PagingData<RandomMissionHistory>> {
         return missionDataSource.getRandomMissionHistory().map { pagingData ->
             pagingData.map(RandomMissionHistoryNetworkModel::toRandomMissionHistory)
+        }
+    }
+
+    override fun getExampleMissionHistory(missionId: Int): Flow<PagingData<ExampleMissionHistory>> {
+        return missionDataSource.exampleMissionHistory(missionId).map { pagingData ->
+            pagingData.map(ExampleMissionHistoryNetworkModel::toExampleMissionHistory)
         }
     }
 

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/MissionRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/MissionRepository.kt
@@ -1,11 +1,14 @@
 package com.ilsangtech.ilsang.core.domain
 
 import androidx.paging.PagingData
+import com.ilsangtech.ilsang.core.model.mission.ExampleMissionHistory
 import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistory
 import kotlinx.coroutines.flow.Flow
 
 interface MissionRepository {
     fun getRandomMissionHistory(): Flow<PagingData<RandomMissionHistory>>
+
+    fun getExampleMissionHistory(missionId: Int): Flow<PagingData<ExampleMissionHistory>>
 
     suspend fun likeMissionHistory(missionHistoryId: Int): Result<Unit>
 

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/mission/ExampleMissionHistory.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/mission/ExampleMissionHistory.kt
@@ -1,0 +1,14 @@
+package com.ilsangtech.ilsang.core.model.mission
+
+data class ExampleMissionHistory(
+    val commercialAreaCode: String,
+    val createdAt: String,
+    val currentUserEmojis: List<String>,
+    val hateCount: Int,
+    val likeCount: Int,
+    val missionHistoryId: Int,
+    val submitImageId: String,
+    val title: String,
+    val user: MissionHistoryUser,
+    val viewCount: Int
+)

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/mission/MissionHistoryUser.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/mission/MissionHistoryUser.kt
@@ -2,7 +2,7 @@ package com.ilsangtech.ilsang.core.model.mission
 
 import com.ilsangtech.ilsang.core.model.title.Title
 
-data class RandomMissionHistoryUser(
+data class MissionHistoryUser(
     val userId: String,
     val nickname: String,
     val profileImageId: String?,

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/mission/RandomMissionHistory.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/mission/RandomMissionHistory.kt
@@ -9,6 +9,6 @@ data class RandomMissionHistory(
     val missionHistoryId: Int,
     val submitImageId: String,
     val title: String,
-    val user: RandomMissionHistoryUser,
+    val user: MissionHistoryUser,
     val viewCount: Int
 )

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/MissionApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/MissionApiService.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.core.network.api
 
+import com.ilsangtech.ilsang.core.network.model.mission.ExampleMissionHistoryResponse
 import com.ilsangtech.ilsang.core.network.model.mission.MissionDetailResponse
 import com.ilsangtech.ilsang.core.network.model.mission.MissionHistoryEmojiRegistrationRequest
 import com.ilsangtech.ilsang.core.network.model.mission.RandomMissionHistoryResponse
@@ -32,6 +33,14 @@ interface MissionApiService {
         @Query("size") size: Int,
         @Query("sort") sort: List<String> = emptyList()
     ): RandomMissionHistoryResponse
+
+    @GET("api/v1/mission/user/history/example")
+    suspend fun getExampleMissionHistory(
+        @Query("missionId") missionId: Int,
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+        @Query("sort") sort: List<String> = emptyList()
+    ): ExampleMissionHistoryResponse
 
     @POST("api/v1/mission/user/history/{missionHistoryId}/view-count")
     suspend fun updateMissionHistoryViewCount(

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/mission/ExampleMissionHistoryNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/mission/ExampleMissionHistoryNetworkModel.kt
@@ -1,0 +1,17 @@
+package com.ilsangtech.ilsang.core.network.model.mission
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ExampleMissionHistoryNetworkModel(
+    val commercialAreaCode: String,
+    val createdAt: String,
+    val currentUserEmojis: List<String>,
+    val hateCount: Int,
+    val likeCount: Int,
+    val missionHistoryId: Int,
+    val submitImageId: String,
+    val title: String,
+    val user: MissionHistoryUserNetworkModel,
+    val viewCount: Int
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/mission/ExampleMissionHistoryResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/mission/ExampleMissionHistoryResponse.kt
@@ -1,0 +1,13 @@
+package com.ilsangtech.ilsang.core.network.model.mission
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ExampleMissionHistoryResponse(
+    val content: List<ExampleMissionHistoryNetworkModel>,
+    val isLast: Boolean,
+    val page: Int,
+    val size: Int,
+    val totalElements: Int,
+    val totalPages: Int
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/mission/MissionHistoryUserNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/mission/MissionHistoryUserNetworkModel.kt
@@ -4,7 +4,7 @@ import com.ilsangtech.ilsang.core.network.model.title.TitleNetworkModel
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class RandomMissionHistoryUserNetworkModel(
+data class MissionHistoryUserNetworkModel(
     val nickname: String,
     val profileImageId: String?,
     val title: TitleNetworkModel?,

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/mission/RandomMissionHistoryNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/mission/RandomMissionHistoryNetworkModel.kt
@@ -12,6 +12,6 @@ data class RandomMissionHistoryNetworkModel(
     val missionHistoryId: Int,
     val submitImageId: String,
     val title: String,
-    val user: RandomMissionHistoryUserNetworkModel,
+    val user: MissionHistoryUserNetworkModel,
     val viewCount: Int
 )

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalExampleScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalExampleScreen.kt
@@ -1,27 +1,58 @@
 package com.ilsangtech.ilsang.feature.approval
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.ilsangtech.ilsang.core.model.mission.MissionHistoryUser
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.feature.approval.component.ApprovalExampleHeader
+import com.ilsangtech.ilsang.feature.approval.component.ApprovalItem
+import com.ilsangtech.ilsang.feature.approval.model.MissionHistoryUiModel
+import kotlinx.coroutines.flow.flowOf
 
 @Composable
 internal fun ApprovalExampleScreen(
-    approvalExampleViewModel: ApprovalExampleViewModel = hiltViewModel(),
+    viewModel: ApprovalExampleViewModel = hiltViewModel(),
     onBackButtonClick: () -> Unit
 ) {
+    val missionHistories = viewModel.exampleMissionHistories.collectAsLazyPagingItems()
+
+    LaunchedEffect(Unit) {
+        viewModel.missionHistoryRefreshTrigger.collect {
+            missionHistories.refresh()
+        }
+    }
     ApprovalExampleScreen(
-        onBackButtonClick = onBackButtonClick
+        onBackButtonClick = onBackButtonClick,
+        missionHistories = missionHistories,
+        onLikeButtonClick = viewModel::likeMissionHistory,
+        onHateButtonClick = viewModel::hateMissionHistory,
+        onReportButtonClick = viewModel::reportMissionHistory,
+        navigateToProfile = {}
     )
 }
 
 @Composable
 private fun ApprovalExampleScreen(
+    missionHistories: LazyPagingItems<MissionHistoryUiModel>,
+    onLikeButtonClick: (MissionHistoryUiModel) -> Unit,
+    onHateButtonClick: (MissionHistoryUiModel) -> Unit,
+    onReportButtonClick: (MissionHistoryUiModel) -> Unit,
+    navigateToProfile: (String) -> Unit,
     onBackButtonClick: () -> Unit
 ) {
     Surface(
@@ -30,6 +61,24 @@ private fun ApprovalExampleScreen(
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             ApprovalExampleHeader(onBackButtonClick = onBackButtonClick)
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(vertical = 48.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                item { Spacer(Modifier.statusBarsPadding()) }
+                items(missionHistories.itemCount) {
+                    missionHistories[it]?.let { missionHistory ->
+                        ApprovalItem(
+                            missionHistory = missionHistory,
+                            onProfileClick = { navigateToProfile(missionHistory.user.userId) },
+                            onLikeButtonClick = { onLikeButtonClick(missionHistory) },
+                            onHateButtonClick = { onHateButtonClick(missionHistory) },
+                            onReportButtonClick = { onReportButtonClick(missionHistory) }
+                        )
+                    }
+                }
+            }
         }
     }
 }
@@ -37,5 +86,36 @@ private fun ApprovalExampleScreen(
 @Preview
 @Composable
 private fun ApprovalExampleScreenPreview() {
-    ApprovalExampleScreen(onBackButtonClick = {})
+    val missionHistories = flowOf(
+        PagingData.from(
+            listOf(
+                MissionHistoryUiModel(
+                    commercialAreaName = "강남",
+                    createdAt = "2023.10.26 10:00",
+                    currentUserEmojis = listOf(""),
+                    hateCount = 0,
+                    likeCount = 0,
+                    missionHistoryId = 0,
+                    submitImageId = "",
+                    title = "강남역에서 사진 찍기",
+                    user = MissionHistoryUser(
+                        userId = "123",
+                        nickname = "홍길동",
+                        profileImageId = null,
+                        title = null
+                    ),
+                    viewCount = 0
+                )
+            )
+        )
+    ).collectAsLazyPagingItems()
+
+    ApprovalExampleScreen(
+        missionHistories = missionHistories,
+        onLikeButtonClick = {},
+        onHateButtonClick = {},
+        onReportButtonClick = {},
+        navigateToProfile = {},
+        onBackButtonClick = {}
+    )
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalExampleScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalExampleScreen.kt
@@ -3,9 +3,7 @@ package com.ilsangtech.ilsang.feature.approval
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -63,10 +61,9 @@ private fun ApprovalExampleScreen(
             ApprovalExampleHeader(onBackButtonClick = onBackButtonClick)
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(vertical = 48.dp),
+                contentPadding = PaddingValues(bottom = 48.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                item { Spacer(Modifier.statusBarsPadding()) }
                 items(missionHistories.itemCount) {
                     missionHistories[it]?.let { missionHistory ->
                         ApprovalItem(

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalExampleViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalExampleViewModel.kt
@@ -1,10 +1,85 @@
 package com.ilsangtech.ilsang.feature.approval
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import androidx.paging.cachedIn
+import androidx.paging.map
+import com.ilsangtech.ilsang.core.domain.AreaRepository
+import com.ilsangtech.ilsang.core.domain.MissionRepository
+import com.ilsangtech.ilsang.feature.approval.model.MissionHistoryUiModel
+import com.ilsangtech.ilsang.feature.approval.model.toUiModel
+import com.ilsangtech.ilsang.feature.approval.navigation.ApprovalExampleRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ApprovalExampleViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    areaRepository: AreaRepository,
+    private val missionRepository: MissionRepository
 ) : ViewModel() {
+    private val missionId = savedStateHandle.toRoute<ApprovalExampleRoute>().missionId
+
+    private val _missionHistoryRefreshTrigger = MutableSharedFlow<Unit>(replay = 1)
+    val missionHistoryRefreshTrigger = _missionHistoryRefreshTrigger.asSharedFlow()
+
+    val exampleMissionHistories = missionRepository.getExampleMissionHistory(missionId)
+        .cachedIn(viewModelScope)
+        .map { pagingData ->
+            pagingData.map { exampleMissionHistory ->
+                val commercialArea =
+                    areaRepository.getCommercialArea(exampleMissionHistory.commercialAreaCode)
+                exampleMissionHistory.toUiModel(commercialArea.areaName)
+            }
+        }
+
+    fun likeMissionHistory(missionHistory: MissionHistoryUiModel) {
+        viewModelScope.launch {
+            val missionHistoryId = missionHistory.missionHistoryId
+            val emojiTypes = missionHistory.currentUserEmojis
+
+            val result = if (!emojiTypes.contains("LIKE")) {
+                missionRepository.likeMissionHistory(missionHistoryId)
+            } else {
+                missionRepository.unlikeMissionHistory(missionHistoryId)
+            }
+
+            result.onSuccess {
+                _missionHistoryRefreshTrigger.emit(Unit)
+            }
+        }
+    }
+
+    fun hateMissionHistory(missionHistory: MissionHistoryUiModel) {
+        viewModelScope.launch {
+            val missionHistoryId = missionHistory.missionHistoryId
+            val emojiTypes = missionHistory.currentUserEmojis
+
+            val result = if (!emojiTypes.contains("HATE")) {
+                missionRepository.hateMissionHistory(missionHistoryId)
+            } else {
+                missionRepository.unhateMissionHistory(missionHistoryId)
+            }
+
+            result.onSuccess {
+                _missionHistoryRefreshTrigger.emit(Unit)
+            }
+        }
+    }
+
+    fun reportMissionHistory(missionHistory: MissionHistoryUiModel) {
+        viewModelScope.launch {
+            runCatching {
+                missionRepository.reportMissionHistory(missionHistory.missionHistoryId)
+            }.onSuccess {
+                _missionHistoryRefreshTrigger.emit(Unit)
+            }
+        }
+    }
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalScreen.kt
@@ -37,7 +37,7 @@ import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.designsystem.theme.heading01
 import com.ilsangtech.ilsang.designsystem.theme.tapRegularTextStyle
 import com.ilsangtech.ilsang.feature.approval.component.ApprovalItem
-import com.ilsangtech.ilsang.feature.approval.model.RandomMissionHistoryUiModel
+import com.ilsangtech.ilsang.feature.approval.model.MissionHistoryUiModel
 import kotlinx.coroutines.flow.flowOf
 
 @Composable
@@ -55,7 +55,7 @@ internal fun ApprovalScreen(
     }
 
     ApprovalScreen(
-        randomMissionHistoryItems = randomMissionHistoryItems,
+        missionHistoryItems = randomMissionHistoryItems,
         onLikeButtonClick = approvalViewModel::likeChallenge,
         onHateButtonClick = approvalViewModel::hateChallenge,
         onReportButtonClick = approvalViewModel::reportMissionHistory,
@@ -65,10 +65,10 @@ internal fun ApprovalScreen(
 
 @Composable
 private fun ApprovalScreen(
-    randomMissionHistoryItems: LazyPagingItems<RandomMissionHistoryUiModel>,
-    onLikeButtonClick: (RandomMissionHistoryUiModel) -> Unit,
-    onHateButtonClick: (RandomMissionHistoryUiModel) -> Unit,
-    onReportButtonClick: (RandomMissionHistoryUiModel) -> Unit,
+    missionHistoryItems: LazyPagingItems<MissionHistoryUiModel>,
+    onLikeButtonClick: (MissionHistoryUiModel) -> Unit,
+    onHateButtonClick: (MissionHistoryUiModel) -> Unit,
+    onReportButtonClick: (MissionHistoryUiModel) -> Unit,
     navigateToProfile: (String) -> Unit
 ) {
     Surface(
@@ -78,8 +78,8 @@ private fun ApprovalScreen(
         color = background
     ) {
         if (
-            randomMissionHistoryItems.loadState.refresh is LoadState.NotLoading &&
-            randomMissionHistoryItems.itemCount == 0
+            missionHistoryItems.loadState.refresh is LoadState.NotLoading &&
+            missionHistoryItems.itemCount == 0
         ) {
             Box(
                 modifier = Modifier.fillMaxSize(),
@@ -115,10 +115,10 @@ private fun ApprovalScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             item { Spacer(Modifier.statusBarsPadding()) }
-            items(randomMissionHistoryItems.itemCount) {
-                randomMissionHistoryItems[it]?.let { randomMissionHistory ->
+            items(missionHistoryItems.itemCount) {
+                missionHistoryItems[it]?.let { randomMissionHistory ->
                     ApprovalItem(
-                        randomMissionHistory = randomMissionHistory,
+                        missionHistory = randomMissionHistory,
                         onProfileClick = { navigateToProfile(randomMissionHistory.user.userId) },
                         onLikeButtonClick = { onLikeButtonClick(randomMissionHistory) },
                         onHateButtonClick = { onHateButtonClick(randomMissionHistory) },
@@ -133,8 +133,8 @@ private fun ApprovalScreen(
 @Preview
 @Composable
 private fun ApprovalScreenPreview() {
-    val randomMissionHistoryItems = listOf(
-        RandomMissionHistoryUiModel(
+    val missionHistoryItems = listOf(
+        MissionHistoryUiModel(
             commercialAreaName = "강남",
             createdAt = "2023.10.27 10:00",
             currentUserEmojis = listOf("LIKE"),
@@ -155,7 +155,7 @@ private fun ApprovalScreenPreview() {
             ),
             viewCount = 100
         ),
-        RandomMissionHistoryUiModel(
+        MissionHistoryUiModel(
             commercialAreaName = "홍대",
             createdAt = "2023.10.28 12:00",
             currentUserEmojis = emptyList(),
@@ -178,11 +178,11 @@ private fun ApprovalScreenPreview() {
         )
     )
     val lazyPagingItems =
-        flowOf(PagingData.from(randomMissionHistoryItems))
+        flowOf(PagingData.from(missionHistoryItems))
             .collectAsLazyPagingItems()
 
     ApprovalScreen(
-        randomMissionHistoryItems = lazyPagingItems,
+        missionHistoryItems = lazyPagingItems,
         onLikeButtonClick = {},
         onHateButtonClick = {},
         onReportButtonClick = {},

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalScreen.kt
@@ -26,7 +26,7 @@ import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
-import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistoryUser
+import com.ilsangtech.ilsang.core.model.mission.MissionHistoryUser
 import com.ilsangtech.ilsang.core.model.title.Title
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.core.model.title.TitleType
@@ -143,7 +143,7 @@ private fun ApprovalScreenPreview() {
             missionHistoryId = 1,
             submitImageId = "sample_image_1",
             title = "강남역 10번 출구에서 사진 찍기",
-            user = RandomMissionHistoryUser(
+            user = MissionHistoryUser(
                 userId = "user1",
                 nickname = "개발자",
                 profileImageId = null,
@@ -164,7 +164,7 @@ private fun ApprovalScreenPreview() {
             missionHistoryId = 2,
             submitImageId = "sample_image_2",
             title = "홍대에서 버스킹 구경하기",
-            user = RandomMissionHistoryUser(
+            user = MissionHistoryUser(
                 userId = "user2",
                 nickname = "디자이너",
                 profileImageId = "profile_image_2",

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalViewModel.kt
@@ -6,7 +6,7 @@ import androidx.paging.cachedIn
 import androidx.paging.map
 import com.ilsangtech.ilsang.core.domain.AreaRepository
 import com.ilsangtech.ilsang.core.domain.MissionRepository
-import com.ilsangtech.ilsang.feature.approval.model.RandomMissionHistoryUiModel
+import com.ilsangtech.ilsang.feature.approval.model.MissionHistoryUiModel
 import com.ilsangtech.ilsang.feature.approval.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -31,7 +31,7 @@ class ApprovalViewModel @Inject constructor(
         }
     }.cachedIn(viewModelScope)
 
-    fun likeChallenge(missionHistory: RandomMissionHistoryUiModel) {
+    fun likeChallenge(missionHistory: MissionHistoryUiModel) {
         viewModelScope.launch {
             val missionHistoryId = missionHistory.missionHistoryId
             val emojiTypes = missionHistory.currentUserEmojis
@@ -48,7 +48,7 @@ class ApprovalViewModel @Inject constructor(
         }
     }
 
-    fun hateChallenge(missionHistory: RandomMissionHistoryUiModel) {
+    fun hateChallenge(missionHistory: MissionHistoryUiModel) {
         viewModelScope.launch {
             val missionHistoryId = missionHistory.missionHistoryId
             val emojiTypes = missionHistory.currentUserEmojis
@@ -65,7 +65,7 @@ class ApprovalViewModel @Inject constructor(
         }
     }
 
-    fun reportMissionHistory(missionHistory: RandomMissionHistoryUiModel) {
+    fun reportMissionHistory(missionHistory: MissionHistoryUiModel) {
         viewModelScope.launch {
             runCatching {
                 missionRepository.reportMissionHistory(missionHistory.missionHistoryId)

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItem.kt
@@ -28,12 +28,12 @@ import com.ilsangtech.ilsang.core.model.mission.MissionHistoryUser
 import com.ilsangtech.ilsang.core.model.title.Title
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.core.model.title.TitleType
-import com.ilsangtech.ilsang.feature.approval.model.RandomMissionHistoryUiModel
+import com.ilsangtech.ilsang.feature.approval.model.MissionHistoryUiModel
 import java.io.File
 
 @Composable
 internal fun ApprovalItem(
-    randomMissionHistory: RandomMissionHistoryUiModel,
+    missionHistory: MissionHistoryUiModel,
     onProfileClick: () -> Unit,
     onLikeButtonClick: () -> Unit,
     onHateButtonClick: () -> Unit,
@@ -107,26 +107,26 @@ internal fun ApprovalItem(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             ApprovalItemUserInfo(
-                userProfileImage = randomMissionHistory.user.profileImageId,
-                userNickname = randomMissionHistory.user.nickname,
-                titleGrade = randomMissionHistory.user.title?.grade,
-                titleName = randomMissionHistory.user.title?.name,
+                userProfileImage = missionHistory.user.profileImageId,
+                userNickname = missionHistory.user.nickname,
+                titleGrade = missionHistory.user.title?.grade,
+                titleName = missionHistory.user.title?.name,
                 onProfileClick = onProfileClick,
                 onShareButtonClick = { isSharing = true },
                 onReportButtonClick = { showReportDialog = true }
             )
             ApprovalItemContent(
-                title = randomMissionHistory.title,
-                challengeImage = randomMissionHistory.submitImageId,
-                createdAt = randomMissionHistory.createdAt,
-                areaName = randomMissionHistory.commercialAreaName,
-                likeCount = randomMissionHistory.likeCount,
-                hateCount = randomMissionHistory.hateCount
+                title = missionHistory.title,
+                challengeImage = missionHistory.submitImageId,
+                createdAt = missionHistory.createdAt,
+                areaName = missionHistory.commercialAreaName,
+                likeCount = missionHistory.likeCount,
+                hateCount = missionHistory.hateCount
             )
             if (!isSharing) {
                 ApprovalFeedbackButtonRow(
-                    isLiked = randomMissionHistory.currentUserEmojis.contains("LIKE"),
-                    isHated = randomMissionHistory.currentUserEmojis.contains("HATE"),
+                    isLiked = missionHistory.currentUserEmojis.contains("LIKE"),
+                    isHated = missionHistory.currentUserEmojis.contains("HATE"),
                     onLikeButtonClick = onLikeButtonClick,
                     onHateButtonClick = onHateButtonClick
                 )
@@ -138,7 +138,7 @@ internal fun ApprovalItem(
 @Preview
 @Composable
 private fun ApprovalItemPreview() {
-    val randomMissionHistory = RandomMissionHistoryUiModel(
+    val missionHistory = MissionHistoryUiModel(
         commercialAreaName = "강남역",
         createdAt = "2023.10.26 10:00",
         currentUserEmojis = listOf("LIKE"),
@@ -160,7 +160,7 @@ private fun ApprovalItemPreview() {
         viewCount = 1000
     )
     ApprovalItem(
-        randomMissionHistory = randomMissionHistory,
+        missionHistory = missionHistory,
         onProfileClick = {},
         onLikeButtonClick = {},
         onHateButtonClick = {},

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItem.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
-import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistoryUser
+import com.ilsangtech.ilsang.core.model.mission.MissionHistoryUser
 import com.ilsangtech.ilsang.core.model.title.Title
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.core.model.title.TitleType
@@ -147,7 +147,7 @@ private fun ApprovalItemPreview() {
         missionHistoryId = 1,
         submitImageId = "sample_image_id",
         title = "강남역에서 가장 맛있는 맛집",
-        user = RandomMissionHistoryUser(
+        user = MissionHistoryUser(
             userId = "user123",
             nickname = "개발자",
             profileImageId = null,

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionHistoryUiModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionHistoryUiModel.kt
@@ -35,3 +35,21 @@ internal fun RandomMissionHistory.toUiModel(areaName: String): MissionHistoryUiM
         viewCount = viewCount
     )
 }
+
+internal fun ExampleMissionHistory.toUiModel(areaName: String): MissionHistoryUiModel {
+    return MissionHistoryUiModel(
+        commercialAreaName = areaName,
+        createdAt = DateConverter.formatDate(
+            input = createdAt,
+            outputPattern = "yyyy.MM.dd HH:mm"
+        ),
+        currentUserEmojis = currentUserEmojis,
+        hateCount = hateCount,
+        likeCount = likeCount,
+        missionHistoryId = missionHistoryId,
+        submitImageId = submitImageId,
+        title = title,
+        user = user,
+        viewCount = viewCount
+    )
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionHistoryUiModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionHistoryUiModel.kt
@@ -1,10 +1,11 @@
 package com.ilsangtech.ilsang.feature.approval.model
 
+import com.ilsangtech.ilsang.core.model.mission.ExampleMissionHistory
 import com.ilsangtech.ilsang.core.model.mission.MissionHistoryUser
 import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistory
 import com.ilsangtech.ilsang.core.util.DateConverter
 
-data class RandomMissionHistoryUiModel(
+data class MissionHistoryUiModel(
     val commercialAreaName: String,
     val createdAt: String,
     val currentUserEmojis: List<String>,
@@ -17,8 +18,8 @@ data class RandomMissionHistoryUiModel(
     val viewCount: Int
 )
 
-internal fun RandomMissionHistory.toUiModel(areaName: String): RandomMissionHistoryUiModel {
-    return RandomMissionHistoryUiModel(
+internal fun RandomMissionHistory.toUiModel(areaName: String): MissionHistoryUiModel {
+    return MissionHistoryUiModel(
         commercialAreaName = areaName,
         createdAt = DateConverter.formatDate(
             input = createdAt,

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/RandomMissionHistoryUiModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/RandomMissionHistoryUiModel.kt
@@ -1,7 +1,7 @@
 package com.ilsangtech.ilsang.feature.approval.model
 
+import com.ilsangtech.ilsang.core.model.mission.MissionHistoryUser
 import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistory
-import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistoryUser
 import com.ilsangtech.ilsang.core.util.DateConverter
 
 data class RandomMissionHistoryUiModel(
@@ -13,7 +13,7 @@ data class RandomMissionHistoryUiModel(
     val missionHistoryId: Int,
     val submitImageId: String,
     val title: String,
-    val user: RandomMissionHistoryUser,
+    val user: MissionHistoryUser,
     val viewCount: Int
 )
 

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
@@ -14,7 +14,7 @@ data object ApprovalBaseRoute
 data object ApprovalRoute
 
 @Serializable
-data object ApprovalExampleRoute
+data class ApprovalExampleRoute(val missionId: Int)
 
 fun NavGraphBuilder.approvalNavigation(
     navigateToProfile: (String) -> Unit
@@ -23,8 +23,8 @@ fun NavGraphBuilder.approvalNavigation(
         composable<ApprovalRoute> {
             ApprovalScreen(navigateToProfile = navigateToProfile)
         }
-        composable<ApprovalExampleRoute> {
-            ApprovalExampleScreen {}
-        }
+    }
+    composable<ApprovalExampleRoute> {
+        ApprovalExampleScreen {}
     }
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
@@ -17,6 +17,7 @@ data object ApprovalRoute
 data class ApprovalExampleRoute(val missionId: Int)
 
 fun NavGraphBuilder.approvalNavigation(
+    popBackStack: () -> Unit,
     navigateToProfile: (String) -> Unit
 ) {
     navigation<ApprovalBaseRoute>(startDestination = ApprovalRoute) {
@@ -25,6 +26,6 @@ fun NavGraphBuilder.approvalNavigation(
         }
     }
     composable<ApprovalExampleRoute> {
-        ApprovalExampleScreen {}
+        ApprovalExampleScreen(onBackButtonClick = popBackStack)
     }
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
@@ -50,6 +50,7 @@ internal fun HomeTabScreen(
     navigateToSubmit: (String) -> Unit,
     navigateToRankingTab: () -> Unit,
     navigateToProfile: (String) -> Unit,
+    onMissionImageClick: (Int) -> Unit,
     onBannerClick: (Banner) -> Unit,
     onMyZoneClick: () -> Unit,
     onIsZoneClick: () -> Unit
@@ -68,9 +69,10 @@ internal fun HomeTabScreen(
         onBannerClick = onBannerClick,
         onMyZoneClick = onMyZoneClick,
         onIsZoneClick = onIsZoneClick,
+        onMissionImageClick = onMissionImageClick,
         onSelectQuest = homeViewModel::selectQuest,
         onUnselectQuest = homeViewModel::unselectQuest,
-        onFavoriteClick = homeViewModel::updateQuestFavoriteStatus
+        onFavoriteClick = homeViewModel::updateQuestFavoriteStatus,
     )
 }
 
@@ -87,6 +89,7 @@ private fun HomeTabScreen(
     onBannerClick: (Banner) -> Unit,
     onMyZoneClick: () -> Unit,
     onIsZoneClick: () -> Unit,
+    onMissionImageClick: (Int) -> Unit,
     onSelectQuest: (Int) -> Unit,
     onUnselectQuest: () -> Unit,
     onFavoriteClick: () -> Unit
@@ -101,7 +104,13 @@ private fun HomeTabScreen(
             onDismiss = onUnselectQuest,
             onFavoriteClick = onFavoriteClick,
             onMissionImageClick = {
-                //TODO 퀘스트 인증 예시 화면으로 이동
+                selectedQuest.missions.firstOrNull()?.let { mission ->
+                    coroutineScope.launch {
+                        bottomSheetState.hide()
+                        onUnselectQuest()
+                        onMissionImageClick(mission.id)
+                    }
+                }
             },
             onApproveButtonClick = {
                 coroutineScope.launch {
@@ -345,6 +354,7 @@ private fun HomeTabScreenPreview() {
         onBannerClick = {},
         onMyZoneClick = {},
         onIsZoneClick = {},
+        onMissionImageClick = {},
         onSelectQuest = {},
         onUnselectQuest = {},
         onFavoriteClick = {}

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/navigation/HomeNavigation.kt
@@ -21,7 +21,8 @@ fun NavGraphBuilder.homeNavigation(
     navigateToSubmit: (String) -> Unit,
     onBannerClick: (Banner) -> Unit,
     onMyZoneClick: () -> Unit,
-    onIsZoneClick: () -> Unit
+    onIsZoneClick: () -> Unit,
+    onMissionImageClick: (Int) -> Unit
 ) {
     navigation<HomeBaseRoute>(startDestination = HomeRoute) {
         composable<HomeRoute> {
@@ -33,7 +34,8 @@ fun NavGraphBuilder.homeNavigation(
                 navigateToProfile = navigateToProfile,
                 onBannerClick = onBannerClick,
                 onMyZoneClick = onMyZoneClick,
-                onIsZoneClick = onIsZoneClick
+                onIsZoneClick = onIsZoneClick,
+                onMissionImageClick = onMissionImageClick
             )
         }
     }

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
@@ -49,7 +49,8 @@ import kotlinx.coroutines.launch
 fun QuestTabScreen(
     questTabViewModel: QuestTabViewModel = hiltViewModel(),
     navigateToSubmit: (Int) -> Unit,
-    navigateToMyZone: () -> Unit
+    navigateToMyZone: () -> Unit,
+    onMissionImageClick: (Int) -> Unit
 ) {
     val selectedQuestType by questTabViewModel.selectedQuestTab.collectAsStateWithLifecycle()
     val selectedRepeatType by questTabViewModel.selectedRepeatType.collectAsStateWithLifecycle()
@@ -82,6 +83,15 @@ fun QuestTabScreen(
         onFavoriteClick = questTabViewModel::updateQuestFavoriteStatus,
         onDismissRequest = questTabViewModel::unselectQuest,
         onMyZoneClick = navigateToMyZone,
+        onMissionImageClick = { missionId ->
+            missionId?.let {
+                coroutineScope.launch {
+                    bottomSheetState.hide()
+                    questTabViewModel.unselectQuest()
+                    onMissionImageClick(it)
+                }
+            }
+        },
         onApproveButtonClick = { questId ->
             coroutineScope.launch {
                 bottomSheetState.hide()
@@ -109,6 +119,7 @@ private fun QuestTabScreen(
     onFavoriteClick: (Int, Boolean) -> Unit,
     onApproveButtonClick: (Int) -> Unit,
     onMyZoneClick: () -> Unit,
+    onMissionImageClick: (Int?) -> Unit,
     onDismissRequest: () -> Unit
 ) {
     if (selectedQuest != null) {
@@ -116,7 +127,9 @@ private fun QuestTabScreen(
             quest = selectedQuest,
             bottomSheetState = bottomSheetState,
             onDismiss = onDismissRequest,
-            onMissionImageClick = {},
+            onMissionImageClick = {
+                onMissionImageClick(selectedQuest.missions.firstOrNull()?.id)
+            },
             onFavoriteClick = { onFavoriteClick(selectedQuest.id, selectedQuest.favoriteYn) },
             onApproveButtonClick = { onApproveButtonClick(selectedQuest.id) }
         )
@@ -220,6 +233,7 @@ private fun QuestTabScreenPreview() {
         onFavoriteClick = { _, _ -> },
         onApproveButtonClick = {},
         onMyZoneClick = {},
+        onMissionImageClick = {},
         onDismissRequest = {}
     )
 }

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/navigation/QuestNavigation.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/navigation/QuestNavigation.kt
@@ -14,13 +14,15 @@ data object QuestRoute
 
 fun NavGraphBuilder.questNavigation(
     onNavigateToSubmit: (Int) -> Unit,
-    onNavigateToMyZone: () -> Unit
+    onNavigateToMyZone: () -> Unit,
+    onMissionImageClick: (Int) -> Unit
 ) {
     navigation<QuestBaseRoute>(startDestination = QuestRoute) {
         composable<QuestRoute> {
             QuestTabScreen(
                 navigateToSubmit = onNavigateToSubmit,
-                navigateToMyZone = onNavigateToMyZone
+                navigateToMyZone = onNavigateToMyZone,
+                onMissionImageClick = onMissionImageClick
             )
         }
     }


### PR DESCRIPTION
이슈 번호: resolves #122 
작업 사항:
- 사진 인증 API 연동
- 인증 예시 화면 UI 적용 및 화면 이동 구현

UI 화면:
<img width="354" height="790" alt="스크린샷 2025-08-27 오후 4 35 00" src="https://github.com/user-attachments/assets/03bf87a2-90ba-47c8-b76c-1ea349dc2981" />
