### PR TITLE
[Feat] 랭킹 화면 UI 개선 및 프로필 화면 이동 구현

### DIFF
--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -188,6 +188,9 @@ fun IlsangNavHost(
                 navigateToUserProfile = { userId ->
                     navController.navigate(ProfileRoute(userId))
                 },
+                navigateToQuestTab = {
+                    navController.navigateToTopLevelDestination(BottomTab.Quest)
+                },
                 onBackButtonClick = navController::popBackStack
             )
 

--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -185,6 +185,9 @@ fun IlsangNavHost(
                 navigateToRankingDetail = { rankingDetailRoute ->
                     navController.navigate(rankingDetailRoute)
                 },
+                navigateToUserProfile = { userId ->
+                    navController.navigate(ProfileRoute(userId))
+                },
                 onBackButtonClick = navController::popBackStack
             )
 

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
@@ -1,9 +1,12 @@
 package com.ilsangtech.ilsang.feature.ranking
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -14,15 +17,23 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.designsystem.theme.gray400
+import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.designsystem.theme.heading02
+import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
 import com.ilsangtech.ilsang.feature.ranking.component.BoxWithOverlay
 import com.ilsangtech.ilsang.feature.ranking.component.MyRankCard
 import com.ilsangtech.ilsang.feature.ranking.component.RankingDetailAreaInfoCard
@@ -122,30 +133,68 @@ private fun RankingDetailScreen(
                             color = Color.Black
                         )
                     }
-                    item {
-                        MyRankCard(
-                            imageId = myRankUiModel.profileImageId,
-                            nickname = myRankUiModel.nickname,
-                            titleName = myRankUiModel.titleName,
-                            titleGrade = myRankUiModel.titleGrade,
-                            point = myRankUiModel.point,
-                            rank = myRankUiModel.rank,
-                            requiredPoint = myRankUiModel.pointGap
-                        )
-                    }
-                    item { Spacer(Modifier.height(12.dp)) }
-                    itemsIndexed(userRankList) { index, item ->
-                        UserRankItem(
-                            imageId = item.profileImageId,
-                            nickname = item.nickname,
-                            titleName = item.titleName,
-                            titleGrade = item.titleGrade,
-                            point = item.point,
-                            rank = item.rank,
-                            onClick = { onUserItemClick(item) }
-                        )
-                        if (index != userRankList.lastIndex) {
-                            Spacer(Modifier.height(12.dp))
+                    if (userRankList.isEmpty()) {
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(230.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Column(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                                ) {
+                                    Text(
+                                        text = "퀘스트를 수행한 유저가 없어요",
+                                        style = TextStyle(
+                                            fontFamily = pretendardFontFamily,
+                                            fontWeight = FontWeight.Bold,
+                                            fontSize = 21.sp,
+                                            lineHeight = 1.5.em
+                                        ),
+                                        color = gray500
+                                    )
+                                    Text(
+                                        text = "랭킹에 가장 먼저 이름을 올려보세요!",
+                                        style = TextStyle(
+                                            fontFamily = pretendardFontFamily,
+                                            fontWeight = FontWeight.Medium,
+                                            fontSize = 17.sp,
+                                            lineHeight = 1.5.em
+                                        ),
+                                        color = gray400
+                                    )
+                                }
+                            }
+                        }
+                    } else {
+                        item {
+                            MyRankCard(
+                                imageId = myRankUiModel.profileImageId,
+                                nickname = myRankUiModel.nickname,
+                                titleName = myRankUiModel.titleName,
+                                titleGrade = myRankUiModel.titleGrade,
+                                point = myRankUiModel.point,
+                                rank = myRankUiModel.rank,
+                                requiredPoint = myRankUiModel.pointGap
+                            )
+                        }
+                        item { Spacer(Modifier.height(12.dp)) }
+                        itemsIndexed(userRankList) { index, item ->
+                            UserRankItem(
+                                imageId = item.profileImageId,
+                                nickname = item.nickname,
+                                titleName = item.titleName,
+                                titleGrade = item.titleGrade,
+                                point = item.point,
+                                rank = item.rank,
+                                onClick = { onUserItemClick(item) }
+                            )
+                            if (index != userRankList.lastIndex) {
+                                Spacer(Modifier.height(12.dp))
+                            }
                         }
                     }
                 }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.ilsangtech.ilsang.feature.ranking
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -15,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -25,6 +23,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.designsystem.theme.heading02
+import com.ilsangtech.ilsang.feature.ranking.component.BoxWithOverlay
 import com.ilsangtech.ilsang.feature.ranking.component.MyRankCard
 import com.ilsangtech.ilsang.feature.ranking.component.RankingDetailAreaInfoCard
 import com.ilsangtech.ilsang.feature.ranking.component.RankingDetailHeader
