### PR TITLE
[Feat] 댓글 관련 UI 컴포넌트 구현

### DIFF
--- a/core/designsystem/src/main/res/drawable/icon_delete.xml
+++ b/core/designsystem/src/main/res/drawable/icon_delete.xml
@@ -1,0 +1,42 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="15dp"
+    android:height="15dp"
+    android:viewportWidth="15"
+    android:viewportHeight="15">
+    <path
+        android:strokeWidth="1"
+        android:pathData="M1.875,3.75H3.125H13.125"
+        android:strokeAlpha="0.8"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#575B6C"
+        android:fillAlpha="0.8"
+        android:strokeLineCap="square" />
+    <path
+        android:strokeWidth="1"
+        android:pathData="M11.875,3.75V12.5C11.875,12.832 11.743,13.149 11.509,13.384C11.274,13.618 10.957,13.75 10.625,13.75H4.375C4.043,13.75 3.726,13.618 3.491,13.384C3.257,13.149 3.125,12.832 3.125,12.5V3.75M5,3.75V2.5C5,2.168 5.132,1.851 5.366,1.616C5.601,1.382 5.918,1.25 6.25,1.25H8.75C9.082,1.25 9.399,1.382 9.634,1.616C9.868,1.851 10,2.168 10,2.5V3.75"
+        android:strokeAlpha="0.8"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#575B6C"
+        android:fillAlpha="0.8"
+        android:strokeLineCap="round" />
+    <path
+        android:strokeWidth="1"
+        android:pathData="M6.25,6.875V10.625"
+        android:strokeAlpha="0.8"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#575B6C"
+        android:fillAlpha="0.8"
+        android:strokeLineCap="round" />
+    <path
+        android:strokeWidth="1"
+        android:pathData="M8.75,6.875V10.625"
+        android:strokeAlpha="0.8"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:strokeColor="#575B6C"
+        android:fillAlpha="0.8"
+        android:strokeLineCap="round" />
+</vector>

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentAlertDialog.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentAlertDialog.kt
@@ -1,0 +1,28 @@
+package com.ilsangtech.ilsang.feature.approval.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.ilsangtech.ilsang.designsystem.component.ILSANGDialog
+import com.ilsangtech.ilsang.feature.approval.model.CommentAlertUiState
+
+@Composable
+internal fun CommentAlertDialog(
+    modifier: Modifier = Modifier,
+    uiState: CommentAlertUiState,
+    onDismissRequest: () -> Unit
+) {
+    ILSANGDialog(
+        modifier = modifier,
+        title = "댓글 입력",
+        content = uiState.toString(),
+        buttonText = "확인",
+        onDismissRequest = onDismissRequest
+    )
+}
+
+@Preview
+@Composable
+private fun CommentAlertDialogPreview() {
+    CommentAlertDialog(uiState = CommentAlertUiState.TooLong) { }
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentItem.kt
@@ -1,0 +1,310 @@
+package com.ilsangtech.ilsang.feature.approval.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import coil3.compose.AsyncImage
+import com.ilsangtech.ilsang.core.model.comment.CommentWriter
+import com.ilsangtech.ilsang.core.model.title.Title
+import com.ilsangtech.ilsang.core.model.title.TitleGrade
+import com.ilsangtech.ilsang.core.model.title.TitleType
+import com.ilsangtech.ilsang.core.ui.BuildConfig
+import com.ilsangtech.ilsang.core.ui.title.TitleGradeIcon
+import com.ilsangtech.ilsang.designsystem.R
+import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.designsystem.theme.badge01TextStyle
+import com.ilsangtech.ilsang.designsystem.theme.caption01
+import com.ilsangtech.ilsang.designsystem.theme.caption02
+import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.gray500
+import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
+import com.ilsangtech.ilsang.designsystem.theme.primary300
+import com.ilsangtech.ilsang.designsystem.theme.subTitle02
+import com.ilsangtech.ilsang.designsystem.theme.tapBoldTextStyle
+import com.ilsangtech.ilsang.feature.approval.model.CommentUiModel
+
+@Composable
+internal fun CommentItem(
+    modifier: Modifier = Modifier,
+    comment: CommentUiModel,
+    onCommentButtonClick: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = 144.dp)
+            .background(
+                if (comment.parentId == null) {
+                    Color.White
+                } else {
+                    background
+                }
+            )
+    ) {
+        when {
+            comment.isReported -> {
+                Text(
+                    text = "신고 누적으로 숨겨진 댓글입니다.",
+                    style = subTitle02,
+                    color = gray500,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            comment.isDeleted -> {
+                Text(
+                    text = "삭제된 댓글입니다.",
+                    style = subTitle02,
+                    color = gray500,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            else -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .drawBehind {
+                            drawLine(
+                                start = Offset(x = 0f, y = size.height),
+                                end = Offset(x = size.width, y = size.height),
+                                color = gray100,
+                                strokeWidth = 1.dp.toPx()
+                            )
+                        }
+                        .padding(20.dp)
+                        .padding(start = comment.parentId?.let { 20.dp } ?: 0.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    CommentItemHeader(
+                        commentWriter = comment.commentWriter,
+                        isMyComment = comment.isMyComment
+                    )
+                    Text(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = comment.comment,
+                        style = caption01
+                    )
+                    CommentItemFooter(
+                        createdAt = comment.createdAt,
+                        onCommentButtonClick = onCommentButtonClick
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CommentItemHeader(
+    modifier: Modifier = Modifier,
+    commentWriter: CommentWriter,
+    isMyComment: Boolean
+) {
+    var showPopup by remember { mutableStateOf(false) }
+    val popupYOffset = with(LocalDensity.current) { 46.dp.roundToPx() }
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        if (showPopup) {
+            Popup(
+                alignment = Alignment.BottomEnd,
+                offset = IntOffset(x = 0, y = popupYOffset),
+                onDismissRequest = { showPopup = false }
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(150.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .border(
+                            border = BorderStroke(
+                                color = gray100,
+                                width = 1.dp
+                            ),
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                        .padding(
+                            vertical = 10.dp,
+                            horizontal = 12.dp
+                        )
+                ) {
+                    Text(
+                        modifier = Modifier.align(Alignment.CenterStart),
+                        text = if (isMyComment) "삭제" else "신고",
+                        style = TextStyle(
+                            fontFamily = pretendardFontFamily,
+                            fontWeight = FontWeight.Normal,
+                            fontSize = 15.sp,
+                            lineHeight = 1.3.sp
+                        ),
+                        color = gray500
+                    )
+                    Icon(
+                        modifier = Modifier
+                            .size(15.dp)
+                            .align(Alignment.CenterEnd),
+                        painter = if (isMyComment) {
+                            painterResource(R.drawable.icon_delete)
+                        } else {
+                            painterResource(R.drawable.report)
+                        },
+                        tint = gray500,
+                        contentDescription = null
+                    )
+                }
+            }
+        }
+
+        AsyncImage(
+            modifier = Modifier.size(35.dp),
+            model = BuildConfig.IMAGE_URL + commentWriter.profileImageId,
+            placeholder = painterResource(R.drawable.default_user_profile),
+            error = painterResource(R.drawable.default_user_profile),
+            contentDescription = null
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = commentWriter.nickname,
+                style = TextStyle(
+                    fontFamily = pretendardFontFamily,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
+                    lineHeight = 12.sp
+                ),
+                color = gray500
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                TitleGradeIcon(
+                    modifier = Modifier.size(20.dp),
+                    titleGrade = commentWriter.title.grade
+                )
+                Text(
+                    text = commentWriter.title.name,
+                    style = badge01TextStyle,
+                    color = gray500
+                )
+            }
+        }
+        Spacer(Modifier.weight(1f))
+        Icon(
+            modifier = Modifier
+                .size(30.dp)
+                .clickable(
+                    onClick = { showPopup = true },
+                    indication = null,
+                    interactionSource = null
+                ),
+            painter = painterResource(R.drawable.icon_more_vertical),
+            tint = gray500,
+            contentDescription = null
+        )
+    }
+}
+
+@Composable
+private fun CommentItemFooter(
+    modifier: Modifier = Modifier,
+    createdAt: String,
+    onCommentButtonClick: () -> Unit
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            modifier = Modifier.clickable(
+                onClick = onCommentButtonClick,
+                indication = null,
+                interactionSource = null
+            ),
+            text = "답글 달기",
+            style = tapBoldTextStyle,
+            color = primary300
+        )
+        Text(
+            text = createdAt,
+            style = caption02,
+            color = gray500
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CommentItemPreview() {
+    val commentContent =
+        "가끔은 아무 이유 없이 마음이 공허할 때가 있다. 일을 하고, 사람을 만나고, " +
+                "해야 할 일을 모두 끝냈는데도 어딘가 비어 있는 느낌이 든다." +
+                " 그럴 때마다 나는 잠시 멈춰서 내가 지금 어디쯤 서 있는지 돌아본다." +
+                " 목표를 향해 달리다 보면 정작 나 자신을 놓치기 쉽다." +
+                " 그래서 나는 요즘 일부러 아무것도 하지 않는 시간을 만든다. " +
+                "창문을 열고 바람을 느끼거나, 커피 한 잔을 천천히 마시는" +
+                " 그 짧은 순간이 이상하게도 나를 다시 현실로 데려온다." +
+                " 완벽하지 않아도 괜찮다는 사실을 기억하려 한다. 그렇게 하루를 살아내는 것만으로도 " +
+                "충분히 잘하고 있다고."
+
+    CommentItem(
+        modifier = Modifier.padding(bottom = 10.dp),
+        comment = CommentUiModel(
+            id = 2,
+            parentId = null,
+            comment = commentContent,
+            commentWriter = CommentWriter(
+                userId = "",
+                nickname = "일상123",
+                profileImageId = null,
+                title = Title(
+                    name = "세상을 움직이는 자",
+                    grade = TitleGrade.Standard,
+                    type = TitleType.Contribution
+                )
+            ),
+            createdAt = "2025.04.12 12:00",
+            isMyComment = false,
+            isReported = false,
+            isDeleted = false
+        ),
+        onCommentButtonClick = {}
+    )
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentTextField.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentTextField.kt
@@ -1,0 +1,122 @@
+package com.ilsangtech.ilsang.feature.approval.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ilsangtech.ilsang.designsystem.theme.buttonTextStyle
+import com.ilsangtech.ilsang.designsystem.theme.caption01
+import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.gray300
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.tapBoldTextStyle
+import com.ilsangtech.ilsang.designsystem.theme.toSp
+
+@Composable
+internal fun CommentTextField(
+    modifier: Modifier = Modifier,
+    textFieldState: TextFieldState,
+    onButtonClick: () -> Unit
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .drawBehind {
+                drawLine(
+                    color = gray100,
+                    strokeWidth = 1.dp.toPx(),
+                    start = Offset(0f, 0f),
+                    end = Offset(size.width, 0f)
+                )
+            }
+            .padding(vertical = 11.dp)
+            .padding(horizontal = 20.dp)
+            .navigationBarsPadding(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        BasicTextField(
+            modifier = Modifier.weight(1f),
+            state = textFieldState,
+            textStyle = caption01.copy(
+                fontSize = 13.dp.toSp(),
+                lineHeight = 20.dp.toSp()
+            ),
+            lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = 3),
+            decorator = { innerTextField ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(gray100)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .padding(vertical = 15.dp, horizontal = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(modifier = Modifier.weight(1f)) {
+                            innerTextField()
+                        }
+                        Text(
+                            text = "${textFieldState.text.length}/300",
+                            style = tapBoldTextStyle.copy(
+                                fontSize = 14.dp.toSp(),
+                                lineHeight = 24.dp.toSp()
+                            ),
+                            color = gray300
+                        )
+                    }
+                }
+            }
+        )
+        Button(
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = primary,
+                disabledContainerColor = gray300
+            ),
+            contentPadding = PaddingValues(
+                horizontal = 21.dp,
+                vertical = 16.dp
+            ),
+            onClick = onButtonClick
+        ) {
+            Text(
+                text = "등록",
+                style = buttonTextStyle.copy(
+                    fontSize = 16.dp.toSp(),
+                    lineHeight = 18.dp.toSp()
+                )
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CommentTextFieldPreview() {
+    val textFieldState = rememberTextFieldState()
+    CommentTextField(textFieldState = textFieldState) { }
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/CommentAlertUiState.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/CommentAlertUiState.kt
@@ -1,0 +1,10 @@
+package com.ilsangtech.ilsang.feature.approval.model
+
+enum class CommentAlertUiState(private val text: String) {
+    TooLong("300자 이하로 작성해 주세요."),
+    Empty("공백 제외 1자 이상 입력하세요."),
+    Invalid("허용되지 않은 문자가 포함되어 있습니다."),
+    SpamPrevention("스팸 방지를 위해 동일 게시물에는 1분 뒤에 다시 댓글을 작성할 수 있어요.");
+
+    override fun toString(): String = text
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/CommentUiModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/CommentUiModel.kt
@@ -1,0 +1,14 @@
+package com.ilsangtech.ilsang.feature.approval.model
+
+import com.ilsangtech.ilsang.core.model.comment.CommentWriter
+
+data class CommentUiModel(
+    val id: Int,
+    val parentId: Int?,
+    val comment: String,
+    val commentWriter: CommentWriter,
+    val createdAt: String,
+    val isMyComment: Boolean,
+    val isReported: Boolean,
+    val isDeleted: Boolean
+)


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolves #298 

## 📝작업 내용

> 댓글 관련 UI 컴포넌트를 구현하였습니다.

### 스크린샷 (선택)
<img width="310" height="226" alt="스크린샷 2025-12-21 오후 8 54 46" src="https://github.com/user-attachments/assets/0e5a6b50-321e-4b5b-9904-00411d9e3410" />
<img width="360" alt="Screenshot_20251221_205508" src="https://github.com/user-attachments/assets/81b5b540-e06a-40dc-a1e0-afd7eeabb707" />
<img width="360" alt="Screenshot_20251221_203814" src="https://github.com/user-attachments/assets/55587f0a-34f7-4084-8bfc-9f65f4d11d0d" />
