### PR TITLE
[Fix] 메인 배너 사진 비율 조정

### DIFF
--- a/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/component/BannerDetailInfoContent.kt
+++ b/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/component/BannerDetailInfoContent.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -34,8 +33,7 @@ internal fun LazyListScope.bannerDetailInfoContent(
             AsyncImage(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .aspectRatio(11 / 10f),
-                contentScale = ContentScale.Crop,
+                    .aspectRatio(3 / 2f),
                 model = BuildConfig.IMAGE_URL + imageId,
                 contentDescription = title
             )

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/component/BannerContent.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/component/BannerContent.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -47,13 +46,12 @@ internal fun BannerContent(
             AsyncImage(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .aspectRatio(11 / 10f)
+                    .aspectRatio(3 / 2f)
                     .clickable(
                         onClick = { onClick(banners[page]) },
                         indication = null,
                         interactionSource = null
                     ),
-                contentScale = ContentScale.Crop,
                 model = BuildConfig.IMAGE_URL + banners[page].bannerImageId,
                 contentDescription = banners[page].description
             )


### PR DESCRIPTION
이슈 번호: resolves #234 
작업 사항:
- 배너 사진 이미지 비율을 3 대  2로 조정
- 배너 이미지가 잘리지 않도록 ContentScale을 Fit 타입으로 변경

UI 화면:
<img width="300" alt="Screenshot_20250915_094657" src="https://github.com/user-attachments/assets/cfae14db-6e98-4d9a-b72e-3edc3ed61809" /><img width="300" alt="Screenshot_20250915_094702" src="https://github.com/user-attachments/assets/9b82abba-3549-40e1-bded-ab990ea0b83a" />