@@ -84,10 +83,27 @@ private fun RankingDetailScreen(
                 .navigationBarsPadding()
         ) {
             RankingDetailHeader(onBackButtonClick = onBackButtonClick)
-            Box(modifier = Modifier.weight(1f)) {
+            BoxWithOverlay(
+                modifier = Modifier.fillMaxSize(),
+                overlay = {
+                    if (endDate != null) {
+                        TimeRemainingCard(
+                            modifier = Modifier
+                                .padding(horizontal = 20.dp)
+                                .padding(bottom = 20.dp),
+                            seasonNumber = currentSeason.seasonNumber,
+                            endDate = endDate,
+                            onSeasonFinished = onSeasonFinished
+                        )
+                    }
+                }
+            ) { paddingValues ->
                 LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(
-                        start = 20.dp, end = 20.dp, bottom = 72.dp
+                        start = 20.dp,
+                        end = 20.dp,
+                        bottom = paddingValues.calculateBottomPadding() + 20.dp
                     )
                 ) {
                     item {
@@ -126,17 +142,6 @@ private fun RankingDetailScreen(
                             Spacer(Modifier.height(12.dp))
                         }
                     }
-                }
-                endDate?.let {
-                    TimeRemainingCard(
-                        modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            .padding(horizontal = 20.dp)
-                            .padding(bottom = 20.dp),
-                        seasonNumber = currentSeason.seasonNumber,
-                        endDate = endDate,
-                        onSeasonFinished = onSeasonFinished
-                    )
                 }
             }
         }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
@@ -137,6 +137,7 @@ private fun RankingDetailScreen(
                             titleGrade = item.titleGrade,
                             point = item.point,
                             rank = item.rank,
+                            onClick = {}
                         )
                         if (index != userRankList.lastIndex) {
                             Spacer(Modifier.height(12.dp))

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
@@ -40,6 +40,7 @@ import java.util.Locale
 @Composable
 fun RankingDetailScreen(
     rankingDetailViewModel: RankingDetailViewModel = hiltViewModel(),
+    navigateToUserProfile: (String) -> Unit,
     onBackButtonClick: () -> Unit
 ) {
     val rankingDetailUiState by
@@ -54,7 +55,10 @@ fun RankingDetailScreen(
             myRankUiModel = rankingDetailUiState.myRankUiModel,
             userRankList = rankingDetailUiState.userRankList,
             onBackButtonClick = onBackButtonClick,
-            onSeasonFinished = rankingDetailViewModel::refreshSeason
+            onSeasonFinished = rankingDetailViewModel::refreshSeason,
+            onUserItemClick = { userRankUiModel ->
+                navigateToUserProfile(userRankUiModel.userId)
+            }
         )
     }
 }
