### PR TITLE
[Feat] 사진 인증 화면 UI 구현 및 적용

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,19 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
 
+        <service
+            android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data
+                android:name="photopicker_activity:0:required"
+                android:value="" />
+        </service>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="com.ilsangtech.ilsang.fileprovider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="true" />
+
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.READ_MEDIA_IMAGES"
+        tools:ignore="PhotoAndVideoPolicy" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+
     <application
         android:name=".IlsangApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -63,6 +63,8 @@ import com.ilsangtech.ilsang.feature.profile.navigation.profileRoute
 import com.ilsangtech.ilsang.feature.quest.navigation.questNavigation
 import com.ilsangtech.ilsang.feature.ranking.navigation.SeasonRewardRoute
 import com.ilsangtech.ilsang.feature.ranking.navigation.rankingNavigation
+import com.ilsangtech.ilsang.feature.submit.navigation.ImageSubmitBaseRoute
+import com.ilsangtech.ilsang.feature.submit.navigation.navigateToImageSubmit
 import com.ilsangtech.ilsang.feature.submit.navigation.navigateToSubmit
 import com.ilsangtech.ilsang.feature.submit.navigation.submitNavigation
 import com.ilsangtech.ilsang.feature.tutorial.navigation.tutorialNavigation
@@ -214,7 +216,16 @@ fun IlsangNavHost(
                 popBackStack = navController::popBackStack
             )
 
