### PR TITLE
[Fix] 사용자 칭호 DTO 클래스 및 칭호 설정 API 수정

### DIFF
--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSource.kt
@@ -27,7 +27,7 @@ interface UserDataSource {
 
     suspend fun deleteUserImage(): UserImageDeleteResponse
 
-    suspend fun updateUserTitle(titleHistoryId: Int): UserTitleUpdateResponse
+    suspend fun updateUserTitle(titleHistoryId: Int?): UserTitleUpdateResponse
 
     suspend fun updateUserIsZone(commericalAreaCode: String): UserInfoResponse
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/datasource/UserDataSourceImpl.kt
@@ -54,7 +54,7 @@ class UserDataSourceImpl @Inject constructor(
         return userApiService.deleteUserImage()
     }
 
-    override suspend fun updateUserTitle(titleHistoryId: Int): UserTitleUpdateResponse {
+    override suspend fun updateUserTitle(titleHistoryId: Int?): UserTitleUpdateResponse {
         return userApiService.updateUserTitle(UserTitleUpdateRequest(titleHistoryId))
     }
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -99,7 +99,7 @@ class UserRepositoryImpl @Inject constructor(
         userDataStore.setShouldShowOnBoarding(false)
     }
 
-    override suspend fun updateUserTitle(titleHistoryId: Int): Result<Unit> {
+    override suspend fun updateUserTitle(titleHistoryId: Int?): Result<Unit> {
         return runCatching {
             userDataSource.updateUserTitle(titleHistoryId)
         }

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
@@ -31,7 +31,7 @@ interface UserRepository {
 
     suspend fun completeOnBoarding()
 
-    suspend fun updateUserTitle(titleHistoryId: Int): Result<Unit>
+    suspend fun updateUserTitle(titleHistoryId: Int?): Result<Unit>
 
     suspend fun updateUserMyZone(commericalAreaCode: String): Result<Unit>
 

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/title/UserTitleNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/title/UserTitleNetworkModel.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UserTitleNetworkModel(
     val titleHistoryId: Int,
+    val userId: String,
     val name: String,
     val grade: String,
     val type: String

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserTitleUpdateRequest.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/user/UserTitleUpdateRequest.kt
@@ -4,5 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class UserTitleUpdateRequest(
-    val titleHistoryId: Int
+    val titleHistoryId: Int?
 )

--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/MyTitleViewModel.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/MyTitleViewModel.kt
@@ -64,9 +64,9 @@ class MyTitleViewModel @Inject constructor(
     fun updateUserTitle() {
         viewModelScope.launch {
             try {
-                selectedTitle.value?.titleHistoryId?.let {
-                    userRepository.updateUserTitle(it)
-                }
+                userRepository.updateUserTitle(
+                    titleHistoryId = selectedTitle.value?.titleHistoryId
+                )
             } catch (_: Exception) {
             } finally {
                 _isTitleUpdated.update { true }


### PR DESCRIPTION
이슈 번호: resolves #193 
작업 사항:
- 사용자 칭호 DTO에 userId 추가
- 사용자 칭호 업데이트 함수 파라미터를 Nullable로 변경하여 칭호를 제거할 수 있도록 수정

UI 화면: 없음