@@ -66,6 +70,7 @@ private fun RankingDetailScreen(
     myRankUiModel: MyAreaRankUiModel,
     userRankList: List<UserRankUiModel>,
     onBackButtonClick: () -> Unit,
+    onUserItemClick: (UserRankUiModel) -> Unit,
     onSeasonFinished: () -> Unit
 ) {
     val endDate = remember(currentSeason) {
@@ -137,7 +142,7 @@ private fun RankingDetailScreen(
                             titleGrade = item.titleGrade,
                             point = item.point,
                             rank = item.rank,
-                            onClick = {}
+                            onClick = { onUserItemClick(item) }
                         )
                         if (index != userRankList.lastIndex) {
                             Spacer(Modifier.height(12.dp))
@@ -200,6 +205,7 @@ private fun RankingDetailScreenPreview() {
         myRankUiModel = myRankUiModel,
         userRankList = userRankList,
         onBackButtonClick = {},
-        onSeasonFinished = {}
+        onSeasonFinished = {},
+        onUserItemClick = {}
     )
 }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -44,6 +43,7 @@ import com.ilsangtech.ilsang.designsystem.R.font.pretendard_bold
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.feature.ranking.component.AreaRankItem
+import com.ilsangtech.ilsang.feature.ranking.component.BoxWithOverlay
 import com.ilsangtech.ilsang.feature.ranking.component.RankingTabBanner
 import com.ilsangtech.ilsang.feature.ranking.component.RewardTabRow
 import com.ilsangtech.ilsang.feature.ranking.component.SeasonSelector
@@ -162,17 +162,27 @@ private fun RankingTabScreen(
                     selectedReward = selectedReward,
                     onRewardSelect = { selectedReward = it }
                 )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                ) {
+                BoxWithOverlay(
+                    modifier = Modifier.fillMaxSize(),
+                    overlay = {
+                        if (endDate != null) {
+                            TimeRemainingCard(
+                                modifier = Modifier
+                                    .padding(horizontal = 20.dp)
+                                    .padding(bottom = 20.dp),
+                                seasonNumber = currentSeason!!.seasonNumber,
+                                endDate = endDate,
+                                onSeasonFinished = onSeasonFinished
+                            )
+                        }
+                    }
+                ) { paddingValues ->
                     LazyColumn(
                         modifier = Modifier
                             .fillMaxSize()
                             .background(background),
                         contentPadding = PaddingValues(
-                            top = 16.dp, bottom = 72.dp,
+                            top = 16.dp, bottom = paddingValues.calculateBottomPadding() + 20.dp,
                             start = 20.dp, end = 20.dp
                         ),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
@@ -216,18 +226,6 @@ private fun RankingTabScreen(
                                 }
                             }
                         }
-                    }
-
-                    endDate?.let {
-                        TimeRemainingCard(
-                            modifier = Modifier
-                                .align(Alignment.BottomCenter)
-                                .padding(horizontal = 20.dp)
-                                .padding(bottom = 20.dp),
-                            seasonNumber = currentSeason!!.seasonNumber,
-                            endDate = endDate,
-                            onSeasonFinished = onSeasonFinished
-                        )
                     }
                 }
             }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
@@ -62,7 +62,8 @@ import java.util.Locale
 fun RankingTabScreen(
     rankingViewModel: RankingTabViewModel = hiltViewModel(),
     navigateToRankingDetail: (RankingDetailRoute) -> Unit,
-    navigateToUserProfile: (String) -> Unit
+    navigateToUserProfile: (String) -> Unit,
+    navigateToQuestTab: () -> Unit
 ) {
     val seasonList by rankingViewModel.seasonList.collectAsStateWithLifecycle()
     val currentSeason by rankingViewModel.currentSeason.collectAsStateWithLifecycle()
@@ -92,6 +93,7 @@ fun RankingTabScreen(
         onUserRankClick = { userRankUiModel ->
             navigateToUserProfile(userRankUiModel.userId)
         },
+        onQuestButtonClick = navigateToQuestTab,
         onSeasonFinished = rankingViewModel::refreshSeason
     )
 }
