### PR TITLE
[Design] 시즌 오픈 팝업 다이얼로그 닫기 버튼 색상 수정

### DIFF
--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/season/SeasonOpenDialog.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/season/SeasonOpenDialog.kt
@@ -109,7 +109,7 @@ fun SeasonOpenDialog(
                             onClick = { onDismissRequest(checked) }
                         ),
                     painter = painterResource(R.drawable.icon_close),
-                    tint = Color.Unspecified,
+                    tint = Color.White,
                     contentDescription = "닫기 버튼"
                 )
                 Column(


### PR DESCRIPTION
이슈 번호: resolves #253
작업 사항:
- 시즌 오픈 팝업 다이얼로그의 닫기 버튼을 흰색으로 적용

UI 화면:
<img width="300" alt="Screenshot_20250919_130751" src="https://github.com/user-attachments/assets/ecd55a2c-2b3d-4df0-a272-590969ea82d2" />
