### PR TITLE
[Fix] 일상존, 내지역 선택 UI 변경

### DIFF
--- a/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneScreen.kt
+++ b/feature/iszone/src/main/java/com/ilsangtech/ilsang/feature/iszone/IsZoneScreen.kt
@@ -96,7 +96,7 @@ private fun IsZoneScreen(
                 ZoneListContent(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(horizontal = 20.dp),
+                        .padding(end = 20.dp),
                     areaList = areaList,
                     selectedMetroArea = selectedMetroArea,
                     selectedCommercialArea = selectedCommercialArea,

--- a/feature/myzone/src/main/java/com/ilsangtech/ilsang/feature/myzone/MyZoneScreen.kt
+++ b/feature/myzone/src/main/java/com/ilsangtech/ilsang/feature/myzone/MyZoneScreen.kt
@@ -77,7 +77,7 @@ private fun MyZoneScreen(
                 ZoneListContent(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(horizontal = 20.dp),
+                        .padding(end = 20.dp),
                     areaList = areaList,
                     selectedMetroArea = selectedMetroArea,
                     selectedCommercialArea = selectedCommercialArea,

--- a/feature/myzone/src/main/java/com/ilsangtech/ilsang/feature/myzone/component/MyZoneHeader.kt
+++ b/feature/myzone/src/main/java/com/ilsangtech/ilsang/feature/myzone/component/MyZoneHeader.kt
@@ -44,7 +44,7 @@ internal fun MyZoneHeader(
         )
         Text(
             modifier = Modifier.align(Alignment.Center),
-            text = "지역 선택하기",
+            text = "지역 선택",
             style = TextStyle(
                 fontFamily = pretendardFontFamily,
                 fontWeight = FontWeight.Bold,


### PR DESCRIPTION
이슈 번호: resolves #257 
작업 사항:
- 일상존, 내 지역 선택 화면에서 지역 선택 UI의 좌측 여백 제거
- 내 지역 선택 화면 헤더 텍스트를 '지역 선택'으로 변경

UI 화면:
<img width="300" alt="Screenshot_20250922_093229" src="https://github.com/user-attachments/assets/242dea5d-9fb8-455b-990d-d2ad46622ce6" />