@@ -106,6 +108,7 @@ private fun RankingTabScreen(
     onSeasonSelected: (SeasonUiModel) -> Unit,
     onAreaClick: (AreaRankUiModel, Boolean) -> Unit,
     onUserRankClick: (UserRankUiModel) -> Unit,
+    onQuestButtonClick: () -> Unit,
     onSeasonFinished: () -> Unit
 ) {
     var selectedReward by remember { mutableStateOf(RewardUiModel.Metro) }
@@ -160,7 +163,7 @@ private fun RankingTabScreen(
                             .padding(horizontal = 20.dp)
                             .padding(bottom = 24.dp),
                         season = currentSeason,
-                        onQuestButtonClick = {}
+                        onQuestButtonClick = onQuestButtonClick
                     )
                 }
                 RewardTabRow(
@@ -373,6 +376,7 @@ private fun RankingTabScreenPreview() {
         onSeasonSelected = {},
         onAreaClick = { _, _ -> },
         onUserRankClick = {},
+        onQuestButtonClick = {},
         onSeasonFinished = {}
     )
 }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
@@ -268,27 +268,27 @@ private fun RankingTabScreenPreview() {
         SeasonUiModel.Season(
             seasonId = 1,
             seasonNumber = 1,
-            startDate = "2023-01-01",
-            endDate = "2023-03-31"
+            startDate = "2023.01.01",
+            endDate = "2023.03.31"
         ),
         SeasonUiModel.Season(
             seasonId = 2,
             seasonNumber = 2,
-            startDate = "2023-04-01",
-            endDate = "2023-06-30"
+            startDate = "2023.04.01",
+            endDate = "2023.06.30"
         )
     )
     val currentSeason = SeasonUiModel.Season(
         seasonId = 2,
         seasonNumber = 2,
-        startDate = "2023-04-01",
-        endDate = "2023-06-30"
+        startDate = "2023.04.01",
+        endDate = "2023.06.30"
     )
     val selectedSeason = SeasonUiModel.Season(
         seasonId = 2,
         seasonNumber = 2,
-        startDate = "2023-04-01",
-        endDate = "2023-06-30"
+        startDate = "2023.04.01",
+        endDate = "2023.06.30"
     )
     val rankingTabUiState = RankingTabUiState.Success(
         metroRankAreas = listOf(

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
@@ -61,7 +61,8 @@ import java.util.Locale
 @Composable
 fun RankingTabScreen(
     rankingViewModel: RankingTabViewModel = hiltViewModel(),
-    navigateToRankingDetail: (RankingDetailRoute) -> Unit
+    navigateToRankingDetail: (RankingDetailRoute) -> Unit,
+    navigateToUserProfile: (String) -> Unit
 ) {
     val seasonList by rankingViewModel.seasonList.collectAsStateWithLifecycle()
     val currentSeason by rankingViewModel.currentSeason.collectAsStateWithLifecycle()
@@ -88,6 +89,9 @@ fun RankingTabScreen(
                 )
             )
         },
+        onUserRankClick = { userRankUiModel ->
+            navigateToUserProfile(userRankUiModel.userId)
+        },
         onSeasonFinished = rankingViewModel::refreshSeason
     )
 }
@@ -101,6 +105,7 @@ private fun RankingTabScreen(
     rankingTabUiState: RankingTabUiState,
     onSeasonSelected: (SeasonUiModel) -> Unit,
     onAreaClick: (AreaRankUiModel, Boolean) -> Unit,
+    onUserRankClick: (UserRankUiModel) -> Unit,
     onSeasonFinished: () -> Unit
 ) {
     var selectedReward by remember { mutableStateOf(RewardUiModel.Metro) }
@@ -220,7 +225,8 @@ private fun RankingTabScreen(
                                             rank = contributionRankUser.rank,
                                             point = contributionRankUser.point,
                                             titleName = contributionRankUser.titleName,
-                                            titleGrade = contributionRankUser.titleGrade
+                                            titleGrade = contributionRankUser.titleGrade,
+                                            onClick = { onUserRankClick(contributionRankUser) }
                                         )
                                     }
                                 }
@@ -366,6 +372,7 @@ private fun RankingTabScreenPreview() {
         rankingTabUiState = rankingTabUiState,
         onSeasonSelected = {},
         onAreaClick = { _, _ -> },
+        onUserRankClick = {},
         onSeasonFinished = {}
     )
 }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/BoxWithOverlay.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/BoxWithOverlay.kt
