### PR TITLE
[Feat] 홈 화면에서 시즌 팝업 배너 표시 구현

### DIFF
--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/mapper/MyInfoMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/mapper/MyInfoMapper.kt
@@ -7,7 +7,8 @@ import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
 fun UserInfoResponse.toMyInfo(
     totalPoint: Int,
     myZoneCommercialAreaCode: String,
-    showIsZoneDialogAgain: Boolean
+    showIsZoneDialogAgain: Boolean,
+    shouldShowSeasonOpenDialog: Boolean
 ): MyInfo {
     return MyInfo(
         id = id,
@@ -21,6 +22,7 @@ fun UserInfoResponse.toMyInfo(
         status = status,
         statusUpdatedAt = statusUpdatedAt,
         title = title?.toUserTitle(),
-        showIsZoneDialogAgain = showIsZoneDialogAgain
+        showIsZoneDialogAgain = showIsZoneDialogAgain,
+        shouldShowSeasonOpenDialog = shouldShowSeasonOpenDialog
     )
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -122,4 +122,8 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun updateShowIsZoneDialogAgain(showAgain: Boolean) {
         return userDataStore.setShowIsZoneDialogAgain(showAgain)
     }
+
+    override suspend fun updateShouldShowSeasonOpenDialog(shouldShow: Boolean) {
+        return userDataStore.setShouldShowSeasonOpenDialog(shouldShow)
+    }
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -30,15 +30,17 @@ class UserRepositoryImpl @Inject constructor(
         combine(
             userDataStore.userMyZone,
             userDataStore.showIsZoneDialogAgain,
+            userDataStore.shouldShowSeasonOpenDialog,
             getUserPoint()
-        ) { myZoneCommercialAreaCode, showIsZoneDialogAgain, userPoint ->
+        ) { myZoneCommercialAreaCode, showIsZoneDialogAgain, shouldShowSeasonOpenDialog, userPoint ->
             val userInfoResponse = userDataSource.getUserInfo(userId = null)
             val totalPoint =
                 userPoint.metroAreaPoint + userPoint.commercialAreaPoint + userPoint.contributionPoint
             userInfoResponse.toMyInfo(
                 totalPoint = totalPoint,
                 myZoneCommercialAreaCode = myZoneCommercialAreaCode,
-                showIsZoneDialogAgain = showIsZoneDialogAgain
+                showIsZoneDialogAgain = showIsZoneDialogAgain,
+                shouldShowSeasonOpenDialog = shouldShowSeasonOpenDialog
             )
         }
 

--- a/core/datastore/src/main/java/com/ilsangtech/ilsang/core/datastore/UserDataStore.kt
+++ b/core/datastore/src/main/java/com/ilsangtech/ilsang/core/datastore/UserDataStore.kt
@@ -24,6 +24,12 @@ class UserDataStore(context: Context) {
         preferences[showIsZoneDialogAgainKey] ?: true
     }
 
+    private val shouldShowSeasonOpenDialogKey =
+        booleanPreferencesKey("should_show_season_open_dialog")
+    val shouldShowSeasonOpenDialog = userDataStore.data.map { preferences ->
+        preferences[shouldShowSeasonOpenDialogKey] ?: true
+    }
+
     private val userMyZoneKey = stringPreferencesKey("user_my_zone")
     val userMyZone = userDataStore.data.map { preferences ->
         preferences[userMyZoneKey] ?: "R100"
@@ -42,6 +48,12 @@ class UserDataStore(context: Context) {
     suspend fun setShouldShowOnBoarding(shouldShow: Boolean) {
         userDataStore.edit { preferences ->
             preferences[shouldShowOnBoardingKey] = shouldShow
+        }
+    }
+
+    suspend fun setShouldShowSeasonOpenDialog(shouldShow: Boolean) {
+        userDataStore.edit { preferences ->
+            preferences[shouldShowSeasonOpenDialogKey] = shouldShow
         }
     }
 

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
@@ -38,4 +38,6 @@ interface UserRepository {
     suspend fun updateUserIsZone(commericalAreaCode: String): Result<Unit>
 
     suspend fun updateShowIsZoneDialogAgain(showAgain: Boolean)
+
+    suspend fun updateShouldShowSeasonOpenDialog(shouldShow: Boolean)
 }

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/MyInfo.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/MyInfo.kt
@@ -14,5 +14,6 @@ data class MyInfo(
     val status: String,
     val statusUpdatedAt: String,
     val title: UserTitle?,
-    val showIsZoneDialogAgain: Boolean
+    val showIsZoneDialogAgain: Boolean,
+    val shouldShowSeasonOpenDialog: Boolean
 )

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,6 +33,7 @@ import com.ilsangtech.ilsang.core.model.title.Title
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.core.model.title.TitleType
 import com.ilsangtech.ilsang.core.ui.quest.bottomsheet.QuestBottomSheet
+import com.ilsangtech.ilsang.core.ui.season.SeasonOpenDialog
 import com.ilsangtech.ilsang.core.ui.zone.IsZoneSelectDisabledDialog
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.feature.home.component.BannerContent
@@ -43,6 +45,7 @@ import com.ilsangtech.ilsang.feature.home.component.UserRankContent
 import com.ilsangtech.ilsang.feature.home.model.HomeTabSuccessData
 import com.ilsangtech.ilsang.feature.home.model.HomeTabUiState
 import com.ilsangtech.ilsang.feature.home.model.MyInfoUiModel
+import com.ilsangtech.ilsang.feature.home.model.OpenSeasonUiModel
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -59,11 +62,13 @@ internal fun HomeTabScreen(
     onMyZoneClick: () -> Unit,
     onIsZoneClick: () -> Unit
 ) {
+    val shouldShowSeasonOpenDialog by homeViewModel.shouldShowSeasonOpenDialog.collectAsState()
     val homeTabUiState by homeViewModel.homeTabUiState.collectAsStateWithLifecycle()
     val selectedQuest by homeViewModel.selectedQuest.collectAsStateWithLifecycle()
 
     HomeTabScreen(
         homeTabUiState = homeTabUiState,
+        shouldShowSeasonOpenDialog = shouldShowSeasonOpenDialog,
         selectedQuest = selectedQuest,
         navigateToQuestTab = navigateToQuestTab,
         navigateToMyTab = navigateToMyTab,
@@ -77,6 +82,7 @@ internal fun HomeTabScreen(
         onSelectQuest = homeViewModel::selectQuest,
         onUnselectQuest = homeViewModel::unselectQuest,
         onFavoriteClick = homeViewModel::updateQuestFavoriteStatus,
+        onDismissSeasonOpenDialog = homeViewModel::seasonOpenDialogShown
     )
 }
 
@@ -84,6 +90,7 @@ internal fun HomeTabScreen(
 @Composable
 private fun HomeTabScreen(
     homeTabUiState: HomeTabUiState,
+    shouldShowSeasonOpenDialog: Boolean?,
     selectedQuest: QuestDetail?,
     navigateToQuestTab: () -> Unit,
     navigateToMyTab: () -> Unit,
@@ -96,7 +103,8 @@ private fun HomeTabScreen(
     onMissionImageClick: (Int) -> Unit,
     onSelectQuest: (Int) -> Unit,
     onUnselectQuest: () -> Unit,
-    onFavoriteClick: () -> Unit
+    onFavoriteClick: () -> Unit,
+    onDismissSeasonOpenDialog: (Boolean) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -144,6 +152,17 @@ private fun HomeTabScreen(
     ) {
         if (homeTabUiState is HomeTabUiState.Success) {
             val (userInfo, season, banners, popularQuests, recommendedQuests, largeRewardQuests, topRankUsers) = homeTabUiState.data
+
+            if (shouldShowSeasonOpenDialog == true) {
+                SeasonOpenDialog(
+                    seasonNumber = season.seasonNumber,
+                    startDate = season.startDate,
+                    endDate = season.endDate,
+                    onRankingButtonClick = navigateToRankingTab,
+                    onDismissRequest = onDismissSeasonOpenDialog
+                )
+            }
+
             LazyColumn {
                 item {
                     HomeTabHeader(
@@ -370,6 +389,7 @@ private fun HomeTabScreenPreview() {
 
     HomeTabScreen(
         homeTabUiState = homeTabUiState,
+        shouldShowSeasonOpenDialog = false,
         selectedQuest = null,
         navigateToQuestTab = {},
         navigateToMyTab = {},
@@ -382,6 +402,7 @@ private fun HomeTabScreenPreview() {
         onMissionImageClick = {},
         onSelectQuest = {},
         onUnselectQuest = {},
-        onFavoriteClick = {}
+        onFavoriteClick = {},
+        onDismissSeasonOpenDialog = {}
     )
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeTabScreen.kt
@@ -143,7 +143,7 @@ private fun HomeTabScreen(
         color = background
     ) {
         if (homeTabUiState is HomeTabUiState.Success) {
-            val (userInfo, banners, popularQuests, recommendedQuests, largeRewardQuests, topRankUsers) = homeTabUiState.data
+            val (userInfo, season, banners, popularQuests, recommendedQuests, largeRewardQuests, topRankUsers) = homeTabUiState.data
             LazyColumn {
                 item {
                     HomeTabHeader(
@@ -216,6 +216,11 @@ private fun HomeTabScreenPreview() {
                 profileImageId = "default_profile",
                 myCommercialAreaName = "서현역",
                 isCommericalAreaName = "서현역"
+            ),
+            season = OpenSeasonUiModel(
+                seasonNumber = 1,
+                startDate = "2023.01.01",
+                endDate = "2023.12.31"
             ),
             banners = listOf(
                 Banner(

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
@@ -32,7 +32,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    userRepository: UserRepository,
+    private val userRepository: UserRepository,
     private val seasonRepository: SeasonRepository,
     private val areaRepository: AreaRepository,
     private val bannerRepository: BannerRepository,
@@ -44,12 +44,13 @@ class HomeViewModel @Inject constructor(
     private val _selectedQuestId = MutableStateFlow<Int?>(null)
     private val selectedQuestId = _selectedQuestId.asStateFlow()
 
-    private val _shouldShowSeasonOpenDialog = MutableStateFlow(true)
+    private val _shouldShowSeasonOpenDialog = MutableStateFlow<Boolean?>(null)
     val shouldShowSeasonOpenDialog = _shouldShowSeasonOpenDialog.asStateFlow()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val homeTabUiState: StateFlow<HomeTabUiState> =
         userRepository.getMyInfo().flatMapLatest<MyInfo, HomeTabUiState> { myInfo ->
+            _shouldShowSeasonOpenDialog.update { myInfo.shouldShowSeasonOpenDialog }
             val myAreaCode = myInfo.myCommericalAreaCode
             val isAreaCode = myInfo.isCommercialAreaCode
 
@@ -135,6 +136,12 @@ class HomeViewModel @Inject constructor(
     }
 
     fun seasonOpenDialogShown(checked: Boolean) {
-        _shouldShowSeasonOpenDialog.update { false }
+        viewModelScope.launch {
+            if (checked) {
+                userRepository.updateShouldShowSeasonOpenDialog(false)
+            } else {
+                _shouldShowSeasonOpenDialog.update { false }
+            }
+        }
     }
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
@@ -6,11 +6,13 @@ import com.ilsangtech.ilsang.core.domain.AreaRepository
 import com.ilsangtech.ilsang.core.domain.BannerRepository
 import com.ilsangtech.ilsang.core.domain.QuestRepository
 import com.ilsangtech.ilsang.core.domain.RankRepository
+import com.ilsangtech.ilsang.core.domain.SeasonRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
 import com.ilsangtech.ilsang.core.model.MyInfo
 import com.ilsangtech.ilsang.feature.home.model.HomeTabSuccessData
 import com.ilsangtech.ilsang.feature.home.model.HomeTabUiState
 import com.ilsangtech.ilsang.feature.home.model.MyInfoUiModel
+import com.ilsangtech.ilsang.feature.home.model.toOpenSeasonUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -31,6 +33,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     userRepository: UserRepository,
+    private val seasonRepository: SeasonRepository,
     private val areaRepository: AreaRepository,
     private val bannerRepository: BannerRepository,
     private val questRepository: QuestRepository,
@@ -40,6 +43,9 @@ class HomeViewModel @Inject constructor(
 
     private val _selectedQuestId = MutableStateFlow<Int?>(null)
     private val selectedQuestId = _selectedQuestId.asStateFlow()
+
+    private val _shouldShowSeasonOpenDialog = MutableStateFlow(true)
+    val shouldShowSeasonOpenDialog = _shouldShowSeasonOpenDialog.asStateFlow()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val homeTabUiState: StateFlow<HomeTabUiState> =
@@ -78,6 +84,7 @@ class HomeViewModel @Inject constructor(
                             myCommercialAreaName = myCommercialAreaName,
                             isCommericalAreaName = isCommercialAreaName
                         ),
+                        season = seasonRepository.getCurrentSeason().toOpenSeasonUiModel(),
                         banners = banners,
                         popularQuests = popular,
                         recommendedQuests = recommended,
@@ -125,5 +132,9 @@ class HomeViewModel @Inject constructor(
                 result.onSuccess { questDetailRefreshTrigger.emit(Unit) }
             }
         }
+    }
+
+    fun seasonOpenDialogShown(checked: Boolean) {
+        _shouldShowSeasonOpenDialog.update { false }
     }
 }

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/model/HomeTabUiState.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/model/HomeTabUiState.kt
@@ -14,6 +14,7 @@ sealed interface HomeTabUiState {
 
 data class HomeTabSuccessData(
     val myInfo: MyInfoUiModel,
+    val season: OpenSeasonUiModel,
     val banners: List<Banner>,
     val popularQuests: List<PopularQuest>,
     val recommendedQuests: List<RecommendedQuest>,

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/model/OpenSeasonUiModel.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/model/OpenSeasonUiModel.kt
@@ -1,0 +1,18 @@
+package com.ilsangtech.ilsang.feature.home.model
+
+import com.ilsangtech.ilsang.core.model.season.Season
+import com.ilsangtech.ilsang.core.util.DateConverter
+
+data class OpenSeasonUiModel(
+    val seasonNumber: Int,
+    val startDate: String,
+    val endDate: String
+)
+
+internal fun Season.toOpenSeasonUiModel(): OpenSeasonUiModel {
+    return OpenSeasonUiModel(
+        seasonNumber = seasonNumber,
+        startDate = DateConverter.formatDate(startDate),
+        endDate = DateConverter.formatDate(endDate)
+    )
+}


### PR DESCRIPTION
이슈 번호: resolves https://github.com/TeamFair/ILSANG-Android/issues/212
작업 사항:
- 홈 화면 진입 시 시즌 팝업 다이얼로그 표시
- 시즌 팝업 다이얼로그 표시 여부 데이터를 로컬로 관리
- 다이얼로그 내 다시 보지않기 클릭 시 표시 여부 데이터 업데이트

UI 화면: 
<img width="300" alt="Screenshot_20250909_154455" src="https://github.com/user-attachments/assets/c019c91f-5a02-46a4-9884-a691b9f91936" />

