### PR TITLE
[Feat] 일상존 선택 관련 다이얼로그 적용

### DIFF
--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
@@ -11,7 +11,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -29,6 +32,7 @@ import com.ilsangtech.ilsang.core.model.title.Title
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.core.model.title.TitleType
 import com.ilsangtech.ilsang.core.ui.quest.bottomsheet.QuestBottomSheet
+import com.ilsangtech.ilsang.core.ui.zone.IsZoneSelectDisabledDialog
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.feature.home.component.BannerContent
 import com.ilsangtech.ilsang.feature.home.component.HomeTabHeader
@@ -96,6 +100,11 @@ private fun HomeTabScreen(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var showZoneSelectDisabledDialog by remember { mutableStateOf(false) }
+
+    if (showZoneSelectDisabledDialog) {
+        IsZoneSelectDisabledDialog { showZoneSelectDisabledDialog = false }
+    }
 
     if (selectedQuest != null) {
         QuestBottomSheet(
@@ -143,7 +152,13 @@ private fun HomeTabScreen(
                         isCommercialAreaName = userInfo.isCommericalAreaName,
                         onProfileClick = navigateToMyTab,
                         onMyZoneClick = onMyZoneClick,
-                        onIsZoneClick = onIsZoneClick
+                        onIsZoneClick = {
+                            if (userInfo.isCommericalAreaName != null) {
+                                showZoneSelectDisabledDialog = true
+                            } else {
+                                onIsZoneClick()
+                            }
+                        }
                     )
                 }
                 item {

--- a/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneScreen.kt
+++ b/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneScreen.kt
@@ -14,6 +14,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,6 +32,7 @@ import com.ilsangtech.ilsang.core.model.area.MetroArea
 import com.ilsangtech.ilsang.core.ui.zone.ZoneListContent
 import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
 import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.feature.iszone.component.IsZoneConfirmDialog
 import com.ilsangtech.ilsang.feature.iszone.component.IsZoneFailureDialog
 import com.ilsangtech.ilsang.feature.iszone.component.IsZoneHeader
 import com.ilsangtech.ilsang.feature.iszone.component.IsZoneSuccessDialog
@@ -39,6 +43,18 @@ internal fun IsZoneScreen(
     onBackButtonClick: () -> Unit
 ) {
     val isZoneUiState by isZoneViewModel.isZoneUiState.collectAsStateWithLifecycle()
+    var showConfirmDialog by remember { mutableStateOf(false) }
+
+    if (showConfirmDialog && isZoneUiState.selectedMetroArea != null) {
+        IsZoneConfirmDialog(
+            selectedCommercialArea = isZoneUiState.selectedCommercialArea!!,
+            onConfirm = {
+                isZoneViewModel.selectIsZone()
+                showConfirmDialog = false
+            },
+            onDismissRequest = { showConfirmDialog = false }
+        )
+    }
 
     if (isZoneUiState.isIsZoneUpdateSuccess == true) {
         IsZoneSuccessDialog(onDismissRequest = {
@@ -55,7 +71,7 @@ internal fun IsZoneScreen(
         areaList = isZoneUiState.areaList,
         onMetroAreaClick = isZoneViewModel::updateSelectedMetroArea,
         onCommercialAreaClick = isZoneViewModel::updateSelectedCommercialArea,
-        onSelectButtonClick = isZoneViewModel::selectIsZone,
+        onSelectButtonClick = { showConfirmDialog = true },
         onBackButtonClick = onBackButtonClick
     )
 }


### PR DESCRIPTION
이슈 번호: resolves #183

작업 사항:
- 일상존 선택 시 선택한 일상존 확인 다이얼로그 UI 표시 
- 일상존 선택 완료된 상태에서 일상존 UI 클릭 시 선택 불가 다이얼로그 UI 표시

UI 화면:
<img width="300" height="2340" alt="Screenshot_20250906_181339" src="https://github.com/user-attachments/assets/a004b68c-c010-447d-8985-3235030878ae" />