@@ -1,0 +1,40 @@
+package com.ilsangtech.ilsang.feature.ranking.component
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.SubcomposeLayout
+
+
+@Composable
+internal fun BoxWithOverlay(
+    modifier: Modifier = Modifier,
+    overlay: @Composable () -> Unit,
+    content: @Composable (PaddingValues) -> Unit
+) {
+    SubcomposeLayout(modifier) { constraints ->
+        val overlayMeasurables = subcompose("overlay", overlay)
+        val overlayPlaceables = overlayMeasurables.map {
+            it.measure(constraints.copy(minWidth = 0, minHeight = 0))
+        }
+        val overlayHeight = overlayPlaceables.maxOfOrNull { it.height } ?: 0
+
+        val contentMeasurables = subcompose("content") {
+            content(PaddingValues(bottom = overlayHeight.toDp()))
+        }
+        val contentPlaceables = contentMeasurables.map { it.measure(constraints) }
+
+        val width = constraints.maxWidth
+        val height = constraints.maxHeight
+
+        layout(width, height) {
+            contentPlaceables.forEach { it.placeRelative(0, 0) }
+            overlayPlaceables.forEach {
+                it.placeRelative(
+                    x = (width - it.width) / 2,
+                    y = height - it.height
+                )
+            }
+        }
+    }
+}

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/RankingDetailAreaInfoCard.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/RankingDetailAreaInfoCard.kt
@@ -27,16 +27,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.ilsangtech.ilsang.designsystem.R
 import com.ilsangtech.ilsang.designsystem.theme.caption02
 import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.gray200
 import com.ilsangtech.ilsang.designsystem.theme.gray300
 import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.designsystem.theme.heading01
+import com.ilsangtech.ilsang.designsystem.theme.heading03
 import com.ilsangtech.ilsang.feature.ranking.BuildConfig
 import com.ilsangtech.ilsang.feature.ranking.model.AreaRankUiModel
 import java.util.Locale
