### PR TITLE
[Feat] 칭호 설정하기 화면 UI 수정

### DIFF
--- a/core/designsystem/src/main/java/com/ilsangtech/ilsang/designsystem/component/Dialog.kt
+++ b/core/designsystem/src/main/java/com/ilsangtech/ilsang/designsystem/component/Dialog.kt
@@ -39,7 +39,6 @@ fun ILSANGDialog(
     title: String,
     content: String,
     buttonText: String,
-    onClickButton: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
     Dialog(
@@ -83,7 +82,7 @@ fun ILSANGDialog(
                 ILSANGButton(
                     modifier = Modifier.fillMaxWidth(),
                     text = buttonText,
-                    onClick = onClickButton,
+                    onClick = onDismissRequest,
                     colors = ButtonDefaults.buttonColors(containerColor = primary)
                 )
             }
@@ -263,7 +262,6 @@ fun ILSANGDialogPreview() {
         title = "알럿 타이틀을 입력하세요",
         content = "내용을 입력하세요내용을 입력하세요내용을 입력하세요내용을 입력하세요",
         buttonText = "확인",
-        onClickButton = {},
         onDismissRequest = {}
     )
 }

--- a/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/component/IsZoneSuccessDialog.kt
+++ b/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/component/IsZoneSuccessDialog.kt
@@ -15,8 +15,7 @@ internal fun IsZoneSuccessDialog(
         title = "일상존이 설정되었습니다.",
         content = "퀘스트를 수행하러 가 볼까요?",
         buttonText = "확인",
-        onDismissRequest = onDismissRequest,
-        onClickButton = onDismissRequest
+        onDismissRequest = onDismissRequest
     )
 
 }

--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/MyTitleScreen.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/MyTitleScreen.kt
@@ -42,6 +42,7 @@ import com.ilsangtech.ilsang.designsystem.theme.toSp
 import com.ilsangtech.ilsang.feature.my.R
 import com.ilsangtech.ilsang.feature.my.screens.title.component.MyTitleHeader
 import com.ilsangtech.ilsang.feature.my.screens.title.component.MyTitleUpdateDialog
+import com.ilsangtech.ilsang.feature.my.screens.title.component.MyTitleUpdateConfirmDialog
 import com.ilsangtech.ilsang.feature.my.screens.title.component.TitleTypeChipRow
 import com.ilsangtech.ilsang.feature.my.screens.title.component.TypeTitleListHeader
 import com.ilsangtech.ilsang.feature.my.screens.title.component.typeTitleList
@@ -74,7 +75,7 @@ internal fun MyTitleScreen(
     )
 
     if (showUpdateDialog) {
-        MyTitleUpdateDialog(
+        MyTitleUpdateConfirmDialog(
             onUpdateButtonClick = myTitleViewModel::updateUserTitle,
             onDismissRequest = { showUpdateDialog = false }
         )

--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/component/MyTitleUpdateConfirmDialog.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/component/MyTitleUpdateConfirmDialog.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import com.ilsangtech.ilsang.designsystem.component.ILSANGDialog
 
 @Composable
-internal fun MyTitleUpdateDialog(
+internal fun MyTitleUpdateConfirmDialog(
     onUpdateButtonClick: () -> Unit,
     onDismissRequest: () -> Unit
 ) {

--- a/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/component/MyTitleUpdateSuccessDialog.kt
+++ b/feature/my/src/main/java/com/ilsangtech/ilsang/feature/my/screens/title/component/MyTitleUpdateSuccessDialog.kt
@@ -1,0 +1,24 @@
+package com.ilsangtech.ilsang.feature.my.screens.title.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.ilsangtech.ilsang.designsystem.component.ILSANGDialog
+
+@Composable
+internal fun MyTitleUpdateSuccessDialog(
+    onDismissRequest: () -> Unit
+) {
+    ILSANGDialog(
+        title = "칭호가 설정되었습니다",
+        content = "퀘스트를 수행하고 다른 칭호도 획득해 보세요!",
+        buttonText = "확인",
+        onDismissRequest = onDismissRequest
+    )
+}
+
+@Preview
+@Composable
+private fun MyTitleUpdateSuccessDialogPreview() {
+    MyTitleUpdateSuccessDialog(onDismissRequest = {})
+}
+


### PR DESCRIPTION
이슈 번호: resolves #247 
작업 사항:
- 칭호 설정하기 화면에서 선택한 칭호가 현재 설정되어 있는 칭호와 다를 경우, 칭호 설정 버튼 표시
- 칭호 설정 버튼 클릭 시, 칭호 설정 기능 동작

UI 화면:
<img width="300" alt="Screenshot_20250918_152902" src="https://github.com/user-attachments/assets/5fce09ce-6506-4677-920d-03a563ccb503" /><img width="300" alt="Screenshot_20250918_152917" src="https://github.com/user-attachments/assets/be223076-c23c-4ae9-88a0-dd260ccee76c" />
