### PR TITLE
[Feat] 배너 퀘스트 클릭 시 하단 시트 UI 적용

### DIFF
--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -236,7 +236,13 @@ fun IlsangNavHost(
 
             isZoneNavigation(onBackButtonClick = navController::popBackStack)
 
-            bannerNavigation(onBackButtonClick = navController::popBackStack)
+            bannerNavigation(
+                onBackButtonClick = navController::popBackStack,
+                navigateToSubmit = navController::navigateToSubmit,
+                navigateToMissionExample = { missionId ->
+                    navController.navigate(ApprovalExampleRoute(missionId))
+                }
+            )
 
             couponNavigation(
                 navigateToHome = {

--- a/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/BannerDetailScreen.kt
+++ b/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/BannerDetailScreen.kt
@@ -5,9 +5,12 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -19,21 +22,27 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.ilsangtech.ilsang.core.model.NewQuestType
 import com.ilsangtech.ilsang.core.model.RewardPoint
 import com.ilsangtech.ilsang.core.model.quest.BannerQuest
+import com.ilsangtech.ilsang.core.model.quest.QuestDetail
+import com.ilsangtech.ilsang.core.ui.quest.bottomsheet.QuestBottomSheet
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.feature.banner.component.BannerDetailHeader
 import com.ilsangtech.ilsang.feature.banner.component.bannerDetailInfoContent
 import com.ilsangtech.ilsang.feature.banner.component.bannerDetailQuestsContent
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun BannerDetailScreen(
     bannerDetailViewModel: BannerDetailViewModel = hiltViewModel(),
+    navigateToSubmit: (Int, Int, String) -> Unit,
+    navigateToMissionExample: (Int) -> Unit,
     onBackButtonClick: () -> Unit
 ) {
     val bannerDetailInfo = bannerDetailViewModel.bannerDetailInfo
 
     val selectedQuestType by bannerDetailViewModel.selectedQuestType.collectAsStateWithLifecycle()
     val selectedSortType by bannerDetailViewModel.selectedSortType.collectAsStateWithLifecycle()
+    val selectedQuest by bannerDetailViewModel.selectedQuest.collectAsStateWithLifecycle()
 
     val onGoingQuests = bannerDetailViewModel.onGoingQuests.collectAsLazyPagingItems()
     val completedQuests = bannerDetailViewModel.completedQuests.collectAsLazyPagingItems()
@@ -42,31 +51,74 @@ internal fun BannerDetailScreen(
         imageId = bannerDetailInfo.imageId,
         title = bannerDetailInfo.title,
         description = bannerDetailInfo.description,
+        selectedQuest = selectedQuest,
         selectedQuestType = selectedQuestType,
         selectedSortType = selectedSortType,
         onGoingQuests = onGoingQuests,
         completedQuests = completedQuests,
-        onQuestClick = {},
+        onQuestClick = bannerDetailViewModel::selectQuest,
+        onUnselectQuest = bannerDetailViewModel::unselectQuest,
         onQuestTypeChanged = bannerDetailViewModel::onQuestTypeChanged,
         onSortTypeChanged = bannerDetailViewModel::onSortTypeChanged,
-        onBackButtonClick = onBackButtonClick
+        onBackButtonClick = onBackButtonClick,
+        onFavoriteClick = bannerDetailViewModel::updateQuestFavoriteStatus,
+        onMissionImageClick = navigateToMissionExample,
+        onSubmitButtonClick = navigateToSubmit
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BannerDetailScreen(
     imageId: String,
     title: String,
     description: String,
+    selectedQuest: QuestDetail?,
     selectedQuestType: BannerDetailQuestType,
     selectedSortType: BannerDetailSortType,
     onGoingQuests: LazyPagingItems<BannerQuest>,
     completedQuests: LazyPagingItems<BannerQuest>,
-    onQuestClick: (BannerQuest) -> Unit,
     onQuestTypeChanged: (BannerDetailQuestType) -> Unit,
     onSortTypeChanged: (BannerDetailSortType) -> Unit,
+    onQuestClick: (BannerQuest) -> Unit,
+    onUnselectQuest: () -> Unit,
+    onFavoriteClick: () -> Unit,
+    onMissionImageClick: (Int) -> Unit,
+    onSubmitButtonClick: (Int, Int, String) -> Unit,
     onBackButtonClick: () -> Unit
 ) {
+    val coroutineScope = rememberCoroutineScope()
+    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    if (selectedQuest != null) {
+        QuestBottomSheet(
+            quest = selectedQuest,
+            bottomSheetState = bottomSheetState,
+            onFavoriteClick = onFavoriteClick,
+            onMissionImageClick = {
+                selectedQuest.missions.firstOrNull()?.let { mission ->
+                    if (mission.exampleImageIds.isNotEmpty()) {
+                        coroutineScope.launch {
+                            bottomSheetState.hide()
+                            onUnselectQuest()
+                            onMissionImageClick(mission.id)
+                        }
+                    }
+                }
+            },
+            onApproveButtonClick = {
+                coroutineScope.launch {
+                    val mission = selectedQuest.missions.firstOrNull()
+                    bottomSheetState.hide()
+                    onUnselectQuest()
+                    mission?.let { missionId ->
+                        onSubmitButtonClick(selectedQuest.id, mission.id, mission.type)
+                    }
+                }
+            },
+            onDismiss = onUnselectQuest
+        )
+    }
+
     Surface(
         modifier = Modifier.fillMaxSize(),
         color = background
@@ -162,6 +214,7 @@ private fun BannerDetailScreenPreview() {
         imageId = "sample_banner_image",
         title = "Sample Banner Title",
         description = "This is a sample banner description. It can be a long text explaining the details of the banner.",
+        selectedQuest = null,
         selectedQuestType = BannerDetailQuestType.OnGoing,
         selectedSortType = BannerDetailSortType.Popular,
         onGoingQuests = onGoingQuests,
@@ -169,6 +222,10 @@ private fun BannerDetailScreenPreview() {
         onQuestClick = {},
         onQuestTypeChanged = {},
         onSortTypeChanged = {},
-        onBackButtonClick = {}
+        onSubmitButtonClick = { _, _, _ -> },
+        onBackButtonClick = {},
+        onUnselectQuest = {},
+        onFavoriteClick = {},
+        onMissionImageClick = {}
     )
 }

--- a/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/BannerDetailViewModel.kt
+++ b/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/BannerDetailViewModel.kt
@@ -6,13 +6,21 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import androidx.paging.cachedIn
 import com.ilsangtech.ilsang.core.domain.QuestRepository
+import com.ilsangtech.ilsang.core.model.quest.BannerQuest
 import com.ilsangtech.ilsang.feature.banner.navigation.BannerDetailRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,6 +35,23 @@ class BannerDetailViewModel @Inject constructor(
 
     private val _selectedSortType = MutableStateFlow(BannerDetailSortType.ExpiredDate)
     val selectedSortType = _selectedSortType.asStateFlow()
+
+    private val selectedQuestId = MutableStateFlow<Int?>(null)
+    private val questDetailRefresh = MutableSharedFlow<Unit>(replay = 1)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val selectedQuest = combine(
+        selectedQuestId,
+        questDetailRefresh.onStart { emit(Unit) }
+    ) { questId, _ -> questId }.flatMapLatest { questId ->
+        questId?.let {
+            questRepository.getQuestDetail(questId)
+        } ?: flowOf(null)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = null
+    )
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val onGoingQuests = selectedSortType.flatMapLatest { sortType ->
@@ -66,5 +91,28 @@ class BannerDetailViewModel @Inject constructor(
 
     fun onSortTypeChanged(sortType: BannerDetailSortType) {
         _selectedSortType.update { sortType }
+    }
+
+    fun selectQuest(quest: BannerQuest) {
+        viewModelScope.launch {
+            selectedQuestId.update { quest.questId }
+        }
+    }
+
+    fun unselectQuest() {
+        selectedQuestId.update { null }
+    }
+
+    fun updateQuestFavoriteStatus() {
+        viewModelScope.launch {
+            selectedQuest.value?.let { quest ->
+                val result = if (quest.favoriteYn) {
+                    questRepository.deleteFavoriteQuest(quest.id)
+                } else {
+                    questRepository.registerFavoriteQuest(quest.id)
+                }
+                result.onSuccess { questDetailRefresh.emit(Unit) }
+            }
+        }
     }
 }

--- a/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/navigation/BannerNavigation.kt
+++ b/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/navigation/BannerNavigation.kt
@@ -31,18 +31,16 @@ fun NavHostController.navigateToBannerDetail(banner: Banner) {
 }
 
 fun NavGraphBuilder.bannerNavigation(
-    onBackButtonClick: () -> Unit
+    onBackButtonClick: () -> Unit,
+    navigateToSubmit: (Int, Int, String) -> Unit,
+    navigateToMissionExample: (Int) -> Unit
 ) {
     navigation<BannerBaseRoute>(startDestination = BannerDetailRoute::class) {
         composable<BannerDetailRoute> {
             BannerDetailScreen(
                 onBackButtonClick = onBackButtonClick,
-                navigateToSubmit = { questId, missionId, missionType ->
-
-                },
-                navigateToMissionExample = { missionId ->
-
-                }
+                navigateToSubmit = navigateToSubmit,
+                navigateToMissionExample = navigateToMissionExample
             )
         }
     }

--- a/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/navigation/BannerNavigation.kt
+++ b/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/navigation/BannerNavigation.kt
@@ -35,7 +35,15 @@ fun NavGraphBuilder.bannerNavigation(
 ) {
     navigation<BannerBaseRoute>(startDestination = BannerDetailRoute::class) {
         composable<BannerDetailRoute> {
-            BannerDetailScreen(onBackButtonClick = onBackButtonClick)
+            BannerDetailScreen(
+                onBackButtonClick = onBackButtonClick,
+                navigateToSubmit = { questId, missionId, missionType ->
+
+                },
+                navigateToMissionExample = { missionId ->
+
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
이슈 번호: resolves #202 
작업 사항:
- 배너 퀘스트 클릭 시 하단 시트 표시
- 하단 시트 내 즐겨찾기 기능 적용
- 미션 이미지 클릭 시 인증 예시 화면 이동 적용
- 인증하기 버튼 클릭 시 인증 화면으로 이동 적용

UI 화면:
<img width="300" alt="Screenshot_20250908_162528" src="https://github.com/user-attachments/assets/ee36567a-93b0-461a-b7ce-dead5a359a9c" />
