### PR TITLE
[Feat] 퀘스트 탭 화면 완료 탭 제거

### DIFF
--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabScreen.kt
@@ -33,7 +33,6 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.ilsangtech.ilsang.core.model.quest.QuestDetail
 import com.ilsangtech.ilsang.core.model.quest.QuestType
 import com.ilsangtech.ilsang.core.model.quest.TypedQuest
-import com.ilsangtech.ilsang.core.ui.quest.CompletedQuestCard
 import com.ilsangtech.ilsang.core.ui.quest.QuestCardWithFavorite
 import com.ilsangtech.ilsang.core.ui.quest.bottomsheet.QuestBottomSheet
 import com.ilsangtech.ilsang.core.ui.zone.MyZoneSelector
@@ -119,7 +118,7 @@ private fun QuestTabScreen(
     onMissionImageClick: (Int?) -> Unit,
     onDismissRequest: () -> Unit
 ) {
-    if (selectedQuest != null && selectedQuestTab != QuestTabUiModel.COMPLETED) {
+    if (selectedQuest != null) {
         QuestBottomSheet(
             quest = selectedQuest,
             bottomSheetState = bottomSheetState,
@@ -184,23 +183,16 @@ private fun QuestTabScreen(
                             items(typedQuests.itemCount) { index ->
                                 val quest = typedQuests[index]
                                 quest?.let {
-                                    if (selectedQuestTab == QuestTabUiModel.COMPLETED) {
-                                        CompletedQuestCard(
-                                            quest = quest,
-                                            onClick = { onQuestClick(quest.questId) }
-                                        )
-                                    } else {
-                                        QuestCardWithFavorite(
-                                            quest = quest,
-                                            onFavoriteClick = {
-                                                onFavoriteClick(
-                                                    quest.questId,
-                                                    quest.favoriteYn
-                                                )
-                                            },
-                                            onClick = { onQuestClick(quest.questId) }
-                                        )
-                                    }
+                                    QuestCardWithFavorite(
+                                        quest = quest,
+                                        onFavoriteClick = {
+                                            onFavoriteClick(
+                                                quest.questId,
+                                                quest.favoriteYn
+                                            )
+                                        },
+                                        onClick = { onQuestClick(quest.questId) }
+                                    )
                                 }
                             }
                             item { Spacer(Modifier.height(64.dp)) }

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabViewModel.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/QuestTabViewModel.kt
@@ -167,7 +167,6 @@ class QuestTabViewModel @Inject constructor(
                 QuestTabUiModel.NORMAL -> normalQuests
                 QuestTabUiModel.REPEAT -> repeatQuests
                 QuestTabUiModel.EVENT -> eventQuests
-                QuestTabUiModel.COMPLETED -> completedQuests
             }
         }.combine(favoriteQuestSet) { typedQuests, favoriteQuestSet ->
             typedQuests.map {

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/component/EmptyQuestContent.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/component/EmptyQuestContent.kt
@@ -34,14 +34,7 @@ fun EmptyQuestContent(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            val (headingText, subText) =
-                if (selectedQuestType != QuestTabUiModel.COMPLETED) {
-                    "퀘스트를 모두 완료하셨어요!" to "상상할 수 없는 퀘스트를 준비중이니\n" +
-                            "다음 업데이트를 기대해주세요!"
-                } else {
-                    "완료된 퀘스트가 없어요" to "퀘스트를 수행하러 가볼까요?"
-                }
-
+            val (headingText, subText) = "완료된 퀘스트가 없어요" to "퀘스트를 수행하러 가볼까요?"
             Text(
                 text = headingText,
                 textAlign = TextAlign.Center,

--- a/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/model/QuestTabUiModel.kt
+++ b/feature/quest/src/main/java/com/ilsangtech/ilsang/feature/quest/model/QuestTabUiModel.kt
@@ -9,8 +9,5 @@ enum class QuestTabUiModel {
     },
     EVENT {
         override fun toString() = "이벤트"
-    },
-    COMPLETED {
-        override fun toString() = "완료"
     }
 }


### PR DESCRIPTION
이슈 번호: resolves #267 
작업 사항:
- 퀘스트 탭 화면에 존재하는 완료 탭 제거

UI 화면:
<img width="300" alt="Screenshot_20251013_090716" src="https://github.com/user-attachments/assets/0706800d-d2e7-42e8-b2ac-cc4c37a76d64" />
