### PR TITLE
[Feat] 퀘스트 타입에 따른 퀘스트 하단 시트 UI 적용

### DIFF
--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QuestAprrovalExample.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QuestAprrovalExample.kt
@@ -5,8 +5,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -14,51 +15,79 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.ilsangtech.ilsang.core.ui.BuildConfig
+import com.ilsangtech.ilsang.designsystem.theme.badge01TextStyle
 import com.ilsangtech.ilsang.designsystem.theme.badge02TextStyle
 import com.ilsangtech.ilsang.designsystem.theme.gray100
 import com.ilsangtech.ilsang.designsystem.theme.gray300
+import com.ilsangtech.ilsang.designsystem.theme.toSp
 
 @Composable
 internal fun QuestApprovalExample(
     modifier: Modifier = Modifier,
-    imageId: String?,
+    imageIds: List<String?>,
     onImageClick: () -> Unit
 ) {
     Column(
         modifier = modifier
-            .padding(start = 16.dp)
+            .padding(horizontal = 16.dp)
             .padding(vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        QuestBottomSheetTextChip(text = "퀘스트 인증 예시")
-        Surface(
-            modifier = Modifier
-                .size(101.dp)
-                .clip(RoundedCornerShape(12.dp)),
-            onClick = onImageClick
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            if (imageId == null) {
-                Box(
-                    modifier = Modifier.background(gray100),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "아직 퀘스트를\n수행하지 않았어요!",
-                        style = badge02TextStyle,
-                        color = gray300,
-                        textAlign = TextAlign.Center
-                    )
-                }
-            } else {
-                AsyncImage(
-                    model = BuildConfig.IMAGE_URL + imageId,
-                    contentDescription = "퀘스트 인증 예시 이미지",
+            QuestBottomSheetTextChip(text = "퀘스트 인증 예시")
+            if (imageIds.size == 3) {
+                Text(
+                    text = "예시 사진은 실제 유저들의 사진입니다",
+                    style = badge01TextStyle.copy(
+                        fontSize = 11.dp.toSp(),
+                        lineHeight = 12.dp.toSp()
+                    ),
+                    color = gray300
                 )
+            }
+        }
+        Row(
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            imageIds.forEach { imageId ->
+                Surface(
+                    modifier = Modifier
+                        .weight(1f)
+                        .aspectRatio(1f)
+                        .clip(RoundedCornerShape(12.dp)),
+                    onClick = onImageClick
+                ) {
+                    if (imageId == null) {
+                        Box(
+                            modifier = Modifier.background(gray100),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "아직 퀘스트를\n수행하지 않았어요!",
+                                style = badge02TextStyle,
+                                color = gray300,
+                                textAlign = TextAlign.Center
+                            )
+                        }
+                    } else {
+                        AsyncImage(
+                            model = BuildConfig.IMAGE_URL + imageId,
+                            contentScale = ContentScale.Crop,
+                            contentDescription = "퀘스트 인증 예시 이미지",
+                        )
+                    }
+                }
             }
         }
     }
@@ -70,7 +99,7 @@ private fun QuestApprovalExamplePreview() {
     Row {
         QuestApprovalExample(
             modifier = Modifier.weight(1f),
-            imageId = null,
+            imageIds = List(3) { null },
             onImageClick = {}
         )
     }

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ilsangtech.ilsang.core.model.NewQuestType
 import com.ilsangtech.ilsang.core.model.RewardPoint
+import com.ilsangtech.ilsang.core.model.mission.Mission
 import com.ilsangtech.ilsang.core.model.quest.QuestDetail
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_semibold
@@ -119,15 +120,26 @@ private fun QuestBottomSheetContent(
     ) {
         QuestInfoContent(quest = quest)
         Row(modifier = Modifier.fillMaxWidth()) {
-            QuestApprovalExample(
-                modifier = Modifier.weight(1f),
-                imageId = quest.missions.firstOrNull()?.exampleImageIds?.firstOrNull(),
-                onImageClick = onImageClick
-            )
-            MyQuestRank(
-                modifier = Modifier.weight(1f),
-                rank = quest.userRank
-            )
+            if (quest.missions.firstOrNull()?.type == "PHOTO") {
+                val imageIds = if (quest.questType is NewQuestType.Repeat) {
+                    listOf(quest.missions.first().exampleImageIds.firstOrNull())
+                } else {
+                    quest.missions.first().exampleImageIds
+                        .plus(List(3 - quest.missions.first().exampleImageIds.size) { null })
+                }
+
+                QuestApprovalExample(
+                    modifier = Modifier.weight(1f),
+                    imageIds = imageIds,
+                    onImageClick = onImageClick
+                )
+            }
+            if (quest.questType is NewQuestType.Repeat) {
+                MyQuestRank(
+                    modifier = Modifier.weight(1f),
+                    rank = quest.userRank
+                )
+            }
         }
         ObtainablePointContent(rewardPoints = quest.rewards)
     }
@@ -197,8 +209,15 @@ fun QuestBottomSheetPreviewQuestDetail() {
         favoriteYn = true,
         imageId = "imageId",
         mainImageId = "mainImageId",
-        missions = emptyList(),
-        questType = NewQuestType.Repeat.Weekly,
+        missions = listOf(
+            Mission(
+                id = 1,
+                exampleImageIds = listOf("imageId1", "imageId2"),
+                title = "사진 인증 미션",
+                type = "PHOTO"
+            )
+        ),
+        questType = NewQuestType.Normal,
         rewards = listOf(
             RewardPoint.Metro(2),
             RewardPoint.Commercial(5),

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
@@ -105,10 +105,12 @@ private fun HomeTabScreen(
             onFavoriteClick = onFavoriteClick,
             onMissionImageClick = {
                 selectedQuest.missions.firstOrNull()?.let { mission ->
-                    coroutineScope.launch {
-                        bottomSheetState.hide()
-                        onUnselectQuest()
-                        onMissionImageClick(mission.id)
+                    if (mission.exampleImageIds.isNotEmpty()) {
+                        coroutineScope.launch {
+                            bottomSheetState.hide()
+                            onUnselectQuest()
+                            onMissionImageClick(mission.id)
+                        }
                     }
                 }
             },

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
@@ -128,7 +128,10 @@ private fun QuestTabScreen(
             bottomSheetState = bottomSheetState,
             onDismiss = onDismissRequest,
             onMissionImageClick = {
-                onMissionImageClick(selectedQuest.missions.firstOrNull()?.id)
+                val mission = selectedQuest.missions.firstOrNull()
+                if (mission?.exampleImageIds?.isNotEmpty() == true) {
+                    onMissionImageClick(selectedQuest.missions.firstOrNull()?.id)
+                }
             },
             onFavoriteClick = { onFavoriteClick(selectedQuest.id, selectedQuest.favoriteYn) },
             onApproveButtonClick = {


### PR DESCRIPTION
이슈 번호: resolves #125 

작업 사항:
- 퀘스트 타입에 따라 퀘스트 하단 시트 UI를 다르게 적용

UI 화면:
<img width="300" alt="Screenshot_20250902_115102" src="https://github.com/user-attachments/assets/2a452f75-fc68-4b13-9188-943da9edec81" />
