### PR TITLE
[Feat] 칭호 획득 API 연동

### DIFF
--- a/app/src/main/java/com/ilsangtech/ilsang/IlsangApp.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/IlsangApp.kt
@@ -1,6 +1,7 @@
 package com.ilsangtech.ilsang
 
 import androidx.compose.runtime.Composable
+import com.ilsangtech.ilsang.core.model.title.UserTitle
 import com.ilsangtech.ilsang.designsystem.theme.ILSANGTheme
 import com.ilsangtech.ilsang.feature.home.navigation.HomeBaseRoute
 import com.ilsangtech.ilsang.feature.login.navigation.LoginBaseRoute
@@ -12,23 +13,26 @@ fun IlsangApp(
     isLoggedIn: Boolean?,
     shouldShowOnBoarding: Boolean,
     shouldShowIsZoneDialog: Boolean,
+    unreadTitleList: List<UserTitle>,
     completeOnBoarding: () -> Unit,
     shownIsZoneDialog: (Boolean) -> Unit,
+    onDismissTitleDialog: (Int) -> Unit,
     login: () -> Unit,
     logout: () -> Unit
 ) {
     ILSANGTheme {
         isLoggedIn?.let {
             IlsangNavHost(
-                startDestination =
-                    when {
-                        !isLoggedIn -> LoginBaseRoute::class
-                        shouldShowOnBoarding -> TutorialBaseRoute::class
-                        else -> HomeBaseRoute::class
-                    },
+                startDestination = when {
+                    !isLoggedIn -> LoginBaseRoute::class
+                    shouldShowOnBoarding -> TutorialBaseRoute::class
+                    else -> HomeBaseRoute::class
+                },
                 shouldShowIsZoneDialog = shouldShowIsZoneDialog,
+                unreadTitleList = unreadTitleList,
                 completeOnBoarding = completeOnBoarding,
                 shownIsZoneDialog = shownIsZoneDialog,
+                onDismissTitleDialog = onDismissTitleDialog,
                 login = login,
                 logout = logout
             )

--- a/app/src/main/java/com/ilsangtech/ilsang/MainActivity.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/MainActivity.kt
@@ -43,13 +43,16 @@ class MainActivity : ComponentActivity() {
             val isLoggedIn by mainActivityViewModel.isLoggedIn.collectAsStateWithLifecycle()
             val shouldShowOnBoarding by mainActivityViewModel.shouldShowOnBoarding.collectAsStateWithLifecycle()
             val shouldShowIsZoneDialog by mainActivityViewModel.shouldShowIsZoneDialog.collectAsStateWithLifecycle()
+            val unreadTitleList by mainActivityViewModel.unreadTitleList.collectAsStateWithLifecycle()
 
             IlsangApp(
                 isLoggedIn = isLoggedIn,
                 shouldShowOnBoarding = shouldShowOnBoarding,
                 shouldShowIsZoneDialog = shouldShowIsZoneDialog,
+                unreadTitleList = unreadTitleList,
                 completeOnBoarding = mainActivityViewModel::completeOnBoarding,
                 shownIsZoneDialog = { checked -> mainActivityViewModel.shownIsZoneDialog(!checked) },
+                onDismissTitleDialog = mainActivityViewModel::readTitle,
                 login = {
                     loginWithGoogle(
                         onLoginSuccess = { idToken ->

--- a/app/src/main/java/com/ilsangtech/ilsang/MainActivityViewModel.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/MainActivityViewModel.kt
@@ -3,7 +3,9 @@ package com.ilsangtech.ilsang
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ilsangtech.ilsang.core.domain.AuthRepository
+import com.ilsangtech.ilsang.core.domain.TitleRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
+import com.ilsangtech.ilsang.core.model.title.UserTitle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -22,7 +24,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
     private val authRepository: AuthRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val titleRepository: TitleRepository
 ) : ViewModel() {
     private val loginTrigger = MutableSharedFlow<Unit>(replay = 1)
     private val _shouldShowIsZoneDialog = MutableStateFlow(false)
@@ -35,6 +38,7 @@ class MainActivityViewModel @Inject constructor(
                 if (myInfo.isCommercialAreaCode == null && myInfo.showIsZoneDialogAgain) {
                     _shouldShowIsZoneDialog.update { true }
                 }
+                _unreadTitleList.update { titleRepository.getUnreadTitleList() }
             }
             .map { true }
             .catch { emit(false) }
@@ -49,6 +53,9 @@ class MainActivityViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = false
     )
+
+    private val _unreadTitleList = MutableStateFlow<List<UserTitle>>(emptyList())
+    val unreadTitleList = _unreadTitleList.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -82,6 +89,15 @@ class MainActivityViewModel @Inject constructor(
                 userRepository.updateShowIsZoneDialogAgain(false)
             }
             _shouldShowIsZoneDialog.update { false }
+        }
+    }
+
+    fun readTitle(titleHistoryId: Int) {
+        viewModelScope.launch {
+            titleRepository.readTitle(titleHistoryId)
+            _unreadTitleList.update { list ->
+                list.filter { it.titleHistoryId != titleHistoryId }
+            }
         }
     }
 }

--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -25,6 +25,8 @@ import androidx.navigation.compose.rememberNavController
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
+import com.ilsangtech.ilsang.core.model.title.UserTitle
+import com.ilsangtech.ilsang.core.ui.title.TitleObtainmentDialog
 import com.ilsangtech.ilsang.core.ui.zone.IsZoneSuggestionDialog
 import com.ilsangtech.ilsang.designsystem.component.ILSANGNavigationBar
 import com.ilsangtech.ilsang.designsystem.component.IlsangNavigationBarItem
@@ -66,10 +68,12 @@ import kotlin.reflect.KClass
 fun IlsangNavHost(
     startDestination: KClass<*>,
     shouldShowIsZoneDialog: Boolean,
+    unreadTitleList: List<UserTitle>,
     login: () -> Unit,
     logout: () -> Unit,
     completeOnBoarding: () -> Unit,
-    shownIsZoneDialog: (Boolean) -> Unit
+    shownIsZoneDialog: (Boolean) -> Unit,
+    onDismissTitleDialog: (Int) -> Unit
 ) {
     val context = LocalContext.current
     val navController = rememberNavController()
@@ -77,7 +81,6 @@ fun IlsangNavHost(
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = currentBackStackEntry?.destination
     val topLevelDestinations = BottomTab.entries
-
     if (shouldShowIsZoneDialog
         && currentBackStackEntry?.destination?.hierarchy?.any {
             it.hasRoute(HomeBaseRoute::class)
@@ -86,6 +89,18 @@ fun IlsangNavHost(
         IsZoneSuggestionDialog(
             onConfirm = { navController.navigate(IsZoneBaseRoute) },
             onDismissRequest = shownIsZoneDialog
+        )
+    }
+
+    if (unreadTitleList.isNotEmpty()
+        && currentBackStackEntry?.destination?.hierarchy?.any {
+            it.hasRoute(HomeBaseRoute::class)
+        } == true
+    ) {
+        val userTitle = unreadTitleList.first()
+        TitleObtainmentDialog(
+            title = userTitle.title,
+            onDismissRequest = { onDismissTitleDialog(userTitle.titleHistoryId) }
         )
     }
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/datasource/TitleDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/datasource/TitleDataSource.kt
@@ -9,4 +9,6 @@ interface TitleDataSource {
     suspend fun getUserTitleList(): List<UserTitleNetworkModel>
 
     suspend fun getUnreadTitleList(): List<UserTitleNetworkModel>
+
+    suspend fun readTitle(titleHistoryId: Int)
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/datasource/TitleDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/datasource/TitleDataSource.kt
@@ -7,4 +7,6 @@ interface TitleDataSource {
     suspend fun getTitleList(): List<TitleDetailNetworkModel>
 
     suspend fun getUserTitleList(): List<UserTitleNetworkModel>
+
+    suspend fun getUnreadTitleList(): List<UserTitleNetworkModel>
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/datasource/TitleDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/datasource/TitleDataSourceImpl.kt
@@ -12,4 +12,8 @@ class TitleDataSourceImpl(private val titleApiService: TitleApiService) : TitleD
     override suspend fun getUserTitleList(): List<UserTitleNetworkModel> {
         return titleApiService.getUserTitleList()
     }
+
+    override suspend fun getUnreadTitleList(): List<UserTitleNetworkModel> {
+        return titleApiService.getUnreadTitleList()
+    }
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/datasource/TitleDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/datasource/TitleDataSourceImpl.kt
@@ -16,4 +16,8 @@ class TitleDataSourceImpl(private val titleApiService: TitleApiService) : TitleD
     override suspend fun getUnreadTitleList(): List<UserTitleNetworkModel> {
         return titleApiService.getUnreadTitleList()
     }
+
+    override suspend fun readTitle(titleHistoryId: Int) {
+        return titleApiService.readTitle(titleHistoryId)
+    }
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/repository/TitleRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/repository/TitleRepositoryImpl.kt
@@ -19,4 +19,8 @@ class TitleRepositoryImpl(
     override suspend fun getUserTitleList(): List<UserTitle> {
         return titleDataSource.getUserTitleList().map(UserTitleNetworkModel::toUserTitle)
     }
+
+    override suspend fun getUnreadTitleList(): List<UserTitle> {
+        return titleDataSource.getUnreadTitleList().map(UserTitleNetworkModel::toUserTitle)
+    }
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/repository/TitleRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/title/repository/TitleRepositoryImpl.kt
@@ -23,4 +23,8 @@ class TitleRepositoryImpl(
     override suspend fun getUnreadTitleList(): List<UserTitle> {
         return titleDataSource.getUnreadTitleList().map(UserTitleNetworkModel::toUserTitle)
     }
+
+    override suspend fun readTitle(titleHistoryId: Int): Result<Unit> {
+        return runCatching { titleDataSource.readTitle(titleHistoryId) }
+    }
 }

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/TitleRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/TitleRepository.kt
@@ -7,4 +7,6 @@ interface TitleRepository {
     suspend fun getTitleList(): List<TitleDetail>
 
     suspend fun getUserTitleList(): List<UserTitle>
+
+    suspend fun getUnreadTitleList(): List<UserTitle>
 }

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/TitleRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/TitleRepository.kt
@@ -9,4 +9,6 @@ interface TitleRepository {
     suspend fun getUserTitleList(): List<UserTitle>
 
     suspend fun getUnreadTitleList(): List<UserTitle>
+
+    suspend fun readTitle(titleHistoryId: Int): Result<Unit>
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/TitleApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/TitleApiService.kt
@@ -3,6 +3,8 @@ package com.ilsangtech.ilsang.core.network.api
 import com.ilsangtech.ilsang.core.network.model.title.TitleDetailNetworkModel
 import com.ilsangtech.ilsang.core.network.model.title.UserTitleNetworkModel
 import retrofit2.http.GET
+import retrofit2.http.PUT
+import retrofit2.http.Path
 
 interface TitleApiService {
     @GET("api/v1/title")
@@ -13,4 +15,7 @@ interface TitleApiService {
 
     @GET("api/v1/user/title/unread")
     suspend fun getUnreadTitleList(): List<UserTitleNetworkModel>
+
+    @PUT("api/v1/user/title/{id}/read")
+    suspend fun readTitle(@Path("id") titleHistoryId: Int)
 }

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/TitleApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/TitleApiService.kt
@@ -10,4 +10,7 @@ interface TitleApiService {
 
     @GET("api/v1/user/title")
     suspend fun getUserTitleList(): List<UserTitleNetworkModel>
+
+    @GET("api/v1/user/title/unread")
+    suspend fun getUnreadTitleList(): List<UserTitleNetworkModel>
 }

--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/MyTitleScreen.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/MyTitleScreen.kt
@@ -34,6 +34,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ilsangtech.ilsang.core.model.title.Title
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.core.model.title.TitleType
+import com.ilsangtech.ilsang.core.ui.title.TitleObtainmentDialog
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
@@ -55,6 +56,7 @@ internal fun MyTitleScreen(
     val uiState by myTitleViewModel.myTitleUiState.collectAsStateWithLifecycle()
     val selectedTitle by myTitleViewModel.selectedTitle.collectAsStateWithLifecycle()
     val isTitleUpdated by myTitleViewModel.isTitleUpdated.collectAsStateWithLifecycle()
+    val unreadTitleList by myTitleViewModel.unreadTitleList.collectAsStateWithLifecycle()
 
     var selectedType by remember { mutableStateOf<TitleGrade>(TitleGrade.Standard) }
     var showUpdateDialog by remember { mutableStateOf(false) }
@@ -75,6 +77,13 @@ internal fun MyTitleScreen(
             onUpdateButtonClick = myTitleViewModel::updateUserTitle,
             onDismissRequest = { showUpdateDialog = false }
         )
+    }
+
+    if (unreadTitleList.isNotEmpty()) {
+        val userTitle = unreadTitleList.first()
+        TitleObtainmentDialog(title = userTitle.title) {
+            myTitleViewModel.readTitle(userTitle.titleHistoryId)
+        }
     }
 
     MyTitleScreen(


### PR DESCRIPTION
이슈 번호: resolves #197
작업 사항:
- 읽지 않은 칭호 리스트 조회, 칭호 읽음 처리 API 연동
- MainActivityViewModel 내 읽지 않은 칭호 리스트 상태 구현
- MyTitleViewModel 내 읽지 않은 칭호 리스트 상태 구현
- 홈 화면, 칭호 화면에서 읽지 않은 칭호 다이얼로그가 나타나도록 구현

UI 화면:
<img width="300" alt="Screenshot_20250908_143043" src="https://github.com/user-attachments/assets/af8239e8-33f8-41f0-81b1-c79f548dda8d" />
