### PR TITLE
[Fix] 랭킹 탭 화면 시즌 종료까지 남은 시간 버그 수정

### DIFF
--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailScreen.kt
@@ -85,7 +85,7 @@ private fun RankingDetailScreen(
     onSeasonFinished: () -> Unit
 ) {
     val endDate = remember(currentSeason) {
-        SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
             .parse(currentSeason.endDate)
     }
 

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailViewModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingDetailViewModel.kt
@@ -65,11 +65,11 @@ class RankingDetailViewModel @Inject constructor(
                     seasonNumber = currentSeason.seasonNumber,
                     startDate = DateConverter.formatDate(
                         input = currentSeason.startDate,
-                        outputPattern = "yyyy-MM-dd"
+                        outputPattern = "yyyy-MM-dd'T'HH:mm:ss"
                     ),
                     endDate = DateConverter.formatDate(
                         input = currentSeason.endDate,
-                        outputPattern = "yyyy-MM-dd"
+                        outputPattern = "yyyy-MM-dd'T'HH:mm:ss"
                     )
                 ),
                 areaRankUiModel = areaRankUiModel,

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabScreen.kt
@@ -121,7 +121,7 @@ private fun RankingTabScreen(
     var expanded by remember { mutableStateOf(false) }
     val endDate = remember(currentSeason) {
         currentSeason?.let {
-            SimpleDateFormat("yyyy.MM.dd", Locale.getDefault())
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
                 .parse(currentSeason.endDate)
         }
     }

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabViewModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/RankingTabViewModel.kt
@@ -49,7 +49,8 @@ class RankingTabViewModel @Inject constructor(
         )
 
     val currentSeason = refreshTrigger.map {
-        seasonRepository.getCurrentSeason().toSeasonUiModel()
+        seasonRepository.getCurrentSeason()
+            .toSeasonUiModel(datePattern = "yyyy-MM-dd'T'HH:mm:ss")
     }
         .catch { }
         .stateIn(

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/RankingTabBanner.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/component/RankingTabBanner.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.core.util.DateConverter
 import com.ilsangtech.ilsang.designsystem.R
 import com.ilsangtech.ilsang.designsystem.theme.caption02
 import com.ilsangtech.ilsang.designsystem.theme.payboocFontFamily
@@ -65,7 +66,8 @@ internal fun RankingTabBanner(
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = "${season.startDate}~${season.endDate}",
+                    text = DateConverter.formatDate(season.startDate) +
+                            "~" + DateConverter.formatDate(season.endDate),
                     style = TextStyle(
                         fontFamily = payboocFontFamily,
                         fontWeight = FontWeight.Medium,
@@ -141,12 +143,12 @@ internal fun RankingTabBanner(
 
 @Preview
 @Composable
-private fun RankingTabBannerPreview() {
+internal fun RankingTabBannerPreview() {
     val season = SeasonUiModel.Season(
         seasonId = 1,
         seasonNumber = 1,
-        startDate = "2023.01.01",
-        endDate = "2023.03.31"
+        startDate = "2025-01-01T00:00:00",
+        endDate = "2025-12-31T23:59:59"
     )
     RankingTabBanner(
         season = season,

--- a/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/SeasonUiModel.kt
+++ b/feature/ranking/src/main/java/com/ilsangtech/ilsang/feature/ranking/model/SeasonUiModel.kt
@@ -22,11 +22,17 @@ sealed interface SeasonUiModel {
     }
 }
 
-internal fun Season.toSeasonUiModel(): SeasonUiModel.Season {
+internal fun Season.toSeasonUiModel(datePattern: String? = null): SeasonUiModel.Season {
     return SeasonUiModel.Season(
         seasonId = id,
         seasonNumber = seasonNumber,
-        startDate = DateConverter.formatDate(startDate),
-        endDate = DateConverter.formatDate(endDate)
+        startDate = DateConverter.formatDate(
+            input = startDate,
+            outputPattern = datePattern ?: "yyyy.MM.dd"
+        ),
+        endDate = DateConverter.formatDate(
+            input = endDate,
+            outputPattern = datePattern ?: "yyyy.MM.dd"
+        )
     )
 }


### PR DESCRIPTION
이슈 번호: resolves #263 
작업 사항:
- 랭킹 탭, 상세 화면 타이머 시간 표기 버그 수정

UI 화면: 없음