### PR TITLE
[Feat] 쿠폰 상세 조회 API 응답 DTO에 쿠폰 정보 추가

### DIFF
--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/coupon/mapper/CouponMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/coupon/mapper/CouponMapper.kt
@@ -1,7 +1,9 @@
 package com.ilsangtech.ilsang.core.data.coupon.mapper
 
 import com.ilsangtech.ilsang.core.model.coupon.Coupon
+import com.ilsangtech.ilsang.core.model.coupon.QuestDetailCoupon
 import com.ilsangtech.ilsang.core.network.model.coupon.CouponDetailNetworkModel
+import com.ilsangtech.ilsang.core.network.model.coupon.QuestDetailCouponNetworkModel
 
 internal fun CouponDetailNetworkModel.toCoupon(): Coupon {
     return Coupon(
@@ -15,5 +17,16 @@ internal fun CouponDetailNetworkModel.toCoupon(): Coupon {
         description = coupon.description,
         validFrom = coupon.validFrom,
         validTo = coupon.validTo
+    )
+}
+
+internal fun QuestDetailCouponNetworkModel.toQuestDetailCoupon(): QuestDetailCoupon {
+    return QuestDetailCoupon(
+        id = id,
+        name = name,
+        imageId = imageId,
+        storeName = storeName,
+        validTo = validTo,
+        description = description
     )
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/mapper/QuestDetailMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/mapper/QuestDetailMapper.kt
@@ -1,8 +1,10 @@
 package com.ilsangtech.ilsang.core.data.quest.mapper
 
+import com.ilsangtech.ilsang.core.data.coupon.mapper.toQuestDetailCoupon
 import com.ilsangtech.ilsang.core.data.mission.mapper.toMission
 import com.ilsangtech.ilsang.core.model.quest.QuestDetail
 import com.ilsangtech.ilsang.core.model.quest.QuestType
+import com.ilsangtech.ilsang.core.network.model.coupon.QuestDetailCouponNetworkModel
 import com.ilsangtech.ilsang.core.network.model.mission.MissionNetworkModel
 import com.ilsangtech.ilsang.core.network.model.quest.QuestDetailResponse
 import com.ilsangtech.ilsang.core.network.model.quest.RewardPointNetworkModel
@@ -28,6 +30,7 @@ internal fun QuestDetailResponse.toQuestDetail(): QuestDetail {
             else -> throw IllegalArgumentException("Unknown quest type: $questType")
         },
         rewards = rewards.map(RewardPointNetworkModel::toRewardPoint),
+        coupons = coupons.map(QuestDetailCouponNetworkModel::toQuestDetailCoupon),
         title = title,
         userRank = userRank,
         writerName = writerName

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/coupon/QuestDetailCoupon.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/coupon/QuestDetailCoupon.kt
@@ -1,0 +1,10 @@
+package com.ilsangtech.ilsang.core.model.coupon
+
+data class QuestDetailCoupon(
+    val id: Int,
+    val name: String,
+    val imageId: String?,
+    val validTo: String,
+    val storeName: String?,
+    val description: String?
+)

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/quest/QuestDetail.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/quest/QuestDetail.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.core.model.quest
 
+import com.ilsangtech.ilsang.core.model.coupon.QuestDetailCoupon
 import com.ilsangtech.ilsang.core.model.mission.Mission
 import com.ilsangtech.ilsang.core.model.reward.RewardPoint
 
@@ -12,6 +13,7 @@ data class QuestDetail(
     val missions: List<Mission>,
     val questType: QuestType,
     val rewards: List<RewardPoint>,
+    val coupons: List<QuestDetailCoupon>,
     val title: String,
     val userRank: Int?,
     val writerName: String

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/coupon/QuestDetailCouponNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/coupon/QuestDetailCouponNetworkModel.kt
@@ -1,0 +1,13 @@
+package com.ilsangtech.ilsang.core.network.model.coupon
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QuestDetailCouponNetworkModel(
+    val id: Int,
+    val name: String,
+    val imageId: String?,
+    val validTo: String,
+    val storeName: String?,
+    val description: String?
+)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/QuestDetailResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/quest/QuestDetailResponse.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.core.network.model.quest
 
+import com.ilsangtech.ilsang.core.network.model.coupon.QuestDetailCouponNetworkModel
 import com.ilsangtech.ilsang.core.network.model.mission.MissionNetworkModel
 import kotlinx.serialization.Serializable
 
@@ -16,5 +17,6 @@ data class QuestDetailResponse(
     val rewards: List<RewardPointNetworkModel>,
     val title: String,
     val userRank: Int?,
-    val writerName: String
+    val writerName: String,
+    val coupons: List<QuestDetailCouponNetworkModel>
 )

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QuestInfoContent.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QuestInfoContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.ilsangtech.ilsang.core.model.coupon.QuestDetailCoupon
 import com.ilsangtech.ilsang.core.model.mission.Mission
 import com.ilsangtech.ilsang.core.model.quest.QuestDetail
 import com.ilsangtech.ilsang.core.model.quest.QuestType
@@ -133,6 +134,16 @@ internal fun QuestDetailInfoContentPreview() {
             RewardPoint.Metro(2),
             RewardPoint.Commercial(5),
             RewardPoint.Contribute(10)
+        ),
+        coupons = listOf(
+            QuestDetailCoupon(
+                id = 201,
+                name = "10% Off Coupon",
+                imageId = "coupon_image_id",
+                validTo = "2024-12-31",
+                storeName = "Store A",
+                description = "Get 10% off on your next purchase."
+            )
         ),
         title = "일상 공유하고 포인트 받기",
         userRank = 5,

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.core.model.coupon.QuestDetailCoupon
 import com.ilsangtech.ilsang.core.model.mission.Mission
 import com.ilsangtech.ilsang.core.model.quest.QuestDetail
 import com.ilsangtech.ilsang.core.model.quest.QuestType
@@ -215,6 +216,16 @@ fun QuestBottomSheetPreviewQuestDetail() {
                 exampleImageIds = listOf("imageId1", "imageId2"),
                 title = "사진 인증 미션",
                 type = "PHOTO"
+            )
+        ),
+        coupons = listOf(
+            QuestDetailCoupon(
+                id = 1,
+                name = "쿠폰 이름",
+                imageId = "couponImageId",
+                storeName = "쿠폰 가게 이름",
+                validTo = "2023-12-31",
+                description = "쿠폰 설명"
             )
         ),
         questType = QuestType.Normal,


### PR DESCRIPTION
이슈 번호: resolves #231 
작업 사항:
- 쿠폰 상세 조회 API 응답 DTO에 쿠폰 정보 추가

UI 화면: 없음