### PR TITLE
[Fix] 퀘스트탭 퀘스트 즐겨찾기 시 깜빡임 버그 수정

### DIFF
--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -65,12 +64,6 @@ fun QuestTabScreen(
 
     val coroutineScope = rememberCoroutineScope()
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-
-    LaunchedEffect(Unit) {
-        questTabViewModel.questDetailRefreshTrigger.collect {
-            typedQuests.refresh()
-        }
-    }
 
     QuestTabScreen(
         bottomSheetState = bottomSheetState,


### PR DESCRIPTION
이슈 번호: resolves #226 
작업 사항:
- 퀘스트 탭의 퀘스트 페이징 아이템에 대한 즐겨찾기 여부를 관리하여 API를 재호출을 막아 깜빡임 방지

UI 화면: 없음