### PR TITLE
[Fix] 퀘스트 바로 가기 버튼 클릭 시 이동할 화면 변경

### DIFF
--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -199,9 +199,6 @@ fun IlsangNavHost(
                 },
                 navigateToMyZone = {
                     navController.navigate(MyZoneBaseRoute)
-                },
-                navigateToQuestTab = {
-                    navController.navigateToTopLevelDestination(BottomTab.Quest)
                 }
             )
 

--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/navigation/MyTabNavigation.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/navigation/MyTabNavigation.kt
@@ -108,7 +108,6 @@ fun NavGraphBuilder.myTabNavigation(
     navigateToMyFavoriteQuest: () -> Unit,
     navigateToCoupon: () -> Unit,
     navigateToMyZone: () -> Unit,
-    navigateToQuestTab: () -> Unit
 ) {
     navigation<MyBaseRoute>(startDestination = MyRoute) {
         composable<MyRoute> {
@@ -118,7 +117,7 @@ fun NavGraphBuilder.myTabNavigation(
                 onMissionHistoryButtonClick = navigateToMyChallenge,
                 onFavoriteQuestButtonClick = navigateToMyFavoriteQuest,
                 onCouponButtonClick = navigateToCoupon,
-                onQuestNavButtonClick = navigateToQuestTab,
+                onQuestNavButtonClick = navigateToHome,
                 onTitleClick = navigateToMyTitle
             )
         }
@@ -152,7 +151,7 @@ fun NavGraphBuilder.myTabNavigation(
                         missionHistory.likeCount
                     )
                 },
-                onQuestNavButtonClick = navigateToQuestTab,
+                onQuestNavButtonClick = navigateToHome,
                 onBackButtonClick = navigateToMyTabMain
             )
         }


### PR DESCRIPTION
이슈 번호: resolves #212 
작업 사항:
- 로드된 데이터가 없을 때 나타나는 '퀘스트 바로가기' 버튼 클릭 시 홈 화면으로 이동하도록 수정

UI 화면: 없음