-            submitNavigation(popBackStack = navController::popBackStack)
+            submitNavigation(
+                navigateToImageSubmit = navController::navigateToImageSubmit,
+                navigateToHomeOrQuest = {
+                    navController.popBackStack(
+                        route = ImageSubmitBaseRoute,
+                        inclusive = true
+                    )
+                },
+                popBackStack = navController::popBackStack
+            )
 
             rankingNavigation(
                 navigateToRankingDetail = { rankingDetailRoute ->

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -57,7 +57,6 @@ dependencies {
     implementation(project(":core:util"))
     implementation(project(":core:ui"))
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.androidx.camera.core)
     implementation(libs.androidx.graphics.shapes)
     implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)

--- a/feature/submit/build.gradle.kts
+++ b/feature/submit/build.gradle.kts
@@ -35,6 +35,12 @@ android {
 
 dependencies {
     implementation(project(":core:ui"))
+
+    implementation(libs.camera.core)
+    implementation(libs.androidx.camera.camera2)
+    implementation(libs.androidx.camera.compose)
+    implementation(libs.androidx.camera.lifecycle)
+    implementation(libs.accompanist.permissions)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureScreen.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureScreen.kt
@@ -1,0 +1,7 @@
+package com.ilsangtech.ilsang.feature.submit
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun ImageCaptureScreen() {
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureScreen.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureScreen.kt
@@ -2,6 +2,9 @@ package com.ilsangtech.ilsang.feature.submit
 
 import android.net.Uri
 import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.compose.CameraXViewfinder
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -71,6 +74,11 @@ internal fun ImageCaptureScreen(
 
     var showCameraPermissionDialog by remember { mutableStateOf(false) }
     var showMediaAccessPermissionDialog by remember { mutableStateOf(false) }
+
+    val pickImage =
+        rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            uri?.let { viewModel.selectGalleryImage(it) }
+        }
 
     val cameraZoom by produceState(1f) {
         viewModel.camera.collect { camera ->
@@ -197,7 +205,13 @@ internal fun ImageCaptureScreen(
                 .padding(start = 30.dp, bottom = 54.dp)
                 .navigationBarsPadding(),
             imageUri = latestImageUri,
-            onClick = {}
+            onClick = {
+                pickImage.launch(
+                    PickVisualMediaRequest(
+                        ActivityResultContracts.PickVisualMedia.ImageOnly
+                    )
+                )
+            }
         )
     }
 }

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureScreen.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureScreen.kt
@@ -1,7 +1,265 @@
 package com.ilsangtech.ilsang.feature.submit
 
+import android.net.Uri
+import android.os.Build
+import androidx.camera.compose.CameraXViewfinder
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.asFlow
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.AsyncImage
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
+import com.google.accompanist.permissions.shouldShowRationale
+import com.ilsangtech.ilsang.designsystem.R
+import com.ilsangtech.ilsang.designsystem.component.ILSANGDialog
+import com.ilsangtech.ilsang.designsystem.theme.background
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+internal fun ImageCaptureScreen(
+    viewModel: ImageCaptureViewModel = viewModel(),
+    navigateToImageSubmit: (String, Int, Int) -> Unit,
+    popBackStack: () -> Unit
+) {
+    val appContext = LocalContext.current.applicationContext
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val mediaAccessPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        android.Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        android.Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+
+    val cameraPermissionState = rememberPermissionState(android.Manifest.permission.CAMERA)
+    val mediaAccessPermissionState = rememberPermissionState(mediaAccessPermission)
+
+    val surfaceRequest by viewModel.surfaceRequest.collectAsStateWithLifecycle()
+    val latestImageUri by viewModel.latestImageUri.collectAsStateWithLifecycle()
+    val selectedImageUri by viewModel.selectedImageUri.collectAsStateWithLifecycle()
+
+    var showCameraPermissionDialog by remember { mutableStateOf(false) }
+    var showMediaAccessPermissionDialog by remember { mutableStateOf(false) }
+
+    val cameraZoom by produceState(1f) {
+        viewModel.camera.collect { camera ->
+            camera?.cameraInfo?.zoomState?.asFlow()?.collect { zoomState ->
+                value = zoomState.zoomRatio
+            }
+        }
+    }
+
+    val cameraState = rememberTransformableState { zoomChange, _, _ ->
+        viewModel.updateCameraZoom(cameraZoom * zoomChange)
+    }
+
+    if (selectedImageUri != null) {
+        navigateToImageSubmit(
+            selectedImageUri.toString(),
+            viewModel.questId,
+            viewModel.missionId
+        )
+        viewModel.clearSelectedImage()
+    }
+
+    if (showCameraPermissionDialog) {
+        ILSANGDialog(
+            title = "카메라 권한",
+            content = "일상은 퀘스트 인증 사진을 촬영하기 위해 카메라 접근 권한이 필요합니다.\n" +
+                    "계속하려면 카메라 접근 권한을 허용해주세요.",
+            positiveButtonText = "허용",
+            negativeButtonText = "허용 안함",
+            onClickPositiveButton = {
+                cameraPermissionState.launchPermissionRequest()
+                showCameraPermissionDialog = false
+            },
+            onClickNegativeButton = {
+                showCameraPermissionDialog = false
+                popBackStack()
+            },
+            onDismissRequest = { showCameraPermissionDialog = false }
+        )
+    }
+
+    if (showMediaAccessPermissionDialog) {
+        ILSANGDialog(
+            title = "앨범 접근 권한",
+            content = "일상은 퀘스트 인증에 필요한 사진을 불러오기 위해 앨범 접근 권한이 필요합니다.",
+            positiveButtonText = "허용",
+            negativeButtonText = "허용 안함",
+            onClickPositiveButton = {
+                mediaAccessPermissionState.launchPermissionRequest()
+                showMediaAccessPermissionDialog = false
+            },
+            onClickNegativeButton = { showMediaAccessPermissionDialog = false },
+            onDismissRequest = { showMediaAccessPermissionDialog = false }
+        )
+    }
+
+    LaunchedEffect(cameraPermissionState.status) {
+        when {
+            cameraPermissionState.status.isGranted -> {
+                viewModel.bindToCamera(appContext, lifecycleOwner)
+            }
+
+            cameraPermissionState.status.shouldShowRationale -> {
+                showCameraPermissionDialog = true
+            }
+
+            else -> {
+                cameraPermissionState.launchPermissionRequest()
+            }
+        }
+    }
+
+    LaunchedEffect(
+        cameraPermissionState.status,
+        mediaAccessPermissionState.status
+    ) {
+        if (cameraPermissionState.status.isGranted) {
+            when {
+                mediaAccessPermissionState.status.isGranted -> {
+                    viewModel.updateLatestImageUri(appContext)
+                }
+
+                mediaAccessPermissionState.status.shouldShowRationale -> {
+                    showMediaAccessPermissionDialog = true
+                }
+
+                else -> {
+                    mediaAccessPermissionState.launchPermissionRequest()
+                }
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+    ) {
+        surfaceRequest?.let { request ->
+            CameraXViewfinder(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .transformable(state = cameraState),
+                surfaceRequest = request
+            )
+        }
+        BackButton(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .statusBarsPadding()
+                .padding(top = 12.dp, start = 15.dp),
+            onClick = popBackStack
+        )
+        ImageCaptureButton(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 40.dp)
+                .navigationBarsPadding(),
+            onClick = { viewModel.captureImage(appContext) }
+        )
+        ImageThumbnailButton(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(start = 30.dp, bottom = 54.dp)
+                .navigationBarsPadding(),
+            imageUri = latestImageUri,
+            onClick = {}
+        )
+    }
+}
 
 @Composable
-internal fun ImageCaptureScreen() {
+private fun ImageCaptureButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = modifier,
+        color = Color.Transparent,
+        shape = CircleShape,
+        onClick = onClick,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(80.dp)
+                .clip(CircleShape)
+                .border(
+                    width = 5.dp,
+                    shape = CircleShape,
+                    color = Color.White
+                )
+        )
+    }
+}
+
+@Composable
+private fun ImageThumbnailButton(
+    modifier: Modifier = Modifier,
+    imageUri: Uri?,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = modifier
+            .size(50.dp)
+            .clip(RoundedCornerShape(8.dp)),
+        color = background,
+        onClick = onClick
+    ) {
+        AsyncImage(
+            model = imageUri,
+            contentScale = ContentScale.Crop,
+            contentDescription = null
+        )
+    }
+}
+
+@Composable
+private fun BackButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Icon(
+        modifier = modifier.clickable(
+            onClick = onClick,
+            indication = null,
+            interactionSource = null
+        ),
+        painter = painterResource(R.drawable.icon_chevron_back),
+        tint = Color.White,
+        contentDescription = null
+    )
 }

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureViewModel.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureViewModel.kt
@@ -111,6 +111,10 @@ class ImageCaptureViewModel @Inject constructor(
         }
     }
 
