### PR TITLE
[Feat] 미션 이력 상세 화면 UI 구현

### DIFF
--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -48,8 +48,8 @@ import com.ilsangtech.ilsang.feature.my.navigation.navigateToMyProfileEdit
 import com.ilsangtech.ilsang.feature.my.navigation.navigateToSetting
 import com.ilsangtech.ilsang.feature.myzone.navigation.MyZoneBaseRoute
 import com.ilsangtech.ilsang.feature.myzone.navigation.myZoneNavigation
-import com.ilsangtech.ilsang.feature.profile.navigation.ChallengeRoute
 import com.ilsangtech.ilsang.feature.profile.navigation.ProfileRoute
+import com.ilsangtech.ilsang.feature.profile.navigation.navigateToChallenge
 import com.ilsangtech.ilsang.feature.profile.navigation.profileRoute
 import com.ilsangtech.ilsang.feature.quest.navigation.questNavigation
 import com.ilsangtech.ilsang.feature.ranking.navigation.rankingNavigation
@@ -176,16 +176,7 @@ fun IlsangNavHost(
             )
 
             profileRoute(
-                navigateToChallenge = {
-                    navController.navigate(
-                        ChallengeRoute(
-                            receiptImageId = it.receiptImageId,
-                            questImageId = it.questImage,
-                            likeCount = it.likeCnt,
-                            title = it.missionTitle
-                        )
-                    )
-                },
+                navigateToChallenge = navController::navigateToChallenge,
                 popBackStack = navController::popBackStack
             )
 

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/mission/UserMissionHistoryItem.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/mission/UserMissionHistoryItem.kt
@@ -73,7 +73,10 @@ private fun UserMissionHistoryItemPreview() {
         missionHistoryId = 1,
         title = "겨울 간식 먹기",
         submitImageId = "sample_image_id",
-        createdAt = "2025.10.27"
+        createdAt = "2025.10.27",
+        likeCount = 10,
+        viewCount = 100,
+        questImageId = null
     )
     UserMissionHistoryItem(userMissionHistory = userMissionHistory, onClick = {})
 }

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/mission/model/UserMissionHistoryUiModel.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/mission/model/UserMissionHistoryUiModel.kt
@@ -6,7 +6,10 @@ import com.ilsangtech.ilsang.core.util.DateConverter
 data class UserMissionHistoryUiModel(
     val missionHistoryId: Int,
     val title: String,
+    val questImageId: String?,
     val submitImageId: String,
+    val viewCount: Int,
+    val likeCount: Int,
     val createdAt: String
 )
 
@@ -14,7 +17,10 @@ fun UserMissionHistory.toUiModel(): UserMissionHistoryUiModel {
     return UserMissionHistoryUiModel(
         missionHistoryId = missionHistoryId,
         title = title,
+        questImageId = questImageId,
         submitImageId = submitImageId,
+        viewCount = viewCount,
+        likeCount = likeCount,
         createdAt = DateConverter.formatDate(input = createdAt)
     )
 }

--- a/feature/profile/src/main/java/com/ilsangtech/ilsang/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/com/ilsangtech/ilsang/feature/profile/ProfileScreen.kt
@@ -25,7 +25,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
-import com.ilsangtech.ilsang.core.model.Challenge
 import com.ilsangtech.ilsang.core.ui.mission.model.UserMissionHistoryUiModel
 import com.ilsangtech.ilsang.core.ui.season.model.SeasonUiModel
 import com.ilsangtech.ilsang.designsystem.R
@@ -41,7 +40,7 @@ import com.ilsangtech.ilsang.feature.profile.model.ProfileUiState
 @Composable
 fun ProfileScreen(
     profileViewModel: ProfileViewModel = hiltViewModel(),
-    navigateToChallenge: (Challenge) -> Unit,
+    navigateToChallenge: (UserMissionHistoryUiModel) -> Unit,
     onPopBackStack: () -> Unit
 ) {
     val uiState by profileViewModel.profileUiState.collectAsStateWithLifecycle()
@@ -53,7 +52,7 @@ fun ProfileScreen(
         selectedSeason = selectedSeason,
         userMissionHistories = userMissionHistories,
         onSeasonChanged = profileViewModel::updateSeason,
-        navigateToChallenge = navigateToChallenge,
+        onMissionHistoryClick = navigateToChallenge,
         onBackButtonClick = onPopBackStack
     )
 }
@@ -64,7 +63,7 @@ private fun ProfileScreen(
     selectedSeason: SeasonUiModel,
     userMissionHistories: LazyPagingItems<UserMissionHistoryUiModel>,
     onSeasonChanged: (SeasonUiModel) -> Unit,
-    navigateToChallenge: (Challenge) -> Unit,
+    onMissionHistoryClick: (UserMissionHistoryUiModel) -> Unit,
     onBackButtonClick: () -> Unit
 ) {
     Surface(
@@ -110,7 +109,7 @@ private fun ProfileScreen(
                         item { Spacer(Modifier.height(48.dp)) }
                         userMissionHistoryContent(
                             userMissionHistoryItems = userMissionHistories,
-                            onClick = {}
+                            onClick = onMissionHistoryClick
                         )
                     }
 

--- a/feature/profile/src/main/java/com/ilsangtech/ilsang/feature/profile/navigation/ProfileNavigation.kt
+++ b/feature/profile/src/main/java/com/ilsangtech/ilsang/feature/profile/navigation/ProfileNavigation.kt
@@ -1,10 +1,10 @@
 package com.ilsangtech.ilsang.feature.profile.navigation
 
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.toRoute
-import com.ilsangtech.ilsang.core.model.Challenge
 import com.ilsangtech.ilsang.feature.profile.ChallengeScreen
 import com.ilsangtech.ilsang.feature.profile.ProfileScreen
 import kotlinx.serialization.Serializable
@@ -17,14 +17,28 @@ data class ProfileRoute(val userId: String)
 
 @Serializable
 data class ChallengeRoute(
-    val receiptImageId: String?,
+    val receiptImageId: String,
     val questImageId: String?,
     val likeCount: Int,
     val title: String
 )
 
+fun NavHostController.navigateToChallenge(
+    submitImageId: String,
+    questImageId: String?,
+    likeCount: Int,
+    title: String
+) = navigate(
+    ChallengeRoute(
+        receiptImageId = submitImageId,
+        questImageId = questImageId,
+        likeCount = likeCount,
+        title = title
+    )
+)
+
 fun NavGraphBuilder.profileRoute(
-    navigateToChallenge: (Challenge) -> Unit,
+    navigateToChallenge: (String, String?, Int, String) -> Unit,
     popBackStack: () -> Unit
 ) {
     navigation<ProfileBaseRoute>(
@@ -32,7 +46,14 @@ fun NavGraphBuilder.profileRoute(
     ) {
         composable<ProfileRoute> {
             ProfileScreen(
-                navigateToChallenge = navigateToChallenge,
+                navigateToChallenge = {
+                    navigateToChallenge(
+                        it.submitImageId,
+                        it.questImageId,
+                        it.likeCount,
+                        it.title
+                    )
+                },
                 onPopBackStack = popBackStack
             )
         }


### PR DESCRIPTION
이슈 번호: resolves #137 

작업 사항:
- 변경된 UI 모델을 기반으로 미션 이력(챌린지) 상세 화면으로 이동할 수 있도록 구현

UI 화면: 없음