### PR TITLE
[Feat] 즐겨찾기 퀘스트 로드 데이터가 비어있을 때 UI 적용

### DIFF
--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -163,9 +163,6 @@ fun IlsangNavHost(
                 navigateToLogin = {
                     Firebase.auth.signOut()
                     logout()
-//                    navController.navigate(LoginRoute) {
-//                        popUpTo(HomeBaseRoute) { inclusive = true }
-//                    }
                 },
                 navigateToHome = {
                     navController.navigateToTopLevelDestination(BottomTab.Home)

--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -167,6 +167,9 @@ fun IlsangNavHost(
 //                        popUpTo(HomeBaseRoute) { inclusive = true }
 //                    }
                 },
+                navigateToHome = {
+                    navController.navigateToTopLevelDestination(BottomTab.Home)
+                },
                 navigateToMyTabMain = {
                     navController.popBackStack()
                 },

--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/navigation/MyTabNavigation.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/navigation/MyTabNavigation.kt
@@ -93,6 +93,7 @@ fun NavHostController.navigateToMyFavoriteQuest() = navigate(MyFavoriteQuestRout
 
 fun NavGraphBuilder.myTabNavigation(
     navigateToLogin: () -> Unit,
+    navigateToHome: () -> Unit,
     navigateToMyTabMain: () -> Unit,
     navigateToMyProfileEdit: (String, String?) -> Unit,
     navigateToMyChallenge: () -> Unit,
@@ -204,6 +205,7 @@ fun NavGraphBuilder.myTabNavigation(
         composable<MyFavoriteQuestRoute> {
             MyFavoriteQuestScreen(
                 onMyZoneClick = navigateToMyZone,
+                onQuestNavButtonClick = navigateToHome,
                 onBackButtonClick = navigateToMyTabMain
             )
         }

--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/favorite_quest/MyFavoriteQuestScreen.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/favorite_quest/MyFavoriteQuestScreen.kt
@@ -13,18 +13,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ilsangtech.ilsang.core.model.quest.TypedQuest
 import com.ilsangtech.ilsang.core.ui.quest.QuestCardWithFavorite
 import com.ilsangtech.ilsang.core.ui.zone.MyZoneSelector
 import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.feature.my.screens.favorite_quest.component.MyFavoriteQuestEmptyContent
 import com.ilsangtech.ilsang.feature.my.screens.favorite_quest.component.MyFavoriteQuestHeader
 
 @Composable
+
 internal fun MyFavoriteQuestScreen(
     viewModel: MyFavoriteQuestViewModel = hiltViewModel(),
     onMyZoneClick: () -> Unit,
+    onQuestNavButtonClick: () -> Unit,
     onBackButtonClick: () -> Unit
 ) {
     val favoriteQuestList = viewModel.favoriteQuestList.collectAsLazyPagingItems()
@@ -35,6 +39,7 @@ internal fun MyFavoriteQuestScreen(
         favoriteQuestList = favoriteQuestList,
         onMyZoneClick = onMyZoneClick,
         onFavoriteClick = viewModel::updateFavoriteStatus,
+        onQuestNavButtonClick = onQuestNavButtonClick,
         onBackButtonClick = onBackButtonClick
     )
 }
@@ -45,6 +50,7 @@ private fun MyFavoriteQuestScreen(
     favoriteQuestList: LazyPagingItems<TypedQuest>,
     onMyZoneClick: () -> Unit,
     onFavoriteClick: (TypedQuest) -> Unit,
+    onQuestNavButtonClick: () -> Unit,
     onBackButtonClick: () -> Unit
 ) {
     Surface(
@@ -58,6 +64,14 @@ private fun MyFavoriteQuestScreen(
                 myCommercialAreaName = commercialAreaName.orEmpty(),
                 onMyZoneClick = onMyZoneClick
             )
+            if (favoriteQuestList.loadState.refresh is LoadState.NotLoading
+                && favoriteQuestList.itemCount == 0
+            ) {
+                MyFavoriteQuestEmptyContent(
+                    modifier = Modifier.weight(1f),
+                    onQuestNavButtonClick = onQuestNavButtonClick
+                )
+            }
             LazyColumn(
                 contentPadding = PaddingValues(
                     top = 24.dp, bottom = 72.dp,

--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/favorite_quest/component/MyFavoriteQuestEmptyContent.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/favorite_quest/component/MyFavoriteQuestEmptyContent.kt
@@ -1,0 +1,94 @@
+package com.ilsangtech.ilsang.feature.my.screens.favorite_quest.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.designsystem.theme.gray400
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
+import com.ilsangtech.ilsang.designsystem.theme.primary
+
+@Composable
+internal fun MyFavoriteQuestEmptyContent(
+    modifier: Modifier = Modifier,
+    onQuestNavButtonClick: () -> Unit
+) {
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Column(
+                modifier = Modifier.padding(bottom = 40.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Text(
+                    text = "즐겨찾기한 퀘스트가 없어요",
+                    style = TextStyle(
+                        fontFamily = pretendardFontFamily,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 21.sp,
+                        lineHeight = 1.5.em,
+                        color = gray500,
+                        textAlign = TextAlign.Center
+                    )
+                )
+                Text(
+                    text = "관심 있는 지역의 퀘스트를\n" +
+                            "즐겨찾기 해보세요!",
+                    style = TextStyle(
+                        fontFamily = pretendardFontFamily,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 17.sp,
+                        lineHeight = 1.5.em,
+                        color = gray400,
+                        textAlign = TextAlign.Center
+                    )
+                )
+            }
+            Button(
+                colors = ButtonDefaults.buttonColors(containerColor = primary),
+                shape = RoundedCornerShape(12.dp),
+                contentPadding = PaddingValues(vertical = 16.dp, horizontal = 24.dp),
+                onClick = onQuestNavButtonClick
+            ) {
+                Text(
+                    text = "퀘스트 바로가기",
+                    style = TextStyle(
+                        fontFamily = pretendardFontFamily,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 16.sp,
+                        lineHeight = 18.sp
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MyFavoriteQuestEmptyContentPreview() {
+    MyFavoriteQuestEmptyContent(
+        modifier = Modifier,
+        onQuestNavButtonClick = {}
+    )
+}


### PR DESCRIPTION
이슈 번호: resolves #214 
작업 사항:
- 마이 탭 내 퀘스트 즐겨찾기 화면에서 즐겨찾기 퀘스트가 없을 경에 보여질 UI 구현 및 적용
- 퀘스트 바로가기 버튼 클릭 시 홈화면 이동 구현

UI 화면:
<img width="300" height="2340" alt="Screenshot_20250909_112111" src="https://github.com/user-attachments/assets/27684fdf-9cd4-45c6-8bcb-7fead389e8ec" />