+    fun selectGalleryImage(uri: Uri) {
+        _selectedImageUri.update { uri }
+    }
+
     fun clearSelectedImage() {
         _selectedImageUri.update { null }
     }

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureViewModel.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureViewModel.kt
@@ -1,0 +1,9 @@
+package com.ilsangtech.ilsang.feature.submit
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ImageCaptureViewModel @Inject constructor() : ViewModel() {
+}

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureViewModel.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageCaptureViewModel.kt
@@ -1,9 +1,122 @@
 package com.ilsangtech.ilsang.feature.submit
 
+import android.content.ContentUris
+import android.content.Context
+import android.net.Uri
+import android.provider.MediaStore
+import android.util.Log
+import androidx.camera.core.Camera
+import androidx.camera.core.CameraSelector.DEFAULT_BACK_CAMERA
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.Preview
+import androidx.camera.core.SurfaceRequest
+import androidx.camera.core.takePicture
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.lifecycle.awaitInstance
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.ilsangtech.ilsang.core.util.FileManager
+import com.ilsangtech.ilsang.feature.submit.navigation.ImageCaptureRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class ImageCaptureViewModel @Inject constructor() : ViewModel() {
+class ImageCaptureViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    val questId = savedStateHandle.toRoute<ImageCaptureRoute>().questId
+    val missionId = savedStateHandle.toRoute<ImageCaptureRoute>().missionId
+
+    private val _surfaceRequest = MutableStateFlow<SurfaceRequest?>(null)
+    val surfaceRequest = _surfaceRequest.asStateFlow()
+
+    val camera = MutableStateFlow<Camera?>(null)
+    private var processCameraProvider: ProcessCameraProvider? = null
+
+    private val cameraPreviewUseCase = Preview.Builder().build().apply {
+        setSurfaceProvider { request ->
+            _surfaceRequest.update { request }
+        }
+    }
+    private val imageCapture = ImageCapture.Builder().build()
+
+    private val _latestImageUri = MutableStateFlow<Uri?>(null)
+    val latestImageUri = _latestImageUri.asStateFlow()
+
+    private val _selectedImageUri = MutableStateFlow<Uri?>(null)
+    val selectedImageUri = _selectedImageUri.asStateFlow()
+
+    suspend fun bindToCamera(appContext: Context, lifecycleOwner: LifecycleOwner) {
+        processCameraProvider = ProcessCameraProvider.awaitInstance(appContext)
+
+        camera.update {
+            processCameraProvider?.bindToLifecycle(
+                lifecycleOwner, DEFAULT_BACK_CAMERA, imageCapture, cameraPreviewUseCase
+            )
+        }
+    }
+
+    fun updateLatestImageUri(appContext: Context) {
+        val projection = arrayOf(
+            MediaStore.Images.Media._ID,
+            MediaStore.Images.Media.DATE_ADDED
+        )
+
+        val sortOrder = "${MediaStore.Images.Media.DATE_ADDED} DESC"
+
+        val cursor = appContext.contentResolver.query(
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+            projection,
+            null,
+            null,
+            sortOrder
+        )
+
+        cursor?.use {
+            if (it.moveToFirst()) {
+                val id = it.getLong(it.getColumnIndexOrThrow(MediaStore.Images.Media._ID))
+                _latestImageUri.update {
+                    ContentUris.withAppendedId(
+                        MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id
+                    )
+                }
+            }
+        }
+    }
+
+    fun updateCameraZoom(zoomLevel: Float) {
+        camera.value?.cameraControl?.setZoomRatio(zoomLevel)
+    }
+
+    fun captureImage(appContext: Context) {
+        viewModelScope.launch {
+            try {
+                val cacheFile = FileManager.createCacheFile(appContext)
+                val outputOptions = ImageCapture.OutputFileOptions.Builder(cacheFile).build()
+
+                val result = imageCapture.takePicture(outputOptions)
+
+                val uri = result.savedUri ?: Uri.fromFile(cacheFile)
+                _selectedImageUri.update { uri }
+            } catch (e: Exception) {
+                Log.e("ImageCapture", "Capture failed", e)
+            }
+        }
+    }
+
+    fun clearSelectedImage() {
+        _selectedImageUri.update { null }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        processCameraProvider?.unbindAll()
+    }
 }

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageSubmitViewModel.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageSubmitViewModel.kt
@@ -1,7 +1,7 @@
 package com.ilsangtech.ilsang.feature.submit
 
 import android.content.Context
