### PR TITLE
[Fix] 랭킹 탭 시즌 선택 UI 수정

### DIFF
--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/SeasonSelector.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/SeasonSelector.kt
@@ -58,9 +58,7 @@ internal fun SeasonSelector(
                 color = gray500
             )
             Icon(
-                painter = painterResource(
-                    if (expanded) R.drawable.icon_under else R.drawable.icon_up
-                ),
+                painter = painterResource(R.drawable.icon_under),
                 contentDescription = null,
                 tint = gray500
             )


### PR DESCRIPTION
이슈 번호: resolves #235 
작업 사항:
- 랭킹 탭 화면의 시즌 선택 UI 에서 화살표 방향이 항상 아래로 향하도록 수정

UI 화면:
<img width="300" alt="Screenshot_20250915_100159" src="https://github.com/user-attachments/assets/fba881d7-2743-4667-8704-44dce3987559" />
