### PR TITLE
[Feat] 다음 순위를 위해 필요한 포인트 데이터 적용

### DIFF
--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/RankMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/RankMapper.kt
@@ -1,7 +1,9 @@
 package com.ilsangtech.ilsang.core.data.rank.mapper
 
 import com.ilsangtech.ilsang.core.data.title.mapper.toTitle
+import com.ilsangtech.ilsang.core.model.rank.MyAreaRank
 import com.ilsangtech.ilsang.core.model.rank.UserRank
+import com.ilsangtech.ilsang.core.network.model.rank.MyAreaRankNetworkModel
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 
 internal fun UserRankNetworkModel.toUserRank(): UserRank {
@@ -12,5 +14,17 @@ internal fun UserRankNetworkModel.toUserRank(): UserRank {
         profileImageId = profileImageId,
         rank = rank,
         title = title?.toTitle()
+    )
+}
+
+internal fun MyAreaRankNetworkModel.toMyAreaRank(): MyAreaRank {
+    return MyAreaRank(
+        userId = userId,
+        nickName = nickName,
+        point = point,
+        profileImageId = profileImageId,
+        rank = rank,
+        title = title?.toTitle(),
+        pointGap = pointGap
     )
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/UserRanksWithMyRankMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/rank/mapper/UserRanksWithMyRankMapper.kt
@@ -2,27 +2,19 @@ package com.ilsangtech.ilsang.core.data.rank.mapper
 
 import com.ilsangtech.ilsang.core.model.rank.UserRanksWithMyRank
 import com.ilsangtech.ilsang.core.network.model.rank.CommercialTopRankUsersResponse
-import com.ilsangtech.ilsang.core.network.model.rank.ContributionTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.MetroTopRankUsersResponse
 import com.ilsangtech.ilsang.core.network.model.rank.UserRankNetworkModel
 
 internal fun CommercialTopRankUsersResponse.toUserRanksWithMyRank(): UserRanksWithMyRank {
     return UserRanksWithMyRank(
         userRanks = ranks.map(UserRankNetworkModel::toUserRank),
-        myRank = user.toUserRank()
+        myRank = user.toMyAreaRank()
     )
 }
 
 internal fun MetroTopRankUsersResponse.toUserRanksWithMyRank(): UserRanksWithMyRank {
     return UserRanksWithMyRank(
         userRanks = ranks.map(UserRankNetworkModel::toUserRank),
-        myRank = user.toUserRank()
-    )
-}
-
-internal fun ContributionTopRankUsersResponse.toUserRanksWithMyRank(): UserRanksWithMyRank {
-    return UserRanksWithMyRank(
-        userRanks = ranks.map(UserRankNetworkModel::toUserRank),
-        myRank = user.toUserRank()
+        myRank = user.toMyAreaRank()
     )
 }

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/MyAreaRank.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/MyAreaRank.kt
@@ -1,0 +1,13 @@
+package com.ilsangtech.ilsang.core.model.rank
+
+import com.ilsangtech.ilsang.core.model.title.Title
+
+data class MyAreaRank(
+    val userId: String,
+    val nickName: String,
+    val point: Int?,
+    val profileImageId: String?,
+    val rank: Int?,
+    val title: Title?,
+    val pointGap: Int?
+)

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/UserRanksWithMyRank.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/rank/UserRanksWithMyRank.kt
@@ -2,5 +2,5 @@ package com.ilsangtech.ilsang.core.model.rank
 
 data class UserRanksWithMyRank(
     val userRanks: List<UserRank>,
-    val myRank: UserRank
+    val myRank: MyAreaRank
 )

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/CommercialTopRankUsersResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/CommercialTopRankUsersResponse.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CommercialTopRankUsersResponse(
     val ranks: List<UserRankNetworkModel>,
-    val user: UserRankNetworkModel
+    val user: MyAreaRankNetworkModel
 )

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/MetroTopRankUsersResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/MetroTopRankUsersResponse.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MetroTopRankUsersResponse(
     val ranks: List<UserRankNetworkModel>,
-    val user: UserRankNetworkModel
+    val user: MyAreaRankNetworkModel
 )

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/MyAreaRankNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/rank/MyAreaRankNetworkModel.kt
@@ -1,0 +1,15 @@
+package com.ilsangtech.ilsang.core.network.model.rank
+
+import com.ilsangtech.ilsang.core.network.model.title.UserTitleNetworkModel
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MyAreaRankNetworkModel(
+    val userId: String,
+    val nickName: String,
+    val point: Int?,
+    val profileImageId: String?,
+    val rank: Int?,
+    val title: UserTitleNetworkModel?,
+    val pointGap: Int?
+)

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
@@ -31,6 +31,7 @@ import com.ilsangtech.ilsang.feature.ranking.component.RankingDetailHeader
 import com.ilsangtech.ilsang.feature.ranking.component.TimeRemainingCard
 import com.ilsangtech.ilsang.feature.ranking.component.UserRankItem
 import com.ilsangtech.ilsang.feature.ranking.model.AreaRankUiModel
+import com.ilsangtech.ilsang.feature.ranking.model.MyAreaRankUiModel
 import com.ilsangtech.ilsang.feature.ranking.model.RankingDetailUiState
 import com.ilsangtech.ilsang.feature.ranking.model.SeasonUiModel
 import com.ilsangtech.ilsang.feature.ranking.model.UserRankUiModel
@@ -63,7 +64,7 @@ fun RankingDetailScreen(
 private fun RankingDetailScreen(
     currentSeason: SeasonUiModel.Season,
     areaRankUiModel: AreaRankUiModel,
-    myRankUiModel: UserRankUiModel,
+    myRankUiModel: MyAreaRankUiModel,
     userRankList: List<UserRankUiModel>,
     onBackButtonClick: () -> Unit,
     onSeasonFinished: () -> Unit
@@ -108,9 +109,7 @@ private fun RankingDetailScreen(
                             titleGrade = myRankUiModel.titleGrade,
                             point = myRankUiModel.point,
                             rank = myRankUiModel.rank,
-                            requiredPoint = userRankList.find {
-                                it.rank == myRankUiModel.rank?.minus(1)
-                            }?.point?.minus(myRankUiModel.point) ?: 0
+                            requiredPoint = myRankUiModel.pointGap
                         )
                     }
                     item { Spacer(Modifier.height(12.dp)) }
@@ -154,14 +153,15 @@ private fun RankingDetailScreenPreview() {
         images = listOf("image1", "image2", "image3"),
         areaCode = ""
     )
-    val myRankUiModel = UserRankUiModel(
+    val myRankUiModel = MyAreaRankUiModel(
         userId = "1",
         profileImageId = "profile1",
         nickname = "일상유저123닉네임 길어",
         point = 81223840,
         rank = 10,
         titleName = "모두의 시선을 받는 자",
-        titleGrade = TitleGrade.Standard
+        titleGrade = TitleGrade.Standard,
+        pointGap = 1000
     )
     val userRankList = listOf(
         UserRankUiModel(

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailViewModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailViewModel.kt
@@ -11,6 +11,7 @@ import com.ilsangtech.ilsang.core.util.DateConverter
 import com.ilsangtech.ilsang.feature.ranking.model.AreaRankUiModel
 import com.ilsangtech.ilsang.feature.ranking.model.RankingDetailUiState
 import com.ilsangtech.ilsang.feature.ranking.model.SeasonUiModel
+import com.ilsangtech.ilsang.feature.ranking.model.toMyAreaRankUiModel
 import com.ilsangtech.ilsang.feature.ranking.model.toUserRankUiModel
 import com.ilsangtech.ilsang.feature.ranking.navigation.RankingDetailRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -72,7 +73,7 @@ class RankingDetailViewModel @Inject constructor(
                     )
                 ),
                 areaRankUiModel = areaRankUiModel,
-                myRankUiModel = it.myRank.toUserRankUiModel(),
+                myRankUiModel = it.myRank.toMyAreaRankUiModel(),
                 userRankList = it.userRanks.map { userRank -> userRank.toUserRankUiModel() }
             )
         }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/RankingDetailUiState.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/RankingDetailUiState.kt
@@ -5,7 +5,7 @@ sealed interface RankingDetailUiState {
     data class Success(
         val currentSeason: SeasonUiModel.Season,
         val areaRankUiModel: AreaRankUiModel,
-        val myRankUiModel: UserRankUiModel,
+        val myRankUiModel: MyAreaRankUiModel,
         val userRankList: List<UserRankUiModel>
     ) : RankingDetailUiState
 

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/UserRankUiModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/UserRankUiModel.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.feature.ranking.model
 
+import com.ilsangtech.ilsang.core.model.rank.MyAreaRank
 import com.ilsangtech.ilsang.core.model.rank.UserRank
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 
@@ -13,6 +14,17 @@ data class UserRankUiModel(
     val titleGrade: TitleGrade?
 )
 
+data class MyAreaRankUiModel(
+    val userId: String,
+    val profileImageId: String?,
+    val nickname: String,
+    val point: Int,
+    val rank: Int?,
+    val titleName: String?,
+    val titleGrade: TitleGrade?,
+    val pointGap: Int?
+)
+
 internal fun UserRank.toUserRankUiModel(): UserRankUiModel {
     return UserRankUiModel(
         userId = userId,
@@ -22,5 +34,18 @@ internal fun UserRank.toUserRankUiModel(): UserRankUiModel {
         rank = rank,
         titleName = title?.name,
         titleGrade = title?.grade
+    )
+}
+
+internal fun MyAreaRank.toMyAreaRankUiModel(): MyAreaRankUiModel {
+    return MyAreaRankUiModel(
+        userId = userId,
+        profileImageId = profileImageId,
+        nickname = nickName,
+        point = point ?: 0,
+        rank = rank,
+        titleName = title?.name,
+        titleGrade = title?.grade,
+        pointGap = pointGap
     )
 }


### PR DESCRIPTION
이슈 번호: resolves #151 

작업 사항:
- 지역 내 랭킹 정보 API 응답 DTO, 도메인 모델, UI 모델 수정
- 변경된 모델을 UI에 적용

UI 화면: 없음