### PR TITLE
[Feat] 퀘스트 상세 정보 하단시트에 보상 UI 추가 및 쿠폰 보상 다이얼로그 UI 구현

### DIFF
--- a/core/designsystem/src/main/res/drawable/icon_coupon_with_background.xml
+++ b/core/designsystem/src/main/res/drawable/icon_coupon_with_background.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="132dp"
+    android:height="132dp"
+    android:viewportWidth="132"
+    android:viewportHeight="132">
+    <path
+        android:pathData="M66,0L66,0A66,66 0,0 1,132 66L132,66A66,66 0,0 1,66 132L66,132A66,66 0,0 1,0 66L0,66A66,66 0,0 1,66 0z"
+        android:fillColor="#00083D" />
+    <path
+        android:pathData="M107.33,59.47C103.69,59.47 100.75,62.42 100.75,66.05C100.75,69.69 103.69,72.64 107.33,72.64V89.11H25V72.64C28.64,72.64 31.58,69.69 31.58,66.05C31.58,62.42 28.64,59.47 25,59.47V43H107.33V59.47Z"
+        android:fillColor="#5DFA7F" />
+    <path
+        android:pathData="M70,43l-0,46l-8,0l-0,-46z"
+        android:fillColor="#A367F1" />
+</vector>

--- a/core/designsystem/src/main/res/drawable/icon_quest_reward_coupon.xml
+++ b/core/designsystem/src/main/res/drawable/icon_quest_reward_coupon.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportWidth="14"
+    android:viewportHeight="14">
+    <path
+        android:pathData="M1.613,5.648H12.129V12.723C12.129,13.276 11.682,13.723 11.129,13.723H2.613C2.061,13.723 1.613,13.276 1.613,12.723V5.648Z"
+        android:fillColor="#FF0000" />
+    <path
+        android:pathData="M1.4,3.226L12.343,3.226A1,1 0,0 1,13.343 4.226L13.343,5.456A1,1 0,0 1,12.343 6.456L1.4,6.456A1,1 0,0 1,0.4 5.456L0.4,4.226A1,1 0,0 1,1.4 3.226z"
+        android:fillColor="#FF0000" />
+    <path
+        android:pathData="M6.063,3.226h1.618v10.497h-1.618z"
+        android:fillColor="#FFC014" />
+    <path
+        android:pathData="M4.845,1.652L6.872,3.226H3.231V2.442C3.231,1.61 4.188,1.142 4.845,1.652Z"
+        android:fillColor="#FFC014" />
+    <path
+        android:pathData="M8.898,1.652L6.872,3.226H10.512V2.442C10.512,1.61 9.555,1.142 8.898,1.652Z"
+        android:fillColor="#FFC014" />
+</vector>

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/coupon/QuestRewardCouponDialog.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/coupon/QuestRewardCouponDialog.kt
@@ -1,0 +1,144 @@
+package com.ilsangtech.ilsang.core.ui.coupon
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import com.ilsangtech.ilsang.core.model.coupon.QuestDetailCoupon
+import com.ilsangtech.ilsang.core.util.DateConverter
+import com.ilsangtech.ilsang.designsystem.R
+import com.ilsangtech.ilsang.designsystem.theme.gray400
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.heading02
+import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.subTitle01
+import com.ilsangtech.ilsang.designsystem.theme.tapRegularTextStyle
+import com.ilsangtech.ilsang.designsystem.theme.title02
+
+@Composable
+internal fun QuestRewardCouponDialog(
+    coupon: QuestDetailCoupon,
+    onDismissRequest: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismissRequest) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            shape = RoundedCornerShape(12.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "이번 주 특별 보상",
+                        style = heading02
+                    )
+                    Icon(
+                        modifier = Modifier.clickable(
+                            onClick = onDismissRequest,
+                            indication = null,
+                            interactionSource = null
+                        ),
+                        painter = painterResource(R.drawable.icon_close),
+                        tint = gray500,
+                        contentDescription = null
+                    )
+                }
+                Icon(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .size(132.dp),
+                    painter = painterResource(R.drawable.icon_coupon_with_background),
+                    tint = Color.Unspecified,
+                    contentDescription = null
+                )
+                Text(
+                    text = coupon.name,
+                    style = title02
+                )
+                Text(
+                    modifier = Modifier.padding(top = 8.dp),
+                    text = coupon.storeName.orEmpty(),
+                    style = subTitle01,
+                    color = gray500
+                )
+                Text(
+                    modifier = Modifier.padding(top = 8.dp),
+                    text = DateConverter.formatDate(
+                        input = coupon.validTo,
+                        outputPattern = "yyyy.MM.dd HH:mm"
+                    ) + "까지",
+                    style = tapRegularTextStyle,
+                    color = gray400
+                )
+                Button(
+                    modifier = Modifier
+                        .padding(top = 48.dp)
+                        .fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = primary),
+                    contentPadding = PaddingValues(vertical = 16.dp),
+                    onClick = onDismissRequest
+                ) {
+                    Text(
+                        text = "확인",
+                        style = TextStyle(
+                            fontFamily = pretendardFontFamily,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 16.sp,
+                            lineHeight = 18.sp
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun QuestRewardCouponDialogPreview() {
+    val coupon = QuestDetailCoupon(
+        id = 1,
+        name = "아메리카노 1잔 무료",
+        imageId = null,
+        validTo = "2025-12-31T23:59:59",
+        storeName = "스타벅스",
+        description = "맛있는 아메리카노"
+    )
+    QuestRewardCouponDialog(
+        coupon = coupon,
+        onDismissRequest = {}
+    )
+}
+

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QuestRewardCouponCard.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QuestRewardCouponCard.kt
@@ -1,0 +1,80 @@
+package com.ilsangtech.ilsang.core.ui.quest.bottomsheet
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ilsangtech.ilsang.designsystem.R
+import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.designsystem.theme.badge01TextStyle
+import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.tapRegularTextStyle
+
+@Composable
+internal fun QuestRewardCouponCard(
+    modifier: Modifier = Modifier,
+    onRewardButtonClick: () -> Unit
+) {
+    OutlinedCard(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.outlinedCardColors(containerColor = background),
+        border = BorderStroke(width = 1.dp, color = gray100)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                modifier = Modifier.weight(1f),
+                text = "일상존 퀘스트로 \n쿠폰 확률을 높여보세요!",
+                style = tapRegularTextStyle,
+                color = gray500
+            )
+            Button(
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = primary,
+                    contentColor = Color.White
+                ),
+                shape = RoundedCornerShape(12.dp),
+                contentPadding = PaddingValues(vertical = 4.dp, horizontal = 12.dp),
+                onClick = onRewardButtonClick
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.icon_quest_reward_coupon),
+                    tint = Color.Unspecified,
+                    contentDescription = null
+                )
+                Text(
+                    modifier = Modifier.padding(start = 4.dp),
+                    text = "보상 확인",
+                    style = badge01TextStyle
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun QuestRewardCouponCardPreview() {
+    QuestRewardCouponCard {}
+}

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
@@ -19,6 +19,10 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -36,6 +40,7 @@ import com.ilsangtech.ilsang.core.model.mission.Mission
 import com.ilsangtech.ilsang.core.model.quest.QuestDetail
 import com.ilsangtech.ilsang.core.model.quest.QuestType
 import com.ilsangtech.ilsang.core.model.reward.RewardPoint
+import com.ilsangtech.ilsang.core.ui.coupon.QuestRewardCouponDialog
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_regular
 import com.ilsangtech.ilsang.designsystem.R.font.pretendard_semibold
 import com.ilsangtech.ilsang.designsystem.component.IlsangBottomSheet
@@ -55,6 +60,15 @@ fun QuestBottomSheet(
     onApproveButtonClick: () -> Unit,
     onDismiss: () -> Unit,
 ) {
+    var showQuestRewardCouponDialog by remember { mutableStateOf(false) }
+
+    if (showQuestRewardCouponDialog) {
+        QuestRewardCouponDialog(
+            coupon = quest.coupons.first(),
+            onDismissRequest = { showQuestRewardCouponDialog = false }
+        )
+    }
+
     IlsangBottomSheet(
         bottomSheetState = bottomSheetState,
         onDismissRequest = onDismiss
@@ -65,7 +79,8 @@ fun QuestBottomSheet(
         )
         QuestBottomSheetContent(
             quest = quest,
-            onImageClick = onMissionImageClick
+            onImageClick = onMissionImageClick,
+            onRewardButtonClick = { showQuestRewardCouponDialog = true }
         )
         Spacer(Modifier.height(16.dp))
         QuestBottomSheetFooter(onClick = onApproveButtonClick)
@@ -110,7 +125,8 @@ private fun QuestBottomSheetHeader(
 private fun QuestBottomSheetContent(
     modifier: Modifier = Modifier,
     quest: QuestDetail,
-    onImageClick: () -> Unit
+    onImageClick: () -> Unit,
+    onRewardButtonClick: () -> Unit
 ) {
     Column(
         modifier = modifier
@@ -143,6 +159,12 @@ private fun QuestBottomSheetContent(
             }
         }
         ObtainablePointContent(rewardPoints = quest.rewards)
+        if (quest.coupons.isNotEmpty()) {
+            QuestRewardCouponCard(
+                modifier = Modifier.padding(top = 24.dp),
+                onRewardButtonClick = onRewardButtonClick
+            )
+        }
     }
 }
 


### PR DESCRIPTION
이슈 번호: resolves #230 
작업 사항:
- 퀘스트 상세 하단시트 보상 UI 추가
- 쿠폰 보상 다이얼로그 UI 구현

UI 화면: 
<img width="300" alt="Screenshot_20250914_131440" src="https://github.com/user-attachments/assets/9041de46-0207-4790-bd0c-950d3030cd32" /><img width="300" alt="Screenshot_20250914_131451" src="https://github.com/user-attachments/assets/c8781fc8-2168-4707-ad55-13c811926ec9" />
