### PR TITLE
[Fix/#130] 배너 퀘스트 탭 드롭다운 수정 

### DIFF
--- a/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/component/BannerDetailQuestsContent.kt
+++ b/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/component/BannerDetailQuestsContent.kt
@@ -29,7 +29,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.ilsangtech.ilsang.core.model.quest.BannerQuest
 import com.ilsangtech.ilsang.core.ui.quest.CompletedQuestCard
 import com.ilsangtech.ilsang.core.ui.quest.QuestCardWithArrow
-import com.ilsangtech.ilsang.designsystem.component.DropDownMenu
+import com.ilsangtech.ilsang.designsystem.component.BorderedDropDownMenu
 import com.ilsangtech.ilsang.designsystem.theme.gray100
 import com.ilsangtech.ilsang.designsystem.theme.gray300
 import com.ilsangtech.ilsang.designsystem.theme.gray500
@@ -109,7 +109,7 @@ internal fun LazyListScope.bannerDetailQuestsContent(
                 text = "특별 퀘스트 모음",
                 style = title02
             )
-            DropDownMenu(
+            BorderedDropDownMenu(
                 list = BannerDetailSortType.entries,
                 selectedItem = selectedSortType,
                 onItemSelected = onSortTypeChanged,


### PR DESCRIPTION
이슈 번호: resolves #130 
작업 사항:
- 배너 퀘스트 탭 메뉴 borderedDropdown 으로 수정

UI 화면: 없음