### PR TITLE
[Feat] 퀘스트 상세 하단 시트에 퀘스트 요약 UI 추가

### DIFF
--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/MissionDescriptionCard.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/MissionDescriptionCard.kt
@@ -1,0 +1,54 @@
+package com.ilsangtech.ilsang.core.ui.quest.bottomsheet
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.designsystem.theme.caption01
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.heading02
+
+@Composable
+internal fun MissionDescriptionCard(
+    modifier: Modifier = Modifier,
+    missionTitle: String
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = background),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = "퀘스트 요약",
+                style = heading02,
+                color = gray500
+            )
+            Text(
+                text = missionTitle,
+                style = caption01,
+                color = gray500
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun MissionDescriptionCardPreview() {
+    MissionDescriptionCard(
+        missionTitle = "서현역 내부 또는 연결구간에서 특이한 패널·격자·기하 구조가 드러난 지점 촬영"
+    )
+}

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/MissionDescriptionCard.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/MissionDescriptionCard.kt
@@ -1,6 +1,5 @@
 package com.ilsangtech.ilsang.core.ui.quest.bottomsheet
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -15,7 +14,7 @@ import androidx.compose.ui.unit.dp
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.designsystem.theme.caption01
 import com.ilsangtech.ilsang.designsystem.theme.gray500
-import com.ilsangtech.ilsang.designsystem.theme.heading02
+import com.ilsangtech.ilsang.designsystem.theme.heading03
 
 @Composable
 internal fun MissionDescriptionCard(
@@ -27,13 +26,11 @@ internal fun MissionDescriptionCard(
         colors = CardDefaults.cardColors(containerColor = background),
         shape = RoundedCornerShape(12.dp)
     ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
+        Column(modifier = Modifier.padding(16.dp)) {
             Text(
+                modifier = Modifier.padding(vertical = 3.dp),
                 text = "퀘스트 요약",
-                style = heading02,
+                style = heading03,
                 color = gray500
             )
             Text(

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/MissionDescriptionCard.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/MissionDescriptionCard.kt
@@ -9,9 +9,9 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.designsystem.theme.caption01
 import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.designsystem.theme.heading03
@@ -23,7 +23,7 @@ internal fun MissionDescriptionCard(
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = background),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFF8F8F8)),
         shape = RoundedCornerShape(12.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
@@ -85,7 +85,7 @@ fun QuestBottomSheet(
             onRewardButtonClick = { showQuestRewardCouponDialog = true }
         )
         Spacer(Modifier.height(16.dp))
-        QuestBottomSheetFooter(
+        QuestBottomSheetButton(
             enabled = quest.isAvailable,
             onClick = onApproveButtonClick
         )
@@ -173,44 +173,39 @@ private fun QuestBottomSheetContent(
                 onRewardButtonClick = onRewardButtonClick
             )
         }
-    }
-}
-
-@Composable
-private fun QuestBottomSheetFooter(
-    enabled: Boolean,
-    onClick: () -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
         Text(
+            modifier = Modifier.padding(top = 8.dp),
             text = "퀘스트를 수행하셨나요?\n" +
                     "인증 후 포인트를 적립받으세요",
             textAlign = TextAlign.Center,
             style = questBottomSheetDescriptionTextStyle
         )
-        Button(
-            modifier = Modifier.fillMaxWidth(),
-            enabled = enabled,
-            shape = RoundedCornerShape(12.dp),
-            colors = ButtonDefaults.buttonColors(
-                disabledContainerColor = gray300,
-                containerColor = primary,
-                disabledContentColor = Color.White
-            ),
-            contentPadding = PaddingValues(vertical = 16.dp),
-            onClick = onClick
-        ) {
-            Text(
-                text = "퀘스트 인증하기",
-                style = questBottomSheetApproveButtonTextStyle
-            )
-        }
+    }
+}
+
+@Composable
+private fun QuestBottomSheetButton(
+    enabled: Boolean,
+    onClick: () -> Unit
+) {
+    Button(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        enabled = enabled,
+        shape = RoundedCornerShape(12.dp),
+        colors = ButtonDefaults.buttonColors(
+            disabledContainerColor = gray300,
+            containerColor = primary,
+            disabledContentColor = Color.White
+        ),
+        contentPadding = PaddingValues(vertical = 16.dp),
+        onClick = onClick
+    ) {
+        Text(
+            text = "퀘스트 인증하기",
+            style = questBottomSheetApproveButtonTextStyle
+        )
     }
 }
 

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -80,6 +82,9 @@ fun QuestBottomSheet(
             onFavoriteClick = onFavoriteClick
         )
         QuestBottomSheetContent(
+            modifier = Modifier
+                .weight(weight = 1f, fill = false)
+                .verticalScroll(rememberScrollState()),
             quest = quest,
             onImageClick = onMissionImageClick,
             onRewardButtonClick = { showQuestRewardCouponDialog = true }

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
@@ -141,6 +141,11 @@ private fun QuestBottomSheetContent(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         QuestInfoContent(quest = quest)
+        if (quest.missions.firstOrNull() != null
+            && quest.missions.first().type == MissionType.Photo
+        ) {
+            MissionDescriptionCard(missionTitle = quest.missions.first().title)
+        }
         Row(modifier = Modifier.fillMaxWidth()) {
             if (quest.missions.firstOrNull()?.type == MissionType.Photo) {
                 val imageIds = if (quest.questType is QuestType.Repeat) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolves #290 

## 📝작업 내용

>  이미지 퀘스트의 경우 하단 시트에 퀘스트 요약 카드 UI가 적용되도록 하였습니다.

### 스크린샷 (선택)
|피그마|개발 화면|
|------|--------|
|<img width="360" alt="image" src="https://github.com/user-attachments/assets/a0e357e6-79dc-42fe-a9c3-65f3712a042d" />|<img width="360" alt="Screenshot_20251117_114002" src="https://github.com/user-attachments/assets/97672725-bac5-4570-ac6c-f3e62dc9d87f" />|
