### PR TITLE
[Fix] 시즌 오픈, 일상존 선택 다이얼로그 버그 수정

### DIFF
--- a/app/src/main/java/com/ilsangtech/ilsang/MainActivityViewModel.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/MainActivityViewModel.kt
@@ -35,7 +35,7 @@ class MainActivityViewModel @Inject constructor(
     val isLoggedIn = loginTrigger.flatMapLatest {
         userRepository.getMyInfo()
             .onEach { myInfo ->
-                if (myInfo.isCommercialAreaCode == null && myInfo.showIsZoneDialogAgain) {
+                if (myInfo.showIsZoneDialogAgain) {
                     _shouldShowIsZoneDialog.update { true }
                 }
                 _unreadTitleList.update { titleRepository.getUnreadTitleList() }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/mapper/MyInfoMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/mapper/MyInfoMapper.kt
@@ -1,10 +1,9 @@
 package com.ilsangtech.ilsang.core.data.user.mapper
 
-import com.ilsangtech.ilsang.core.data.title.mapper.toUserTitle
 import com.ilsangtech.ilsang.core.model.MyInfo
-import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
+import com.ilsangtech.ilsang.core.model.UserInfo
 
-fun UserInfoResponse.toMyInfo(
+fun UserInfo.toMyInfo(
     totalPoint: Int,
     myZoneCommercialAreaCode: String,
     showIsZoneDialogAgain: Boolean,
@@ -21,7 +20,7 @@ fun UserInfoResponse.toMyInfo(
         profileImageId = profileImageId,
         status = status,
         statusUpdatedAt = statusUpdatedAt,
-        title = title?.toUserTitle(),
+        title = userTitle,
         showIsZoneDialogAgain = showIsZoneDialogAgain,
         shouldShowSeasonOpenDialog = shouldShowSeasonOpenDialog
     )

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/mapper/UserInfoMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/mapper/UserInfoMapper.kt
@@ -1,6 +1,6 @@
 package com.ilsangtech.ilsang.core.data.user.mapper
 
-import com.ilsangtech.ilsang.core.data.title.mapper.toTitle
+import com.ilsangtech.ilsang.core.data.title.mapper.toUserTitle
 import com.ilsangtech.ilsang.core.model.UserInfo
 import com.ilsangtech.ilsang.core.network.model.user.UserInfoResponse
 
@@ -14,6 +14,6 @@ internal fun UserInfoResponse.toUserInfo(): UserInfo {
         profileImageId = profileImageId,
         status = status,
         statusUpdatedAt = statusUpdatedAt,
-        title = title?.toTitle()
+        userTitle = title?.toUserTitle()
     )
 }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -31,15 +31,15 @@ class UserRepositoryImpl @Inject constructor(
             userDataStore.userMyZone,
             userDataStore.showIsZoneDialogAgain,
             userDataStore.shouldShowSeasonOpenDialog,
-            getUserPoint()
-        ) { myZoneCommercialAreaCode, showIsZoneDialogAgain, shouldShowSeasonOpenDialog, userPoint ->
-            val userInfoResponse = userDataSource.getUserInfo(userId = null)
+            getUserPoint(),
+            getUserInfo(null)
+        ) { myZoneCommercialAreaCode, showIsZoneDialogAgain, shouldShowSeasonOpenDialog, userPoint, userInfo ->
             val totalPoint =
                 userPoint.metroAreaPoint + userPoint.commercialAreaPoint + userPoint.contributionPoint
-            userInfoResponse.toMyInfo(
+            userInfo.toMyInfo(
                 totalPoint = totalPoint,
                 myZoneCommercialAreaCode = myZoneCommercialAreaCode,
-                showIsZoneDialogAgain = showIsZoneDialogAgain,
+                showIsZoneDialogAgain = userInfo.commercialAreaCode == null && showIsZoneDialogAgain,
                 shouldShowSeasonOpenDialog = shouldShowSeasonOpenDialog
             )
         }

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/user/repository/UserRepositoryImpl.kt
@@ -44,7 +44,7 @@ class UserRepositoryImpl @Inject constructor(
             )
         }
 
-    override fun getUserInfo(userId: String): Flow<UserInfo> = flow {
+    override fun getUserInfo(userId: String?): Flow<UserInfo> = flow {
         emit(
             userDataSource.getUserInfo(userId = userId).toUserInfo()
         )

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/UserRepository.kt
@@ -13,7 +13,7 @@ interface UserRepository {
 
     fun getMyInfo(): Flow<MyInfo>
 
-    fun getUserInfo(userId: String): Flow<UserInfo>
+    fun getUserInfo(userId: String? = null): Flow<UserInfo>
 
     fun getUserPoint(userId: String? = null, seasonId: Int? = null): Flow<UserPoint>
 

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/UserInfo.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/UserInfo.kt
@@ -1,6 +1,6 @@
 package com.ilsangtech.ilsang.core.model
 
-import com.ilsangtech.ilsang.core.model.title.Title
+import com.ilsangtech.ilsang.core.model.title.UserTitle
 
 data class UserInfo(
     val id: String,
@@ -11,5 +11,5 @@ data class UserInfo(
     val profileImageId: String?,
     val status: String,
     val statusUpdatedAt: String,
-    val title: Title?
+    val userTitle: UserTitle?
 )

--- a/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/ilsangtech/ilsang/feature/home/HomeViewModel.kt
@@ -141,9 +141,8 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             if (checked) {
                 userRepository.updateShouldShowSeasonOpenDialog(false)
-            } else {
-                _shouldShowSeasonOpenDialog.update { false }
             }
+            _shouldShowSeasonOpenDialog.update { false }
         }
     }
 }

--- a/feature/profile/src/main/java/com/ilsangtech/ilsang/feature/profile/model/UserProfileInfoUiModel.kt
+++ b/feature/profile/src/main/java/com/ilsangtech/ilsang/feature/profile/model/UserProfileInfoUiModel.kt
@@ -14,7 +14,7 @@ internal fun UserInfo.toUserProfileInfoUiModel(point: Int): UserProfileInfoUiMod
     return UserProfileInfoUiModel(
         nickname = nickname,
         profileImageId = profileImageId,
-        title = title,
+        title = userTitle?.title,
         point = point
     )
 }


### PR DESCRIPTION
이슈 번호: resolves #244 
작업 사항:
- 시즌 오프 다이얼로그 다시 보지 않기 선택 시 닫히지 않는 버그 수정
- 일상존 다이얼로그 다시 보지 않기 선택 후 닫을 때 한 번 더 나타나는 버그 수정

UI 화면: 없음