### PR TITLE
[Fix] 마이 탭 화면의 경험치 게이지 방향 수정

### DIFF
--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/mytab/component/MyProfileInfoCard.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/mytab/component/MyProfileInfoCard.kt
@@ -352,8 +352,8 @@ private fun DrawScope.drawUserLevelProgress(progress: Float) {
             -this.center.y / 4
         ),
         color = primary500,
-        startAngle = 267f,
-        sweepAngle = -(267f * progress),
+        startAngle = 139f,
+        sweepAngle = 262f * progress,
         useCenter = false,
         style = Stroke(
             width = 9.dp.toPx(),
@@ -368,7 +368,7 @@ private fun MyProfileInfoCardPreview() {
     val myProfileInfo = MyProfileInfoUiModel(
         nickname = "김일상123닉네임 길이가 길어",
         profileImageId = "some_image_id",
-        levelProgress = 0.5f,
+        levelProgress = 1.0f,
         level = 5,
         userTitle = UserTitle(
             titleHistoryId = 1,


### PR DESCRIPTION
이슈 번호: resolves #164 

작업 사항:
- 마이 남은 경험치 게이지 UI 방향 수정

UI 화면: 
<img width="300"  alt="Screenshot_20250902_231031" src="https://github.com/user-attachments/assets/7239034d-aec5-434f-9b74-44f691bd0c99" />
