### PR TITLE
[Fix] 홈 화면 시즌 오픈 팝업 중복 노출 버그 수정

### DIFF
--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
@@ -50,7 +50,9 @@ class HomeViewModel @Inject constructor(
     @OptIn(ExperimentalCoroutinesApi::class)
     val homeTabUiState: StateFlow<HomeTabUiState> =
         userRepository.getMyInfo().flatMapLatest<MyInfo, HomeTabUiState> { myInfo ->
-            _shouldShowSeasonOpenDialog.update { myInfo.shouldShowSeasonOpenDialog }
+            if (shouldShowSeasonOpenDialog.value == null) {
+                _shouldShowSeasonOpenDialog.update { myInfo.shouldShowSeasonOpenDialog }
+            }
             val myAreaCode = myInfo.myCommericalAreaCode
             val isAreaCode = myInfo.isCommercialAreaCode
 


### PR DESCRIPTION
이슈 번호: resolves #228 
작업 사항:
- 홈 탭에서 시즌 오픈 다이얼로그가 한 번만 나타나도록 수정

UI 화면: 없음