### PR TITLE
[Fix] 배너 상세 화면 완료 탭 퀘스트 미노출 버그 수정

### DIFF
--- a/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/BannerDetailViewModel.kt
+++ b/feature/banner/src/main/java/com/ilsangtech/ilsang/feature/banner/BannerDetailViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import androidx.paging.cachedIn
-import androidx.paging.filter
 import androidx.paging.map
 import com.ilsangtech.ilsang.core.domain.QuestRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
@@ -108,7 +107,6 @@ class BannerDetailViewModel @Inject constructor(
             isZoneCode = isZoneCode
         )
     }.cachedIn(viewModelScope)
-        .map { it.filter { quest -> quest.lastCompleteDate == null } }
         .map { pagingData ->
             pagingData.map(BannerQuest::toUiModel)
         }


### PR DESCRIPTION
이슈 번호: resolves #279 
작업 사항:
- 배너 상세 화면에서 완료 탭의 퀘스트가 노출되지 않는 버그 수정

UI 화면:
<img width="360" alt="Screenshot_20251108_114139" src="https://github.com/user-attachments/assets/2059e8dc-1640-4111-af0f-574afe879c06" />
