### PR TITLE
[Feat] 일상존이 선택되지 않았을 때 다이얼로그 표시

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":core:ui"))
     implementation(project(":core:network"))
     implementation(project(":core:domain"))
     implementation(project(":core:model"))

--- a/app/src/main/java/com/ilsangtech/ilsang/IlsangApp.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/IlsangApp.kt
@@ -11,7 +11,9 @@ import com.ilsangtech.ilsang.navigation.IlsangNavHost
 fun IlsangApp(
     isLoggedIn: Boolean?,
     shouldShowOnBoarding: Boolean,
+    shouldShowIsZoneDialog: Boolean,
     completeOnBoarding: () -> Unit,
+    shownIsZoneDialog: (Boolean) -> Unit,
     login: () -> Unit
 ) {
     ILSANGTheme {
@@ -23,7 +25,9 @@ fun IlsangApp(
                         shouldShowOnBoarding -> TutorialBaseRoute::class
                         else -> HomeBaseRoute::class
                     },
+                shouldShowIsZoneDialog = shouldShowIsZoneDialog,
                 completeOnBoarding = completeOnBoarding,
+                shownIsZoneDialog = shownIsZoneDialog,
                 login = login
             )
         }

--- a/app/src/main/java/com/ilsangtech/ilsang/MainActivity.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.ilsangtech.ilsang
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -42,10 +43,15 @@ class MainActivity : ComponentActivity() {
         setContent {
             val isLoggedIn by mainActivityViewModel.isLoggedIn.collectAsStateWithLifecycle()
             val shouldShowOnBoarding by mainActivityViewModel.shouldShowOnBoarding.collectAsStateWithLifecycle()
+            val shouldShowIsZoneDialog by mainActivityViewModel.shouldShowIsZoneDialog.collectAsStateWithLifecycle()
+
+            Log.d("shouldShowIsZoneDialog", shouldShowIsZoneDialog.toString())
             IlsangApp(
                 isLoggedIn = isLoggedIn,
                 shouldShowOnBoarding = shouldShowOnBoarding,
+                shouldShowIsZoneDialog = shouldShowIsZoneDialog,
                 completeOnBoarding = mainActivityViewModel::completeOnBoarding,
+                shownIsZoneDialog = { checked -> mainActivityViewModel.shownIsZoneDialog(!checked) },
                 login = {
                     loginWithGoogle(
                         onLoginSuccess = { idToken ->

--- a/app/src/main/java/com/ilsangtech/ilsang/MainActivityViewModel.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/MainActivityViewModel.kt
@@ -7,11 +7,15 @@ import com.ilsangtech.ilsang.core.domain.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -21,16 +25,19 @@ class MainActivityViewModel @Inject constructor(
     private val userRepository: UserRepository
 ) : ViewModel() {
     private val loginTrigger = MutableSharedFlow<Unit>(replay = 1)
+    private val _shouldShowIsZoneDialog = MutableStateFlow(false)
+    val shouldShowIsZoneDialog = _shouldShowIsZoneDialog.asStateFlow()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val isLoggedIn = loginTrigger.flatMapLatest {
-        userRepository.getMyInfo().map { true }
+        userRepository.getMyInfo()
+            .onEach { myInfo ->
+                if (myInfo.isCommercialAreaCode == null && myInfo.showIsZoneDialogAgain) {
+                    _shouldShowIsZoneDialog.update { true }
+                }
+            }
+            .map { true }
             .catch { emit(false) }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
-                initialValue = null
-            )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
@@ -60,6 +67,15 @@ class MainActivityViewModel @Inject constructor(
     fun completeOnBoarding() {
         viewModelScope.launch {
             userRepository.completeOnBoarding()
+        }
+    }
+
+    fun shownIsZoneDialog(showAgain: Boolean) {
+        viewModelScope.launch {
+            if (!showAgain) {
+                userRepository.updateShowIsZoneDialogAgain(false)
+            }
+            _shouldShowIsZoneDialog.update { false }
         }
     }
 }

--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -25,6 +25,7 @@ import androidx.navigation.compose.rememberNavController
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
+import com.ilsangtech.ilsang.core.ui.zone.IsZoneSuggestionDialog
 import com.ilsangtech.ilsang.designsystem.component.ILSANGNavigationBar
 import com.ilsangtech.ilsang.designsystem.component.IlsangNavigationBarItem
 import com.ilsangtech.ilsang.feature.approval.navigation.ApprovalExampleRoute
@@ -57,15 +58,16 @@ import com.ilsangtech.ilsang.feature.quest.navigation.questNavigation
 import com.ilsangtech.ilsang.feature.ranking.navigation.rankingNavigation
 import com.ilsangtech.ilsang.feature.submit.navigation.navigateToSubmit
 import com.ilsangtech.ilsang.feature.submit.navigation.submitNavigation
-import com.ilsangtech.ilsang.feature.tutorial.navigation.TutorialBaseRoute
 import com.ilsangtech.ilsang.feature.tutorial.navigation.tutorialNavigation
 import kotlin.reflect.KClass
 
 @Composable
 fun IlsangNavHost(
     startDestination: KClass<*>,
+    shouldShowIsZoneDialog: Boolean,
     login: () -> Unit,
-    completeOnBoarding: () -> Unit
+    completeOnBoarding: () -> Unit,
+    shownIsZoneDialog: (Boolean) -> Unit
 ) {
     val context = LocalContext.current
     val navController = rememberNavController()
@@ -73,6 +75,17 @@ fun IlsangNavHost(
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = currentBackStackEntry?.destination
     val topLevelDestinations = BottomTab.entries
+
+    if (shouldShowIsZoneDialog
+        && currentBackStackEntry?.destination?.hierarchy?.any {
+            it.hasRoute(HomeBaseRoute::class)
+        } == true
+    ) {
+        IsZoneSuggestionDialog(
+            onConfirm = { navController.navigate(IsZoneBaseRoute) },
+            onDismissRequest = shownIsZoneDialog
+        )
+    }
 
     Scaffold(
         bottomBar = {
@@ -96,9 +109,6 @@ fun IlsangNavHost(
             tutorialNavigation(
                 navigateToHome = {
                     completeOnBoarding()
-                    navController.navigate(HomeBaseRoute) {
-                        popUpTo(TutorialBaseRoute) { inclusive = true }
-                    }
                 }
             )
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/mapper/MyInfoMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/mapper/MyInfoMapper.kt
@@ -6,7 +6,8 @@ import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
 
 fun UserInfoResponse.toMyInfo(
     totalPoint: Int,
-    myZoneCommercialAreaCode: String
+    myZoneCommercialAreaCode: String,
+    showIsZoneDialogAgain: Boolean
 ): MyInfo {
     return MyInfo(
         id = id,
@@ -19,6 +20,7 @@ fun UserInfoResponse.toMyInfo(
         profileImageId = profileImageId,
         status = status,
         statusUpdatedAt = statusUpdatedAt,
-        title = title?.toUserTitle()
+        title = title?.toUserTitle(),
+        showIsZoneDialogAgain = showIsZoneDialogAgain
     )
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -27,13 +27,18 @@ class UserRepositoryImpl @Inject constructor(
     override val shouldShowOnBoarding: Flow<Boolean> = userDataStore.shouldShowOnBoarding
 
     override fun getMyInfo(): Flow<MyInfo> =
-        combine(userDataStore.userMyZone, getUserPoint()) { myZoneCommercialAreaCode, userPoint ->
+        combine(
+            userDataStore.userMyZone,
+            userDataStore.showIsZoneDialogAgain,
+            getUserPoint()
+        ) { myZoneCommercialAreaCode, showIsZoneDialogAgain, userPoint ->
             val userInfoResponse = userDataSource.getUserInfo(userId = null)
             val totalPoint =
                 userPoint.metroAreaPoint + userPoint.commercialAreaPoint + userPoint.contributionPoint
             userInfoResponse.toMyInfo(
                 totalPoint = totalPoint,
-                myZoneCommercialAreaCode = myZoneCommercialAreaCode
+                myZoneCommercialAreaCode = myZoneCommercialAreaCode,
+                showIsZoneDialogAgain = showIsZoneDialogAgain
             )
         }
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -116,4 +116,8 @@ class UserRepositoryImpl @Inject constructor(
             userDataSource.updateUserIsZone(commericalAreaCode)
         }
     }
+
+    override suspend fun updateShowIsZoneDialogAgain(showAgain: Boolean) {
+        return userDataStore.setShowIsZoneDialogAgain(showAgain)
+    }
 }

--- a/core/datastore/src/main/java/com/ilsangtech/ilsang/core/datastore/UserDataStore.kt
+++ b/core/datastore/src/main/java/com/ilsangtech/ilsang/core/datastore/UserDataStore.kt
@@ -19,6 +19,11 @@ class UserDataStore(context: Context) {
         preferences[shouldShowOnBoardingKey] ?: true
     }
 
+    private val showIsZoneDialogAgainKey = booleanPreferencesKey("show_is_zone_dialog_again")
+    val showIsZoneDialogAgain = userDataStore.data.map { preferences ->
+        preferences[showIsZoneDialogAgainKey] ?: true
+    }
+
     private val userMyZoneKey = stringPreferencesKey("user_my_zone")
     val userMyZone = userDataStore.data.map { preferences ->
         preferences[userMyZoneKey] ?: "R100"
@@ -37,6 +42,12 @@ class UserDataStore(context: Context) {
     suspend fun setShouldShowOnBoarding(shouldShow: Boolean) {
         userDataStore.edit { preferences ->
             preferences[shouldShowOnBoardingKey] = shouldShow
+        }
+    }
+
+    suspend fun setShowIsZoneDialogAgain(showAgain: Boolean) {
+        userDataStore.edit { preferences ->
+            preferences[showIsZoneDialogAgainKey] = showAgain
         }
     }
 

--- a/core/designsystem/src/main/java/com/ilsangtech/ilsang/designsystem/component/button.kt
+++ b/core/designsystem/src/main/java/com/ilsangtech/ilsang/designsystem/component/button.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.ilsangtech.ilsang.designsystem.R
+import com.ilsangtech.ilsang.designsystem.theme.toSp
 
 private val ilsangButtonRadius = 12.dp
 
@@ -33,9 +33,9 @@ fun ILSANGButton(
         Text(
             text = text,
             style = TextStyle(
-                fontSize = 14.sp,
-                lineHeight = 24.sp,
-                letterSpacing = 0.sp,
+                fontSize = 14.dp.toSp(),
+                lineHeight = 24.dp.toSp(),
+                letterSpacing = 0.dp.toSp(),
                 fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
             )
         )

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
@@ -36,4 +36,6 @@ interface UserRepository {
     suspend fun updateUserMyZone(commericalAreaCode: String): Result<Unit>
 
     suspend fun updateUserIsZone(commericalAreaCode: String): Result<Unit>
+
+    suspend fun updateShowIsZoneDialogAgain(showAgain: Boolean)
 }

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/MyInfo.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/MyInfo.kt
@@ -13,5 +13,6 @@ data class MyInfo(
     val profileImageId: String?,
     val status: String,
     val statusUpdatedAt: String,
-    val title: UserTitle?
+    val title: UserTitle?,
+    val showIsZoneDialogAgain: Boolean
 )

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/zone/IsZoneSuggestionDialog.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/zone/IsZoneSuggestionDialog.kt
@@ -29,17 +29,16 @@ import com.ilsangtech.ilsang.designsystem.theme.tapRegularTextStyle
 @Composable
 fun IsZoneSuggestionDialog(
     onConfirm: () -> Unit,
-    onCancel: (checked: Boolean) -> Unit,
-    onDismissRequest: () -> Unit
+    onDismissRequest: (checked: Boolean) -> Unit
 ) {
     var checked by remember { mutableStateOf(false) }
 
     ILSANGDialog(
         positiveButtonText = "일상존 선택하기",
         negativeButtonText = "취소",
-        onDismissRequest = onDismissRequest,
+        onDismissRequest = { onDismissRequest(checked) },
         onPositiveButtonClick = onConfirm,
-        onNegativeButtonClick = { onCancel(checked) }
+        onNegativeButtonClick = { onDismissRequest(checked) }
     ) {
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -93,7 +92,6 @@ fun IsZoneSuggestionDialog(
 private fun IsZoneSuggestionDialogPreview() {
     IsZoneSuggestionDialog(
         onConfirm = {},
-        onCancel = {},
         onDismissRequest = {}
     )
 }


### PR DESCRIPTION
이슈 번호: resolves #160 

작업 사항:
- 일상존이 선택되지 않았을 경우에 일상존 선택 다이얼로그 표시
- 일상존 선택 다이얼로그 다시 보지 않기 데이터 로컬로 관리

UI 화면: 없음