### PR TITLE
[Design] 신고하기 화면 UI 수정

### DIFF
--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ReportScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ReportScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
@@ -101,7 +102,9 @@ private fun ReportScreen(
                 }
                 Spacer(Modifier.weight(1f))
                 Button(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .navigationBarsPadding(),
                     shape = RoundedCornerShape(12.dp),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = primary,

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ReportResultDialog.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ReportResultDialog.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.feature.approval.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -60,6 +61,11 @@ internal fun ReportResultDialog(
                         style = heading02
                     )
                     Icon(
+                        modifier = Modifier.clickable(
+                            onClick = onDismissRequest,
+                            indication = null,
+                            interactionSource = null
+                        ),
                         painter = painterResource(R.drawable.icon_close),
                         tint = gray500,
                         contentDescription = null
@@ -97,7 +103,7 @@ internal fun ReportResultDialog(
                     shape = RoundedCornerShape(12.dp),
                     colors = ButtonDefaults.buttonColors(containerColor = primary),
                     contentPadding = PaddingValues(vertical = 16.dp),
-                    onClick = {}
+                    onClick = onDismissRequest
                 ) {
                     Text(
                         text = "확인",


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolves #301 

## 📝작업 내용

> 신고하기 화면 하단 버튼에 패딩을 적용하고, 결과 다이얼로그 버튼에 클릭 액션을 적용했습니다.

### 스크린샷 (선택)
