### PR TITLE
[Fix] 회원탈퇴 API http 메서드 변경

### DIFF
--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/AuthApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/AuthApiService.kt
@@ -3,7 +3,6 @@ package com.ilsangtech.ilsang.core.network.api
 import com.ilsangtech.ilsang.core.network.model.auth.OAuthLoginRequest
 import com.ilsangtech.ilsang.core.network.model.auth.OAuthLoginResponse
 import retrofit2.http.Body
-import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface AuthApiService {
@@ -15,6 +14,6 @@ interface AuthApiService {
     @POST("api/v1/logout")
     suspend fun logout()
 
-    @GET("api/v1/withdraw")
+    @POST("api/v1/withdraw")
     suspend fun withdraw()
 }


### PR DESCRIPTION
이슈 번호: resolves #181 
작업 사항:
- 회원탈퇴 HTTP 메서드 타입을 POST로 변경

UI 화면: 없음