-import android.net.Uri
+import androidx.core.net.toUri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -30,8 +30,7 @@ class ImageSubmitViewModel @Inject constructor(
 ) : ViewModel() {
     private val questId = savedStateHandle.toRoute<ImageSubmitRoute>().questId
     private val missionId = savedStateHandle.toRoute<ImageSubmitRoute>().missionId
-    private val _capturedImageUri = MutableStateFlow<Uri?>(null)
-    val capturedImageFile = MutableStateFlow(FileManager.createCacheFile(context)).asStateFlow()
+    val imageUri = savedStateHandle.toRoute<ImageSubmitRoute>().imageUri.toUri()
 
     private val _submitUiState =
         MutableStateFlow<SubmitResultUiState>(SubmitResultUiState.NotSubmitted)
@@ -41,7 +40,7 @@ class ImageSubmitViewModel @Inject constructor(
         viewModelScope.launch {
             _submitUiState.update { SubmitResultUiState.Loading }
             imageRepository.uploadMissionImage(
-                imageBytes = FileManager.getBytesFromFile(context, capturedImageFile.value),
+                imageBytes = FileManager.getBytesFromUri(context, imageUri),
             ).onSuccess { imageId ->
                 missionRepository.submitImageMission(
                     missionId = missionId,
@@ -61,11 +60,5 @@ class ImageSubmitViewModel @Inject constructor(
 
     fun completeSubmit() {
         _submitUiState.update { SubmitResultUiState.NotSubmitted }
-        _capturedImageUri.update { null }
-    }
-
-    override fun onCleared() {
-        capturedImageFile.value.delete()
-        super.onCleared()
     }
 }

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/navigation/SubmitNavigation.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/navigation/SubmitNavigation.kt
@@ -3,16 +3,25 @@ package com.ilsangtech.ilsang.feature.submit.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import com.ilsangtech.ilsang.feature.submit.ImageCaptureScreen
 import com.ilsangtech.ilsang.feature.submit.ImageSubmitScreen
 import com.ilsangtech.ilsang.feature.submit.OxQuizSubmitScreen
 import com.ilsangtech.ilsang.feature.submit.WordsQuizSubmitScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object SubmitBaseRoute
+data object ImageSubmitBaseRoute
+
+@Serializable
+data class ImageCaptureRoute(
+    val questId: Int,
+    val missionId: Int
+)
 
 @Serializable
 data class ImageSubmitRoute(
+    val imageUri: String,
     val questId: Int,
     val missionId: Int
 )
@@ -35,15 +44,28 @@ fun NavHostController.navigateToSubmit(
     type: String
 ) {
     when (type) {
-        "PHOTO" -> navigate(ImageSubmitRoute(questId, missionId))
+        "PHOTO" -> navigate(ImageCaptureRoute(questId, missionId))
         "OX" -> navigate(OxQuizSubmitRoute(questId, missionId))
         "WORDS" -> navigate(WordsQuizSubmitRoute(questId, missionId))
     }
 }
 
-fun NavGraphBuilder.submitNavigation(popBackStack: () -> Unit) {
-    composable<ImageSubmitRoute> {
-        ImageSubmitScreen(onDismiss = popBackStack)
+fun NavHostController.navigateToImageSubmit(
+    imageUri: String,
+    questId: Int,
+    missionId: Int
+) = navigate(ImageSubmitRoute(imageUri, questId, missionId))
+
+fun NavGraphBuilder.submitNavigation(
+    navigateToImageSubmit: (String, Int, Int) -> Unit,
+    navigateToHomeOrQuest: () -> Unit,
+    popBackStack: () -> Unit
+) {
+    navigation<ImageSubmitBaseRoute>(startDestination = ImageCaptureRoute::class) {
+        composable<ImageCaptureRoute> {
+        }
+        composable<ImageSubmitRoute> {
+        }
     }
     composable<OxQuizSubmitRoute> {
         OxQuizSubmitScreen(onBackButtonClick = popBackStack)

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/navigation/SubmitNavigation.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/navigation/SubmitNavigation.kt
@@ -63,8 +63,16 @@ fun NavGraphBuilder.submitNavigation(
 ) {
     navigation<ImageSubmitBaseRoute>(startDestination = ImageCaptureRoute::class) {
         composable<ImageCaptureRoute> {
+            ImageCaptureScreen(
+                navigateToImageSubmit = navigateToImageSubmit,
+                popBackStack = popBackStack
+            )
         }
         composable<ImageSubmitRoute> {
+            ImageSubmitScreen(
+                onSubmitSuccess = navigateToHomeOrQuest,
+                popBackStack = popBackStack
+            )
         }
     }
     composable<OxQuizSubmitRoute> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,15 +30,21 @@ appcompat = "1.7.0"
 material = "1.12.0"
 jetbrainsKotlinJvm = "2.0.0"
 exifinterface = "1.3.6"
+camerax = "1.5.0"
+accompanist = "0.37.3"
 ksp = "2.0.21-1.0.27"
 
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camerax" }
+androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }
+androidx-camera-compose = { module = "androidx.camera:camera-compose", version.ref = "camerax" }
+camera-core = { module = "androidx.camera:camera-core", version.ref = "camerax" }
+accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 compose-compiler-gradle-plugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 plugin-kotlin-serializationPlugin = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 
-androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "cameraCore" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "splashScreen" }
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "credentialsPlayServicesAuth" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 agp = "8.8.0"
-cameraCore = "1.4.2"
 coilCompose = "3.1.0"
 credentialsPlayServicesAuth = "1.5.0"
 datastorePreferences = "1.1.7"


### PR DESCRIPTION
이슈 번호: resolves https://github.com/TeamFair/ILSANG-Android/issues/240
작업 사항:

- 사진 활영 함수와 차진 제출 화면 라우트를 분리
- 사진 촬영과  미디어 접근을 위한 권한 요청
- 촬영 버튼 클릭 시 촬영된 사진으로 제출할 수 있도록 구현

UI 화면: 없음