### PR TITLE
[Fix] 칭호 화면에서 진입 시 칭호가 잘못 선택되어 있는 버그 수정

### DIFF
--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/MyTitleViewModel.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/MyTitleViewModel.kt
@@ -53,8 +53,10 @@ class MyTitleViewModel @Inject constructor(
             }
         )
     }.onEach { state ->
-        state.titleList.find { it.titleHistoryId == originTitleHistoryId }
-            ?.let { title -> _selectedTitle.update { title } }
+        originTitleHistoryId?.let {
+            state.titleList.find { it.titleHistoryId == originTitleHistoryId }
+                ?.let { title -> _selectedTitle.update { title } }
+        }
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),


### PR DESCRIPTION
이슈 번호: resolves #208
작업 사항:
- 선택된 칭호가 없을 때 획득하지 않은 칭호가 선택되어 있는 버그 수정

UI 화면: 없음