### PR TITLE
[Fix] 완료된 퀘스트 클릭 시 하단 시트 표시 제거

### DIFF
--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
@@ -126,7 +126,7 @@ private fun QuestTabScreen(
     onMissionImageClick: (Int?) -> Unit,
     onDismissRequest: () -> Unit
 ) {
-    if (selectedQuest != null) {
+    if (selectedQuest != null && selectedQuestTab != QuestTabUiModel.COMPLETED) {
         QuestBottomSheet(
             quest = selectedQuest,
             bottomSheetState = bottomSheetState,


### PR DESCRIPTION
이슈 번호: resolves #204 
작업 사항:
- 퀘스트 탭의 완료된 퀘스트 클릭 시 하단 시트가 나오지 않도록 수정

UI 화면: 없음