### PR TITLE
[Feat] 퀘스트 탭 데이터가 없을 때 UI 적용

### DIFF
--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -36,6 +37,7 @@ import com.ilsangtech.ilsang.core.ui.quest.QuestCardWithFavorite
 import com.ilsangtech.ilsang.core.ui.quest.bottomsheet.QuestBottomSheet
 import com.ilsangtech.ilsang.core.ui.zone.MyZoneSelector
 import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.feature.quest.component.EmptyQuestContent
 import com.ilsangtech.ilsang.feature.quest.component.QuestTabHeader
 import com.ilsangtech.ilsang.feature.quest.component.SortTypeMenuContent
 import com.ilsangtech.ilsang.feature.quest.model.QuestTabUiModel
@@ -172,6 +174,13 @@ private fun QuestTabScreen(
                     onSelectRepeatType = onSelectRepeatType,
                     onSelectSortType = onSelectSortType
                 )
+
+                if (typedQuests.loadState.refresh is LoadState.NotLoading
+                    && typedQuests.itemCount == 0
+                ) {
+                    EmptyQuestContent(selectedQuestType = selectedQuestTab)
+                }
+
                 LazyColumn(
                     modifier = Modifier
                         .offset(y = 64.dp)

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/component/EmptyQuestContent.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/component/EmptyQuestContent.kt
@@ -1,0 +1,69 @@
+package com.ilsangtech.ilsang.feature.quest.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.designsystem.theme.gray400
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
+import com.ilsangtech.ilsang.feature.quest.model.QuestTabUiModel
+
+@Composable
+fun EmptyQuestContent(
+    modifier: Modifier = Modifier,
+    selectedQuestType: QuestTabUiModel
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            val (headingText, subText) =
+                if (selectedQuestType != QuestTabUiModel.COMPLETED) {
+                    "퀘스트를 모두 완료하셨어요!" to "상상할 수 없는 퀘스트를 준비중이니\n" +
+                            "다음 업데이트를 기대해주세요!"
+                } else {
+                    "완료된 퀘스트가 없어요" to "퀘스트를 수행하러 가볼까요?"
+                }
+
+            Text(
+                text = headingText,
+                textAlign = TextAlign.Center,
+                style = TextStyle(
+                    fontFamily = pretendardFontFamily,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 21.sp,
+                    lineHeight = 1.5.em
+                ),
+                color = gray500
+            )
+            Text(
+                text = subText,
+                textAlign = TextAlign.Center,
+                style = TextStyle(
+                    fontFamily = pretendardFontFamily,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 17.sp,
+                    lineHeight = 1.5.em
+                ),
+                color = gray400
+            )
+        }
+    }
+}


### PR DESCRIPTION
이슈 번호: resolves #158 

작업 사항:
- 퀘스트 데이터가 없을 경우에 보여지는 UI 구현 및 적용

UI 화면:
<img width="300" alt="Screenshot_20250902_154301" src="https://github.com/user-attachments/assets/547e9173-7680-4bb5-81e1-5e575ea6a349" />