@@ -56,21 +60,39 @@ internal fun RankingDetailAreaInfoCard(
         colors = CardDefaults.cardColors(containerColor = Color.White),
         shape = RoundedCornerShape(12.dp)
     ) {
-        HorizontalPager(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(
-                    RoundedCornerShape(
-                        topStart = 12.dp, topEnd = 12.dp
-                    )
-                ),
-            state = pagerState
-        ) { page ->
-            AsyncImage(
-                modifier = Modifier.height(150.dp),
-                model = BuildConfig.IMAGE_URL + areaRankUiModel.images[page],
-                contentDescription = null
-            )
+        if (areaRankUiModel.images.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(150.dp)
+                    .background(gray100),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "아직 사진이\n등록되지 않았어요",
+                    textAlign = TextAlign.Center,
+                    style = heading03,
+                    color = gray200
+                )
+            }
+        } else {
+            HorizontalPager(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(
+                        RoundedCornerShape(
+                            topStart = 12.dp, topEnd = 12.dp
+                        )
+                    ),
+                state = pagerState
+            ) { page ->
+                AsyncImage(
+                    modifier = Modifier.height(150.dp),
+                    model = BuildConfig.IMAGE_URL + areaRankUiModel.images[page],
+                    contentScale = ContentScale.Crop,
+                    contentDescription = null
+                )
+            }
         }
 
         Row(

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/RankingDetailHeader.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/RankingDetailHeader.kt
@@ -33,11 +33,13 @@ internal fun RankingDetailHeader(
             .padding(top = 12.dp, bottom = 11.dp)
     ) {
         Icon(
-            modifier = Modifier.clickable(
-                onClick = onBackButtonClick,
-                interactionSource = null,
-                indication = null
-            ),
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .clickable(
+                    onClick = onBackButtonClick,
+                    interactionSource = null,
+                    indication = null
+                ),
             painter = painterResource(R.drawable.icon_chevron_back),
             tint = gray500,
             contentDescription = "뒤로 가기"

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/UserRankItem.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/UserRankItem.kt
@@ -52,9 +52,13 @@ internal fun UserRankItem(
     titleName: String?,
     titleGrade: TitleGrade?,
     rank: Int?,
-    point: Int
+    point: Int,
+    onClick: () -> Unit
 ) {
-    DefaultUserRankCard(modifier = modifier.fillMaxWidth()) {
+    DefaultUserRankCard(
+        modifier = modifier.fillMaxWidth(),
+        onClick = onClick
+    ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -173,10 +177,12 @@ internal fun MyRankCard(
 @Composable
 private fun DefaultUserRankCard(
     modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Card(
         modifier = modifier,
+        onClick = { onClick?.invoke() },
         colors = CardDefaults.cardColors(containerColor = Color.White),
         shape = RoundedCornerShape(16.dp),
     ) {
@@ -265,7 +271,8 @@ private fun UserRankItemPreview() {
         titleName = titleName,
         titleGrade = titleGrade,
         rank = rank,
-        point = point
+        point = point,
+        onClick = {}
     )
 }
 

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/navigation/RankingNavigation.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/navigation/RankingNavigation.kt
@@ -27,13 +27,15 @@ data class RankingDetailRoute(
 fun NavGraphBuilder.rankingNavigation(
     navigateToRankingDetail: (RankingDetailRoute) -> Unit,
     navigateToUserProfile: (String) -> Unit,
+    navigateToQuestTab: () -> Unit,
     onBackButtonClick: () -> Unit
 ) {
     navigation<RankingBaseRoute>(startDestination = RankingRoute) {
         composable<RankingRoute> {
             RankingTabScreen(
                 navigateToRankingDetail = navigateToRankingDetail,
-                navigateToUserProfile = navigateToUserProfile
+                navigateToUserProfile = navigateToUserProfile,
+                navigateToQuestTab = navigateToQuestTab
             )
         }
 

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/navigation/RankingNavigation.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/navigation/RankingNavigation.kt
@@ -38,7 +38,10 @@ fun NavGraphBuilder.rankingNavigation(
         }
 
         composable<RankingDetailRoute> {
-            RankingDetailScreen(onBackButtonClick = onBackButtonClick)
+            RankingDetailScreen(
+                onBackButtonClick = onBackButtonClick,
+                navigateToUserProfile = navigateToUserProfile
+            )
         }
     }
 }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/navigation/RankingNavigation.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/navigation/RankingNavigation.kt
@@ -26,11 +26,15 @@ data class RankingDetailRoute(
 
 fun NavGraphBuilder.rankingNavigation(
     navigateToRankingDetail: (RankingDetailRoute) -> Unit,
+    navigateToUserProfile: (String) -> Unit,
     onBackButtonClick: () -> Unit
 ) {
     navigation<RankingBaseRoute>(startDestination = RankingRoute) {
         composable<RankingRoute> {
-            RankingTabScreen(navigateToRankingDetail = navigateToRankingDetail)
+            RankingTabScreen(
+                navigateToRankingDetail = navigateToRankingDetail,
+                navigateToUserProfile = navigateToUserProfile
+            )
         }
 
         composable<RankingDetailRoute> {


### PR DESCRIPTION
이슈 번호: resolves #156 

작업 사항:
- 랭킹 지역 이미지, 유저 랭킹 정보가 없을 경우에 나타나는 UI 구현 및 적용
- 타이머 UI로 인해 랭킹 정보 리스트 아이템이 가려지지 않도록 패딩 적용
- 유저 랭킹 정보 아이템 클릭 시 프로필 화면으로 이동하도록 구현
- 랭킹 배너의 퀘스트 버튼 클릭 시 퀘스트 탭으로 이동하도록 구현

UI 화면:
<img width="300" alt="Screenshot_20250902_151325" src="https://github.com/user-attachments/assets/2e67dc39-09cd-4b8c-9a70-c1d4c4d01bf1" /><img width="300" alt="Screenshot_20250902_151345" src="https://github.com/user-attachments/assets/79c75508-7a64-467a-98a2-3f33fa63e4d5" />
