### PR TITLE
[Feat] 인증 상세 화면 UI 구현 및 댓글 API 연동

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -283,6 +283,9 @@ fun IlsangNavHost(
                 },
                 navigateToMissionReport = { missionHistoryId ->
                     navController.navigate(ReportRoute(missionHistoryId = missionHistoryId))
+                },
+                navigateToCommentReport = { commentId ->
+                    navController.navigate(ReportRoute(commentId = commentId))
                 }
             )
 

--- a/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
+++ b/app/src/main/java/com/ilsangtech/ilsang/navigation/IlsangNavHost.kt
@@ -36,6 +36,7 @@ import com.ilsangtech.ilsang.designsystem.component.IlsangNavigationBarItem
 import com.ilsangtech.ilsang.feature.approval.navigation.ApprovalExampleRoute
 import com.ilsangtech.ilsang.feature.approval.navigation.ReportRoute
 import com.ilsangtech.ilsang.feature.approval.navigation.approvalNavigation
+import com.ilsangtech.ilsang.feature.approval.navigation.navigateToApprovalDetail
 import com.ilsangtech.ilsang.feature.banner.navigation.bannerNavigation
 import com.ilsangtech.ilsang.feature.banner.navigation.navigateToBannerDetail
 import com.ilsangtech.ilsang.feature.coupon.navigation.CouponBaseRoute
@@ -265,6 +266,7 @@ fun IlsangNavHost(
 
             approvalNavigation(
                 popBackStack = navController::popBackStack,
+                navigateToApprovalDetail = navController::navigateToApprovalDetail,
                 navigateToQuestTab = { questId ->
                     navController.navigateToTopLevelDestination(BottomTab.Quest)
                 },

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(project(":core:network"))
     implementation(project(":core:model"))
     implementation(project(":core:domain"))
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.protobuf.kotlin.lite)
     implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/comment/datasource/CommentDataSource.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/comment/datasource/CommentDataSource.kt
@@ -8,7 +8,7 @@ interface CommentDataSource {
         missionHistoryId: Int,
         parentId: Int?,
         comment: String
-    )
+    ): Result<String?>
 
     suspend fun deleteComment(commentId: Int)
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/comment/datasource/CommentDataSourceImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/comment/datasource/CommentDataSourceImpl.kt
@@ -5,6 +5,8 @@ import com.ilsangtech.ilsang.core.network.model.comment.CommentCreationRequest
 import com.ilsangtech.ilsang.core.network.model.comment.CommentNetworkModel
 import com.ilsangtech.ilsang.core.network.model.comment.CommentReportRequest
 import com.ilsangtech.ilsang.core.network.model.comment.CommentReportResponse
+import com.ilsangtech.ilsang.core.network.model.common.ErrorResponse
+import kotlinx.serialization.json.Json
 
 class CommentDataSourceImpl(
     private val commentApiService: CommentApiService
@@ -13,14 +15,24 @@ class CommentDataSourceImpl(
         missionHistoryId: Int,
         parentId: Int?,
         comment: String
-    ) {
-        return commentApiService.createComment(
+    ): Result<String?> {
+        val response = commentApiService.createComment(
             missionHistoryId = missionHistoryId,
             request = CommentCreationRequest(
                 parentId = parentId,
                 comment = comment
             )
         )
+        return if (response.isSuccessful) {
+            Result.success(null)
+        } else {
+            val errorBody =
+                response.errorBody()?.string() ?: return Result.failure(Throwable("Unknown error"))
+            val errorMessage = Json.decodeFromString<ErrorResponse>(errorBody)
+            errorMessage.message?.let { message ->
+                Result.success(message)
+            } ?: Result.failure(Throwable("Unknown error"))
+        }
     }
 
     override suspend fun deleteComment(commentId: Int) {

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/comment/mapper/CommentMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/comment/mapper/CommentMapper.kt
@@ -14,7 +14,8 @@ internal fun CommentNetworkModel.toComment(): Comment {
         writer = writer.toCommentWriter(),
         createdAt = createdAt,
         hasReported = hasReportedYn,
-        isDeleted = deleteYn
+        isDeleted = deleteYn,
+        children = children.map(CommentNetworkModel::toComment)
     )
 }
 

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/comment/repository/CommentRepositoryImpl.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/comment/repository/CommentRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.ilsangtech.ilsang.core.data.comment.datasource.CommentDataSource
 import com.ilsangtech.ilsang.core.data.comment.mapper.toComment
 import com.ilsangtech.ilsang.core.domain.CommentRepository
 import com.ilsangtech.ilsang.core.model.comment.Comment
+import com.ilsangtech.ilsang.core.model.comment.CommentCreationResult
 import com.ilsangtech.ilsang.core.network.model.comment.CommentNetworkModel
 
 class CommentRepositoryImpl(
@@ -13,14 +14,24 @@ class CommentRepositoryImpl(
         missionHistoryId: Int,
         parentId: Int?,
         comment: String
-    ): Result<Unit> {
-        return runCatching {
-            commentDataSource.createComment(
-                missionHistoryId = missionHistoryId,
-                parentId = parentId,
-                comment = comment
-            )
-        }
+    ): CommentCreationResult {
+        return commentDataSource.createComment(
+            missionHistoryId = missionHistoryId,
+            parentId = parentId,
+            comment = comment
+        ).fold(
+            onSuccess = { message ->
+                if (message == null) return@fold CommentCreationResult.Success
+                if (message.contains("1 minute")) {
+                    CommentCreationResult.Failure.SpamPrevention
+                } else {
+                    CommentCreationResult.Failure.UnknownError
+                }
+            },
+            onFailure = {
+                CommentCreationResult.Failure.UnknownError
+            }
+        )
     }
 
     override suspend fun deleteComment(commentId: Int): Result<Unit> {

--- a/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/CommentRepository.kt
+++ b/core/domain/src/main/java/com/ilsangtech/ilsang/core/domain/CommentRepository.kt
@@ -1,13 +1,14 @@
 package com.ilsangtech.ilsang.core.domain
 
 import com.ilsangtech.ilsang.core.model.comment.Comment
+import com.ilsangtech.ilsang.core.model.comment.CommentCreationResult
 
 interface CommentRepository {
     suspend fun createComment(
         missionHistoryId: Int,
         parentId: Int?,
         comment: String
-    ): Result<Unit>
+    ): CommentCreationResult
 
     suspend fun deleteComment(commentId: Int): Result<Unit>
 

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/comment/Comment.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/comment/Comment.kt
@@ -7,5 +7,6 @@ data class Comment(
     val writer: CommentWriter,
     val createdAt: String,
     val hasReported: Boolean,
-    val isDeleted: Boolean
+    val isDeleted: Boolean,
+    val children: List<Comment>
 )

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/comment/CommentCreationResult.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/comment/CommentCreationResult.kt
@@ -1,0 +1,9 @@
+package com.ilsangtech.ilsang.core.model.comment
+
+sealed interface CommentCreationResult {
+    data object Success : CommentCreationResult
+    sealed interface Failure : CommentCreationResult {
+        data object SpamPrevention : Failure
+        data object UnknownError : Failure
+    }
+}

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/mission/MissionHistoryUser.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/mission/MissionHistoryUser.kt
@@ -1,7 +1,9 @@
 package com.ilsangtech.ilsang.core.model.mission
 
 import com.ilsangtech.ilsang.core.model.title.Title
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class MissionHistoryUser(
     val userId: String,
     val nickname: String,

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/title/Title.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/title/Title.kt
@@ -1,5 +1,8 @@
 package com.ilsangtech.ilsang.core.model.title
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Title(
     val name: String,
     val grade: TitleGrade,

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/title/TitleGrade.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/title/TitleGrade.kt
@@ -1,7 +1,15 @@
 package com.ilsangtech.ilsang.core.model.title
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 sealed interface TitleGrade {
+    @Serializable
     data object Standard : TitleGrade
+
+    @Serializable
     data object Rare : TitleGrade
+
+    @Serializable
     data object Legend : TitleGrade
 }

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/title/TitleType.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/title/TitleType.kt
@@ -1,8 +1,18 @@
 package com.ilsangtech.ilsang.core.model.title
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 sealed interface TitleType {
+    @Serializable
     data object None : TitleType
+
+    @Serializable
     data object Metro : TitleType
+
+    @Serializable
     data object Commercial : TitleType
+
+    @Serializable
     data object Contribution : TitleType
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     api(libs.okhttp)
     implementation(libs.logging.interceptor)
-    implementation(libs.retrofit)
+    api(libs.retrofit)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/CommentApiService.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/api/CommentApiService.kt
@@ -4,6 +4,7 @@ import com.ilsangtech.ilsang.core.network.model.comment.CommentCreationRequest
 import com.ilsangtech.ilsang.core.network.model.comment.CommentNetworkModel
 import com.ilsangtech.ilsang.core.network.model.comment.CommentReportRequest
 import com.ilsangtech.ilsang.core.network.model.comment.CommentReportResponse
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -16,7 +17,7 @@ interface CommentApiService {
     suspend fun createComment(
         @Path("missionHistoryId") missionHistoryId: Int,
         @Body request: CommentCreationRequest
-    )
+    ): Response<Unit>
 
     @DELETE("api/v1/mission/user/history/comment/{commentId}")
     suspend fun deleteComment(@Path("commentId") commentId: Int)

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/comment/CommentNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/comment/CommentNetworkModel.kt
@@ -11,5 +11,6 @@ data class CommentNetworkModel(
     val status: String,
     val createdAt: String,
     val hasReportedYn: Boolean,
-    val deleteYn: Boolean
+    val deleteYn: Boolean,
+    val children: List<CommentNetworkModel>
 )

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/common/ErrorResponse.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/common/ErrorResponse.kt
@@ -1,0 +1,10 @@
+package com.ilsangtech.ilsang.core.network.model.common
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ErrorResponse(
+    val message: String?,
+    val status: Int?,
+    val error: String?
+)

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
@@ -60,7 +60,8 @@ internal fun ApprovalDetailScreen(
     viewModel: ApprovalDetailViewModel = hiltViewModel(),
     onBackButtonClick: () -> Unit,
     onProfileClick: (String) -> Unit,
-    onMissionHistoryReportClick: (Int) -> Unit
+    onMissionHistoryReportClick: (Int) -> Unit,
+    onCommentReportClick: (Int) -> Unit
 ) {
     val missionHistory = viewModel.missionHistoryUiModel
     val commentTextField = viewModel.commentTextField
@@ -84,7 +85,7 @@ internal fun ApprovalDetailScreen(
         onCommentSelected = viewModel::selectComment,
         onCommentUnselected = viewModel::unselectComment,
         onSendButtonClick = viewModel::createComment,
-        onCommentReportClick = {},
+        onCommentReportClick = onCommentReportClick,
         onCommentDeleteClick = viewModel::deleteComment,
         validateComment = viewModel::validateComment,
         onShownCommentAlert = viewModel::shownCommentAlert,

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
@@ -225,5 +225,96 @@ private fun ApprovalDetailScreen(
 @Preview
 @Composable
 private fun ApprovalDetailScreenPreview() {
-    ApprovalDetailScreen()
+    val missionHistoryUiModel = MissionHistoryUiModel(
+        missionHistoryId = 1,
+        questId = 1,
+        commercialAreaName = "서현역",
+        createdAt = "2025.04.12 12:00",
+        currentUserEmojis = emptyList(),
+        hateCount = 0,
+        likeCount = 10,
+        submitImageId = "",
+        title = "정자동 최고의 돈까스 가게 가기",
+        writerName = "야미돈까스 정자동점",
+        user = MissionHistoryUser(
+            userId = "123",
+            nickname = "일상123",
+            profileImageId = null,
+            title = Title(
+                name = "세상을 움직이는 자",
+                grade = TitleGrade.Standard,
+                type = TitleType.Commercial
+            )
+        ),
+        viewCount = 20,
+        questType = QuestType.Repeat.Weekly,
+        commentCount = 10,
+        shareCount = 2,
+        lastCompleteDate = "2025.04.12 12:00",
+        expireDate = "2025.04.12 12:00",
+        isIsZoneQuest = false
+    )
+
+    ApprovalDetailScreen(
+        missionHistory = missionHistoryUiModel,
+        commentTextFieldState = rememberTextFieldState(),
+        commentUiState = CommentUiState.Success(
+            comments = listOf(
+                CommentUiModel(
+                    id = 1,
+                    parentId = null,
+                    comment = "댓글댓글",
+                    commentWriter = CommentUiModel.CommentWriterUiModel(
+                        userId = "",
+                        nickname = "일상123",
+                        profileImageId = null,
+                        title = Title(
+                            name = "세상을 움직이는 자",
+                            grade = TitleGrade.Standard,
+                            type = TitleType.Commercial
+                        ),
+                        isMissionHistoryUser = false
+                    ),
+                    createdAt = "2025.04.12 12:00",
+                    isMyComment = false,
+                    isReported = false,
+                    isDeleted = false
+                ),
+                CommentUiModel(
+                    id = 2,
+                    parentId = null,
+                    comment = "댓글댓글",
+                    commentWriter = CommentUiModel.CommentWriterUiModel(
+                        userId = "",
+                        nickname = "일상123",
+                        profileImageId = null,
+                        title = Title(
+                            name = "세상을 움직이는 자",
+                            grade = TitleGrade.Standard,
+                            type = TitleType.Commercial
+                        ),
+                        isMissionHistoryUser = false
+                    ),
+                    createdAt = "2025.04.12 12:00",
+                    isMyComment = false,
+                    isReported = false,
+                    isDeleted = false
+                )
+            ),
+            validCommentsSize = 2
+        ),
+        selectedCommentWriter = null,
+        listScrollPosition = null,
+        onBackButtonClick = {},
+        onProfileClick = {},
+        onShareButtonClick = {},
+        onMissionHistoryReportClick = {},
+        onCtaButtonClick = {},
+        onCommentSelected = { },
+        onCommentUnselected = { },
+        onSendButtonClick = {},
+        onCommentDeleteClick = {},
+        onCommentReportClick = {},
+        onListScrolled = {}
+    )
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
@@ -46,6 +46,7 @@ import com.ilsangtech.ilsang.designsystem.theme.gray200
 import com.ilsangtech.ilsang.designsystem.theme.heading01
 import com.ilsangtech.ilsang.feature.approval.component.ApprovalDetailHeader
 import com.ilsangtech.ilsang.feature.approval.component.ApprovalDetailItem
+import com.ilsangtech.ilsang.feature.approval.component.CommentAlertDialog
 import com.ilsangtech.ilsang.feature.approval.component.CommentItem
 import com.ilsangtech.ilsang.feature.approval.component.CommentTextField
 import com.ilsangtech.ilsang.feature.approval.component.EmptyCommentBox
@@ -85,6 +86,8 @@ internal fun ApprovalDetailScreen(
         onSendButtonClick = viewModel::createComment,
         onCommentReportClick = {},
         onCommentDeleteClick = viewModel::deleteComment,
+        validateComment = viewModel::validateComment,
+        onShownCommentAlert = viewModel::shownCommentAlert,
         onListScrolled = viewModel::clearScrollPosition
     )
 }
@@ -106,10 +109,16 @@ private fun ApprovalDetailScreen(
     onSendButtonClick: () -> Unit,
     onCommentDeleteClick: (Int) -> Unit,
     onCommentReportClick: (Int) -> Unit,
+    validateComment: suspend () -> Unit,
+    onShownCommentAlert: () -> Unit,
     onListScrolled: () -> Unit
 ) {
     val focusRequest = remember { FocusRequester() }
     val lazyListState = rememberLazyListState()
+
+    LaunchedEffect(Unit) {
+        validateComment.invoke()
+    }
 
     LaunchedEffect(listScrollPosition) {
         listScrollPosition?.let { position ->
@@ -117,6 +126,16 @@ private fun ApprovalDetailScreen(
             onListScrolled()
         }
     }
+
+    (commentUiState as? CommentUiState.Success)?.let { state ->
+        state.alertUiState?.let { alertUiState ->
+            CommentAlertDialog(
+                uiState = alertUiState,
+                onDismissRequest = onShownCommentAlert
+            )
+        }
+    }
+
     Surface(
         modifier = Modifier
             .fillMaxSize()
@@ -301,7 +320,8 @@ private fun ApprovalDetailScreenPreview() {
                     isDeleted = false
                 )
             ),
-            validCommentsSize = 2
+            validCommentsSize = 2,
+            alertUiState = null
         ),
         selectedCommentWriter = null,
         listScrollPosition = null,
@@ -315,6 +335,8 @@ private fun ApprovalDetailScreenPreview() {
         onSendButtonClick = {},
         onCommentDeleteClick = {},
         onCommentReportClick = {},
+        validateComment = {},
+        onShownCommentAlert = {},
         onListScrolled = {}
     )
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
@@ -1,17 +1,142 @@
 package com.ilsangtech.ilsang.feature.approval
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ilsangtech.ilsang.designsystem.theme.background
+import com.ilsangtech.ilsang.designsystem.theme.bodyTextStyle
+import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.designsystem.theme.gray200
+import com.ilsangtech.ilsang.designsystem.theme.heading01
+import com.ilsangtech.ilsang.feature.approval.component.ApprovalDetailHeader
+import com.ilsangtech.ilsang.feature.approval.component.ApprovalDetailItem
+import com.ilsangtech.ilsang.feature.approval.component.CommentItem
+import com.ilsangtech.ilsang.feature.approval.component.CommentTextField
+import com.ilsangtech.ilsang.feature.approval.component.EmptyCommentBox
+import com.ilsangtech.ilsang.feature.approval.model.CommentUiState
+import com.ilsangtech.ilsang.feature.approval.model.MissionHistoryUiModel
 
 @Composable
 internal fun ApprovalDetailScreen(
     viewModel: ApprovalDetailViewModel = hiltViewModel()
 ) {
+    val missionHistory = viewModel.missionHistoryUiModel
+    val commentUiState by viewModel.commentUiState.collectAsStateWithLifecycle()
+
+    ApprovalDetailScreen(
+        missionHistory = missionHistory,
+        commentUiState = commentUiState
+    )
 }
 
 @Composable
-private fun ApprovalDetailScreen() {
+private fun ApprovalDetailScreen(
+    missionHistory: MissionHistoryUiModel,
+    commentUiState: CommentUiState
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+            .imePadding(),
+        color = Color.White
+    ) {
+        Column {
+            ApprovalDetailHeader(
+                modifier = Modifier.background(background),
+                onBackButtonClick = {}
+            )
+            LazyColumn(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
+                    .background(Color.White)
+            ) {
+                item {
+                    ApprovalDetailItem(
+                        missionHistory = missionHistory,
+                        onProfileClick = {},
+                        onShareButtonClick = {},
+                        onReportButtonClick = {},
+                        onCtaButtonClick = {}
+                    )
+                }
+                val successUiState = commentUiState as? CommentUiState.Success
+                val comments = successUiState?.comments ?: emptyList()
+                val commentsCount = successUiState?.validCommentsSize ?: 0
+
+                item {
+                    Row(
+                        modifier = Modifier
+                            .padding(horizontal = 20.dp)
+                            .padding(bottom = 10.dp),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(
+                            text = "댓글",
+                            style = heading01
+                        )
+                        if (commentUiState !is CommentUiState.Loading) {
+                            Text(
+                                text = "$commentsCount",
+                                style = bodyTextStyle
+                            )
+                        }
+                    }
+                }
+                item { HorizontalDivider(color = gray100) }
+                if (commentUiState is CommentUiState.Loading) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(144.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(color = gray200)
+                        }
+                    }
+                } else {
+                    if (comments.isEmpty()) item { EmptyCommentBox() }
+                    items(comments) { comment ->
+                        CommentItem(
+                            comment = comment,
+                            onCommentButtonClick = {}
+                        )
+                    }
+                }
+            }
+
+            CommentTextField(
+                textFieldState = rememberTextFieldState(),
+                onButtonClick = {}
+            )
+        }
+    }
 }
 
 @Preview

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
@@ -141,13 +141,10 @@ private fun ApprovalDetailScreen(
         modifier = Modifier
             .fillMaxSize()
             .imePadding(),
-        color = Color.White
+        color = background
     ) {
         Column {
-            ApprovalDetailHeader(
-                modifier = Modifier.background(background),
-                onBackButtonClick = onBackButtonClick
-            )
+            ApprovalDetailHeader(onBackButtonClick = onBackButtonClick)
             LazyColumn(
                 modifier = Modifier
                     .weight(1f)

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
@@ -1,7 +1,21 @@
 package com.ilsangtech.ilsang.feature.approval
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+internal fun ApprovalDetailScreen(
+    viewModel: ApprovalDetailViewModel = hiltViewModel()
+) {
+}
 
 @Composable
 private fun ApprovalDetailScreen() {
+}
+
+@Preview
+@Composable
+private fun ApprovalDetailScreenPreview() {
+    ApprovalDetailScreen()
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
@@ -1,0 +1,7 @@
+package com.ilsangtech.ilsang.feature.approval
+
+import androidx.compose.runtime.Composable
+
+@Composable
+private fun ApprovalDetailScreen() {
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
@@ -12,22 +12,33 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ilsangtech.ilsang.core.model.mission.MissionHistoryUser
+import com.ilsangtech.ilsang.core.model.quest.QuestType
+import com.ilsangtech.ilsang.core.model.title.Title
+import com.ilsangtech.ilsang.core.model.title.TitleGrade
+import com.ilsangtech.ilsang.core.model.title.TitleType
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.designsystem.theme.bodyTextStyle
 import com.ilsangtech.ilsang.designsystem.theme.gray100
@@ -38,27 +49,74 @@ import com.ilsangtech.ilsang.feature.approval.component.ApprovalDetailItem
 import com.ilsangtech.ilsang.feature.approval.component.CommentItem
 import com.ilsangtech.ilsang.feature.approval.component.CommentTextField
 import com.ilsangtech.ilsang.feature.approval.component.EmptyCommentBox
+import com.ilsangtech.ilsang.feature.approval.component.RecommentProgressCard
+import com.ilsangtech.ilsang.feature.approval.model.CommentUiModel
 import com.ilsangtech.ilsang.feature.approval.model.CommentUiState
 import com.ilsangtech.ilsang.feature.approval.model.MissionHistoryUiModel
 
 @Composable
 internal fun ApprovalDetailScreen(
-    viewModel: ApprovalDetailViewModel = hiltViewModel()
+    viewModel: ApprovalDetailViewModel = hiltViewModel(),
+    onBackButtonClick: () -> Unit,
+    onProfileClick: (String) -> Unit,
+    onMissionHistoryReportClick: (Int) -> Unit
 ) {
     val missionHistory = viewModel.missionHistoryUiModel
+    val commentTextField = viewModel.commentTextField
     val commentUiState by viewModel.commentUiState.collectAsStateWithLifecycle()
+    val selectedCommentWriter by viewModel.selectedCommentWriter.collectAsStateWithLifecycle()
+    val listScrollPosition by viewModel.listScrollPosition.collectAsStateWithLifecycle()
 
     ApprovalDetailScreen(
         missionHistory = missionHistory,
-        commentUiState = commentUiState
+        commentTextFieldState = commentTextField,
+        commentUiState = commentUiState,
+        selectedCommentWriter = selectedCommentWriter,
+        listScrollPosition = listScrollPosition,
+        onBackButtonClick = onBackButtonClick,
+        onProfileClick = onProfileClick,
+        onShareButtonClick = {},
+        onMissionHistoryReportClick = {
+            onMissionHistoryReportClick(missionHistory.missionHistoryId)
+        },
+        onCtaButtonClick = {},
+        onCommentSelected = viewModel::selectComment,
+        onCommentUnselected = viewModel::unselectComment,
+        onSendButtonClick = viewModel::createComment,
+        onCommentReportClick = {},
+        onCommentDeleteClick = viewModel::deleteComment,
+        onListScrolled = viewModel::clearScrollPosition
     )
 }
 
 @Composable
 private fun ApprovalDetailScreen(
     missionHistory: MissionHistoryUiModel,
-    commentUiState: CommentUiState
+    commentTextFieldState: TextFieldState,
+    commentUiState: CommentUiState,
+    listScrollPosition: Int?,
+    selectedCommentWriter: String?,
+    onBackButtonClick: () -> Unit,
+    onProfileClick: (String) -> Unit,
+    onShareButtonClick: () -> Unit,
+    onMissionHistoryReportClick: () -> Unit,
+    onCtaButtonClick: () -> Unit,
+    onCommentSelected: (CommentUiModel) -> Unit,
+    onCommentUnselected: () -> Unit,
+    onSendButtonClick: () -> Unit,
+    onCommentDeleteClick: (Int) -> Unit,
+    onCommentReportClick: (Int) -> Unit,
+    onListScrolled: () -> Unit
 ) {
+    val focusRequest = remember { FocusRequester() }
+    val lazyListState = rememberLazyListState()
+
+    LaunchedEffect(listScrollPosition) {
+        listScrollPosition?.let { position ->
+            lazyListState.animateScrollToItem(position + 3)
+            onListScrolled()
+        }
+    }
     Surface(
         modifier = Modifier
             .fillMaxSize()
@@ -68,21 +126,22 @@ private fun ApprovalDetailScreen(
         Column {
             ApprovalDetailHeader(
                 modifier = Modifier.background(background),
-                onBackButtonClick = {}
+                onBackButtonClick = onBackButtonClick
             )
             LazyColumn(
                 modifier = Modifier
                     .weight(1f)
                     .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
-                    .background(Color.White)
+                    .background(color = Color.White),
+                state = lazyListState,
             ) {
                 item {
                     ApprovalDetailItem(
                         missionHistory = missionHistory,
-                        onProfileClick = {},
-                        onShareButtonClick = {},
-                        onReportButtonClick = {},
-                        onCtaButtonClick = {}
+                        onProfileClick = { onProfileClick(missionHistory.user.userId) },
+                        onShareButtonClick = onShareButtonClick,
+                        onReportButtonClick = onMissionHistoryReportClick,
+                        onCtaButtonClick = onCtaButtonClick
                     )
                 }
                 val successUiState = commentUiState as? CommentUiState.Success
@@ -122,18 +181,42 @@ private fun ApprovalDetailScreen(
                     }
                 } else {
                     if (comments.isEmpty()) item { EmptyCommentBox() }
-                    items(comments) { comment ->
+                    items(
+                        items = comments,
+                        key = { it.id }
+                    ) { comment ->
                         CommentItem(
                             comment = comment,
-                            onCommentButtonClick = {}
+                            onProfileClick = {
+                                onProfileClick(comment.commentWriter.userId)
+                            },
+                            onCommentButtonClick = {
+                                onCommentSelected(comment)
+                                focusRequest.requestFocus()
+                            },
+                            onReportButtonClick = {
+                                onCommentReportClick(comment.id)
+                            },
+                            onDeleteButtonClick = {
+                                onCommentDeleteClick(comment.id)
+                            }
                         )
                     }
                 }
             }
-
+            selectedCommentWriter?.let { commentWriter ->
+                RecommentProgressCard(
+                    commentWriterName = commentWriter,
+                    onCancelButtonClick = {
+                        onCommentUnselected()
+                        focusRequest.freeFocus()
+                    }
+                )
+            }
             CommentTextField(
-                textFieldState = rememberTextFieldState(),
-                onButtonClick = {}
+                modifier = Modifier.focusRequester(focusRequest),
+                textFieldState = commentTextFieldState,
+                onButtonClick = onSendButtonClick
             )
         }
     }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
@@ -1,0 +1,10 @@
+package com.ilsangtech.ilsang.feature.approval
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ApprovalDetailViewModel @Inject constructor(
+) : ViewModel() {
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.ilsangtech.ilsang.core.domain.CommentRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
+import com.ilsangtech.ilsang.core.model.comment.CommentCreationResult
 import com.ilsangtech.ilsang.feature.approval.model.CommentAlertUiState
 import com.ilsangtech.ilsang.feature.approval.model.CommentUiModel
 import com.ilsangtech.ilsang.feature.approval.model.CommentUiState
@@ -111,20 +112,31 @@ class ApprovalDetailViewModel @Inject constructor(
                     CommentAlertUiState.Empty
                 }
 
-                else -> commentRepository.createComment(
-                    missionHistoryId = missionHistoryId,
-                    parentId = selectedComment.value?.id,
-                    comment = commentTextField.text.toString()
-                ).onSuccess {
-                    commentRetryFlow.emit(Unit)
-                    (commentUiState.value as? CommentUiState.Success)?.let { state ->
-                        _listScrollRequestPosition.update {
-                            if (selectedComment.value?.id == null) {
-                                state.comments.size - 1
-                            } else {
-                                state.comments.indexOfLast {
-                                    it.parentId == selectedComment.value?.id
+                else -> {
+                    val result = commentRepository.createComment(
+                        missionHistoryId = missionHistoryId,
+                        parentId = selectedComment.value?.id,
+                        comment = commentTextField.text.toString()
+                    )
+                    when (result) {
+                        is CommentCreationResult.Success -> {
+                            commentRetryFlow.emit(Unit)
+                            (commentUiState.value as? CommentUiState.Success)?.let { state ->
+                                _listScrollRequestPosition.update {
+                                    if (selectedComment.value?.id == null) {
+                                        state.comments.size - 1
+                                    } else {
+                                        state.comments.indexOfLast {
+                                            it.parentId == selectedComment.value?.id
+                                        }
+                                    }
                                 }
+                            }
+                        }
+
+                        is CommentCreationResult.Failure -> {
+                            if (result is CommentCreationResult.Failure.SpamPrevention) {
+                                _commentAlertUiState.update { CommentAlertUiState.SpamPrevention }
                             }
                         }
                     }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
@@ -25,8 +25,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
@@ -57,44 +55,42 @@ class ApprovalDetailViewModel @Inject constructor(
     val commentTextField = TextFieldState()
 
     private val commentRetryFlow = MutableSharedFlow<Unit>()
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val commentUiState = commentRetryFlow
-        .onStart {
-            emit(Unit)
-        }.flatMapLatest {
-            combine(
-                userRepository.getMyInfo(),
-                flow { emit(commentRepository.getComments(missionHistoryId)) },
-                commentAlertUiState
-            ) { myInfo, comments, alertUiState ->
-                val commentUiModels = comments.flatMap { comment ->
-                    listOf(comment) + comment.children
-                }.map { comment ->
-                    comment.toUiModel(
-                        isMyComment = comment.writer.userId == myInfo.id,
-                        isMissionHistoryUser = comment.writer.userId == missionUserId
-                    )
-                }
-                val validCommentsSize = commentUiModels
-                    .filter { comment -> !comment.isDeleted && !comment.isReported }
-                    .size
-
-                CommentUiState.Success(
-                    comments = commentUiModels,
-                    validCommentsSize = validCommentsSize,
-                    alertUiState = alertUiState
-                ) as CommentUiState
-            }
-        }.catch { e ->
-            emit(CommentUiState.Error)
-        }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = CommentUiState.Loading
-        )
     private val _commentAlertUiState = MutableStateFlow<CommentAlertUiState?>(null)
     val commentAlertUiState: StateFlow<CommentAlertUiState?> = _commentAlertUiState
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val commentUiState = combine(
+        commentRetryFlow
+            .onStart { emit(Unit) }
+            .map { commentRepository.getComments(missionHistoryId) },
+        userRepository.getMyInfo(),
+        commentAlertUiState
+    ) { comments, myInfo, alertUiState ->
+        val commentUiModels = comments.flatMap { comment ->
+            listOf(comment) + comment.children
+        }.map { comment ->
+            comment.toUiModel(
+                isMyComment = comment.writer.userId == myInfo.id,
+                isMissionHistoryUser = comment.writer.userId == missionUserId
+            )
+        }
+        val validCommentsSize = commentUiModels
+            .filter { comment -> !comment.isDeleted && !comment.isReported }
+            .size
+
+        CommentUiState.Success(
+            comments = commentUiModels,
+            validCommentsSize = validCommentsSize,
+            alertUiState = alertUiState
+        ) as CommentUiState
+
+    }.catch { e ->
+        emit(CommentUiState.Error)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = CommentUiState.Loading
+    )
 
     private val _listScrollRequestPosition = MutableStateFlow<Int?>(null)
     val listScrollPosition: StateFlow<Int?> = _listScrollRequestPosition

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
@@ -1,5 +1,7 @@
 package com.ilsangtech.ilsang.feature.approval
 
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -8,16 +10,26 @@ import com.ilsangtech.ilsang.core.domain.CommentRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
 import com.ilsangtech.ilsang.core.model.comment.Comment
 import com.ilsangtech.ilsang.core.model.user.MyInfo
+import com.ilsangtech.ilsang.feature.approval.model.CommentUiModel
 import com.ilsangtech.ilsang.feature.approval.model.CommentUiState
 import com.ilsangtech.ilsang.feature.approval.model.toUiModel
 import com.ilsangtech.ilsang.feature.approval.navigation.ApprovalDetailRoute
 import com.ilsangtech.ilsang.feature.approval.navigation.missionHistoryUiModelTypeMap
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -31,31 +43,98 @@ class ApprovalDetailViewModel @Inject constructor(
     private val missionHistoryId = missionHistoryUiModel.missionHistoryId
     private val missionUserId = missionHistoryUiModel.user.userId
 
-    val commentUiState = combine<MyInfo, List<Comment>, CommentUiState>(
-        userRepository.getMyInfo(),
-        flow { emit(commentRepository.getComments(missionHistoryId)) }
-    ) { myInfo, comments ->
-        val commentUiModels = comments.flatMap { comment ->
-            listOf(comment) + comment.children
-        }.map { comment ->
-            comment.toUiModel(
-                isMyComment = comment.writer.userId == myInfo.id,
-                isMissionHistoryUser = comment.writer.userId == missionUserId
-            )
-        }
-        val validCommentsSize = commentUiModels
-            .filter { comment -> !comment.isDeleted && !comment.isReported }
-            .size
-
-        CommentUiState.Success(
-            comments = commentUiModels,
-            validCommentsSize = validCommentsSize
-        )
-    }.catch { e ->
-        emit(CommentUiState.Error)
+    private val selectedComment = MutableStateFlow<CommentUiModel?>(null)
+    val selectedCommentWriter = selectedComment.map { comment ->
+        comment?.commentWriter?.nickname
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
-        initialValue = CommentUiState.Loading
+        initialValue = null
     )
+
+    val commentTextField = TextFieldState()
+
+    private val commentRetryFlow = MutableSharedFlow<Unit>()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val commentUiState = commentRetryFlow
+        .onStart {
+            emit(Unit)
+        }.flatMapLatest {
+            combine<MyInfo, List<Comment>, CommentUiState>(
+                userRepository.getMyInfo(),
+                flow { emit(commentRepository.getComments(missionHistoryId)) }
+            ) { myInfo, comments ->
+                val commentUiModels = comments.flatMap { comment ->
+                    listOf(comment) + comment.children
+                }.map { comment ->
+                    comment.toUiModel(
+                        isMyComment = comment.writer.userId == myInfo.id,
+                        isMissionHistoryUser = comment.writer.userId == missionUserId
+                    )
+                }
+                val validCommentsSize = commentUiModels
+                    .filter { comment -> !comment.isDeleted && !comment.isReported }
+                    .size
+
+                CommentUiState.Success(
+                    comments = commentUiModels,
+                    validCommentsSize = validCommentsSize
+                )
+            }
+        }.catch { e ->
+            emit(CommentUiState.Error)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = CommentUiState.Loading
+        )
+
+    private val _listScrollRequestPosition = MutableStateFlow<Int?>(null)
+    val listScrollPosition: StateFlow<Int?> = _listScrollRequestPosition
+
+    fun selectComment(commentUiModel: CommentUiModel) {
+        selectedComment.update { commentUiModel }
+    }
+
+    fun unselectComment() {
+        selectedComment.update { null }
+    }
+
+    fun createComment() {
+        viewModelScope.launch {
+            commentRepository.createComment(
+                missionHistoryId = missionHistoryId,
+                parentId = selectedComment.value?.id,
+                comment = commentTextField.text.toString()
+            ).onSuccess {
+                commentRetryFlow.emit(Unit)
+                (commentUiState.value as? CommentUiState.Success)?.let { state ->
+                    _listScrollRequestPosition.update {
+                        if (selectedComment.value?.id == null) {
+                            state.comments.size - 1
+                        } else {
+                            state.comments.indexOfLast {
+                                it.parentId == selectedComment.value?.id
+                            }
+                        }
+                    }
+                }
+            }
+            commentTextField.clearText()
+            unselectComment()
+        }
+    }
+
+    fun deleteComment(commentId: Int) {
+        viewModelScope.launch {
+            commentRepository.deleteComment(commentId).onSuccess {
+                commentRetryFlow.emit(Unit)
+            }
+        }
+    }
+
+    fun clearScrollPosition() {
+        _listScrollRequestPosition.update { null }
+    }
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
@@ -2,16 +2,60 @@ package com.ilsangtech.ilsang.feature.approval
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.ilsangtech.ilsang.core.domain.CommentRepository
+import com.ilsangtech.ilsang.core.domain.UserRepository
+import com.ilsangtech.ilsang.core.model.comment.Comment
+import com.ilsangtech.ilsang.core.model.user.MyInfo
+import com.ilsangtech.ilsang.feature.approval.model.CommentUiState
+import com.ilsangtech.ilsang.feature.approval.model.toUiModel
 import com.ilsangtech.ilsang.feature.approval.navigation.ApprovalDetailRoute
 import com.ilsangtech.ilsang.feature.approval.navigation.missionHistoryUiModelTypeMap
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
 class ApprovalDetailViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    userRepository: UserRepository,
+    private val commentRepository: CommentRepository
 ) : ViewModel() {
     val missionHistoryUiModel =
         savedStateHandle.toRoute<ApprovalDetailRoute>(missionHistoryUiModelTypeMap).missionHistory
+    private val missionHistoryId = missionHistoryUiModel.missionHistoryId
+    private val missionUserId = missionHistoryUiModel.user.userId
+
+    val commentUiState = combine<MyInfo, List<Comment>, CommentUiState>(
+        userRepository.getMyInfo(),
+        flow { emit(commentRepository.getComments(missionHistoryId)) }
+    ) { myInfo, comments ->
+        val commentUiModels = comments.flatMap { comment ->
+            listOf(comment) + comment.children
+        }.map { comment ->
+            comment.toUiModel(
+                isMyComment = comment.writer.userId == myInfo.id,
+                isMissionHistoryUser = comment.writer.userId == missionUserId
+            )
+        }
+        val validCommentsSize = commentUiModels
+            .filter { comment -> !comment.isDeleted && !comment.isReported }
+            .size
+
+        CommentUiState.Success(
+            comments = commentUiModels,
+            validCommentsSize = validCommentsSize
+        )
+    }.catch { e ->
+        emit(CommentUiState.Error)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = CommentUiState.Loading
+    )
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
@@ -2,14 +2,15 @@ package com.ilsangtech.ilsang.feature.approval
 
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.delete
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.ilsangtech.ilsang.core.domain.CommentRepository
 import com.ilsangtech.ilsang.core.domain.UserRepository
-import com.ilsangtech.ilsang.core.model.comment.Comment
-import com.ilsangtech.ilsang.core.model.user.MyInfo
+import com.ilsangtech.ilsang.feature.approval.model.CommentAlertUiState
 import com.ilsangtech.ilsang.feature.approval.model.CommentUiModel
 import com.ilsangtech.ilsang.feature.approval.model.CommentUiState
 import com.ilsangtech.ilsang.feature.approval.model.toUiModel
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -61,10 +63,11 @@ class ApprovalDetailViewModel @Inject constructor(
         .onStart {
             emit(Unit)
         }.flatMapLatest {
-            combine<MyInfo, List<Comment>, CommentUiState>(
+            combine(
                 userRepository.getMyInfo(),
-                flow { emit(commentRepository.getComments(missionHistoryId)) }
-            ) { myInfo, comments ->
+                flow { emit(commentRepository.getComments(missionHistoryId)) },
+                commentAlertUiState
+            ) { myInfo, comments, alertUiState ->
                 val commentUiModels = comments.flatMap { comment ->
                     listOf(comment) + comment.children
                 }.map { comment ->
@@ -79,8 +82,9 @@ class ApprovalDetailViewModel @Inject constructor(
 
                 CommentUiState.Success(
                     comments = commentUiModels,
-                    validCommentsSize = validCommentsSize
-                )
+                    validCommentsSize = validCommentsSize,
+                    alertUiState = alertUiState
+                ) as CommentUiState
             }
         }.catch { e ->
             emit(CommentUiState.Error)
@@ -89,6 +93,8 @@ class ApprovalDetailViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = CommentUiState.Loading
         )
+    private val _commentAlertUiState = MutableStateFlow<CommentAlertUiState?>(null)
+    val commentAlertUiState: StateFlow<CommentAlertUiState?> = _commentAlertUiState
 
     private val _listScrollRequestPosition = MutableStateFlow<Int?>(null)
     val listScrollPosition: StateFlow<Int?> = _listScrollRequestPosition
@@ -103,19 +109,26 @@ class ApprovalDetailViewModel @Inject constructor(
 
     fun createComment() {
         viewModelScope.launch {
-            commentRepository.createComment(
-                missionHistoryId = missionHistoryId,
-                parentId = selectedComment.value?.id,
-                comment = commentTextField.text.toString()
-            ).onSuccess {
-                commentRetryFlow.emit(Unit)
-                (commentUiState.value as? CommentUiState.Success)?.let { state ->
-                    _listScrollRequestPosition.update {
-                        if (selectedComment.value?.id == null) {
-                            state.comments.size - 1
-                        } else {
-                            state.comments.indexOfLast {
-                                it.parentId == selectedComment.value?.id
+            val text = commentTextField.text.toString()
+            when {
+                text.trim().isBlank() -> _commentAlertUiState.update {
+                    CommentAlertUiState.Empty
+                }
+
+                else -> commentRepository.createComment(
+                    missionHistoryId = missionHistoryId,
+                    parentId = selectedComment.value?.id,
+                    comment = commentTextField.text.toString()
+                ).onSuccess {
+                    commentRetryFlow.emit(Unit)
+                    (commentUiState.value as? CommentUiState.Success)?.let { state ->
+                        _listScrollRequestPosition.update {
+                            if (selectedComment.value?.id == null) {
+                                state.comments.size - 1
+                            } else {
+                                state.comments.indexOfLast {
+                                    it.parentId == selectedComment.value?.id
+                                }
                             }
                         }
                     }
@@ -136,5 +149,24 @@ class ApprovalDetailViewModel @Inject constructor(
 
     fun clearScrollPosition() {
         _listScrollRequestPosition.update { null }
+    }
+
+    suspend fun validateComment() {
+        val invalidInputRegex =
+            Regex("(<[^>]+>)|(https?://\\S+)")
+        snapshotFlow { commentTextField.text }.collectLatest { text ->
+            if (text.length > 300) {
+                commentTextField.edit { delete(300, text.length) }
+                _commentAlertUiState.update { CommentAlertUiState.TooLong }
+            }
+            if (invalidInputRegex.containsMatchIn(text)) {
+                commentTextField.clearText()
+                _commentAlertUiState.update { CommentAlertUiState.Invalid }
+            }
+        }
+    }
+
+    fun shownCommentAlert() {
+        _commentAlertUiState.update { null }
     }
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailViewModel.kt
@@ -1,10 +1,17 @@
 package com.ilsangtech.ilsang.feature.approval
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
+import com.ilsangtech.ilsang.feature.approval.navigation.ApprovalDetailRoute
+import com.ilsangtech.ilsang.feature.approval.navigation.missionHistoryUiModelTypeMap
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class ApprovalDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+    val missionHistoryUiModel =
+        savedStateHandle.toRoute<ApprovalDetailRoute>(missionHistoryUiModelTypeMap).missionHistory
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalScreen.kt
@@ -163,6 +163,8 @@ private fun ApprovalScreenPreview() {
             shareCount = 20,
             lastCompleteDate = null,
             expireDate = "",
+            isIsZoneQuest = false,
+            questId = 0
         ),
         MissionHistoryUiModel(
             commercialAreaName = "홍대",
@@ -190,6 +192,8 @@ private fun ApprovalScreenPreview() {
             shareCount = 20,
             lastCompleteDate = null,
             expireDate = "",
+            isIsZoneQuest = false,
+            questId = 0
         )
     )
     val lazyPagingItems =

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalScreen.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.flowOf
 @Composable
 internal fun ApprovalScreen(
     approvalViewModel: ApprovalViewModel = hiltViewModel(),
+    navigateToApprovalDetail: (MissionHistoryUiModel) -> Unit,
     navigateToQuestTab: (Int) -> Unit,
     navigateToProfile: (String) -> Unit,
     navigateToReport: (Int) -> Unit
@@ -59,6 +60,7 @@ internal fun ApprovalScreen(
 
     ApprovalScreen(
         missionHistoryItems = randomMissionHistoryItems,
+        onApprovalItemClick = navigateToApprovalDetail,
         onCtaCardClick = navigateToQuestTab,
         onLikeButtonClick = approvalViewModel::likeChallenge,
         onReportButtonClick = navigateToReport,
@@ -69,6 +71,7 @@ internal fun ApprovalScreen(
 @Composable
 private fun ApprovalScreen(
     missionHistoryItems: LazyPagingItems<MissionHistoryUiModel>,
+    onApprovalItemClick: (MissionHistoryUiModel) -> Unit,
     onCtaCardClick: (Int) -> Unit,
     onLikeButtonClick: (MissionHistoryUiModel) -> Unit,
     onReportButtonClick: (Int) -> Unit,
@@ -122,6 +125,7 @@ private fun ApprovalScreen(
                 missionHistoryItems[it]?.let { randomMissionHistory ->
                     ApprovalItem(
                         missionHistory = randomMissionHistory,
+                        onItemClick = { onApprovalItemClick(randomMissionHistory) },
                         onProfileClick = { navigateToProfile(randomMissionHistory.user.userId) },
                         onCtaCardClick = { /*TODO 실제 퀘스트 id 적용 필요*/ onCtaCardClick(0) },
                         onLikeButtonClick = { onLikeButtonClick(randomMissionHistory) },
@@ -202,6 +206,7 @@ private fun ApprovalScreenPreview() {
 
     ApprovalScreen(
         missionHistoryItems = lazyPagingItems,
+        onApprovalItemClick = {},
         onCtaCardClick = {},
         onLikeButtonClick = {},
         onReportButtonClick = {},

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalViewModel.kt
@@ -6,6 +6,7 @@ import androidx.paging.cachedIn
 import androidx.paging.map
 import com.ilsangtech.ilsang.core.domain.AreaRepository
 import com.ilsangtech.ilsang.core.domain.MissionRepository
+import com.ilsangtech.ilsang.core.domain.UserRepository
 import com.ilsangtech.ilsang.feature.approval.model.MissionHistoryUiModel
 import com.ilsangtech.ilsang.feature.approval.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,7 +14,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -21,6 +21,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ApprovalViewModel @Inject constructor(
     areaRepository: AreaRepository,
+    userRepository: UserRepository,
     private val missionRepository: MissionRepository
 ) : ViewModel() {
     private val _missionHistoryRefreshTrigger = MutableSharedFlow<Unit>(replay = 1)
@@ -29,7 +30,10 @@ class ApprovalViewModel @Inject constructor(
     private val likeMissionHistorySet = MutableStateFlow(setOf<Int>())
     private val hateMissionHistorySet = MutableStateFlow(setOf<Int>())
 
-    val randomMissionHistories = missionRepository.getRandomMissionHistory().map { pagingData ->
+    val randomMissionHistories = combine(
+        userRepository.getMyInfo(),
+        missionRepository.getRandomMissionHistory()
+    ) { myInfo, pagingData ->
         pagingData.map { randomMissionHistory ->
             if (randomMissionHistory.currentUserEmojis.contains("LIKE")) {
                 likeMissionHistorySet.update { it + randomMissionHistory.missionHistoryId }
@@ -40,7 +44,10 @@ class ApprovalViewModel @Inject constructor(
 
             val commercialArea =
                 areaRepository.getCommercialArea(randomMissionHistory.commercialAreaCode)
-            randomMissionHistory.toUiModel(commercialArea.areaName)
+            randomMissionHistory.toUiModel(
+                isIsZoneQuest = myInfo.isCommercialAreaCode == commercialArea.code,
+                areaName = commercialArea.areaName
+            )
         }
     }.cachedIn(viewModelScope)
         .combine(likeMissionHistorySet) { pagingData, likeMissionHistorySet ->

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ReportViewModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ReportViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.ilsangtech.ilsang.core.domain.CommentRepository
 import com.ilsangtech.ilsang.core.domain.MissionRepository
 import com.ilsangtech.ilsang.feature.approval.model.ReportResultUiState
 import com.ilsangtech.ilsang.feature.approval.model.ReportTypeUiModel
@@ -18,7 +19,8 @@ import javax.inject.Inject
 @HiltViewModel
 class ReportViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val missionRepository: MissionRepository
+    private val missionRepository: MissionRepository,
+    private val commentRepository: CommentRepository
 ) : ViewModel() {
     private val missionHistoryId = savedStateHandle.toRoute<ReportRoute>().missionHistoryId
     private val commentId = savedStateHandle.toRoute<ReportRoute>().commentId
@@ -47,6 +49,20 @@ class ReportViewModel @Inject constructor(
             missionHistoryId?.let { missionHistoryId ->
                 missionRepository.reportMissionHistory(
                     missionHistoryId = missionHistoryId,
+                    reason = reason
+                ).onSuccess { isSuccess ->
+                    if (isSuccess) {
+                        _reportResultUiState.update { ReportResultUiState.Success }
+                    } else {
+                        _reportResultUiState.update { ReportResultUiState.Reported }
+                    }
+                }.onFailure {
+                    _reportResultUiState.update { ReportResultUiState.Failure }
+                }
+            }
+            commentId?.let { commentId ->
+                commentRepository.reportComment(
+                    commentId = commentId,
                     reason = reason
                 ).onSuccess { isSuccess ->
                     if (isSuccess) {

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalDetailHeader.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalDetailHeader.kt
@@ -1,0 +1,63 @@
+package com.ilsangtech.ilsang.feature.approval.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ilsangtech.ilsang.designsystem.R
+import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
+import com.ilsangtech.ilsang.designsystem.theme.toSp
+
+@Composable
+internal fun ApprovalDetailHeader(
+    modifier: Modifier = Modifier,
+    onBackButtonClick: () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(top = 12.dp, bottom = 11.dp)
+            .padding(start = 15.dp)
+    ) {
+        Icon(
+            modifier = Modifier
+                .clickable(
+                    onClick = onBackButtonClick,
+                    indication = null,
+                    interactionSource = null
+                ),
+            tint = Color.Black,
+            painter = painterResource(R.drawable.icon_chevron_back),
+            contentDescription = "뒤로 가기"
+        )
+        Text(
+            modifier = Modifier.align(Alignment.Center),
+            text = "인증 상세",
+            style = TextStyle(
+                fontFamily = pretendardFontFamily,
+                fontWeight = FontWeight.Bold,
+                fontSize = 17.dp.toSp(),
+                lineHeight = 22.dp.toSp()
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ApprovalDetailHeaderPreview() {
+    ApprovalDetailHeader {}
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalDetailItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalDetailItem.kt
@@ -1,0 +1,44 @@
+package com.ilsangtech.ilsang.feature.approval.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.ilsangtech.ilsang.feature.approval.model.MissionHistoryUiModel
+
+@Composable
+internal fun ApprovalDetailItem(
+    modifier: Modifier = Modifier,
+    missionHistory: MissionHistoryUiModel,
+    onProfileClick: () -> Unit,
+    onShareButtonClick: () -> Unit,
+    onReportButtonClick: () -> Unit,
+    onCtaButtonClick: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .padding(top = 20.dp, bottom = 32.dp)
+            .padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        ApprovalItemUserInfo(
+            user = missionHistory.user,
+            onProfileClick = onProfileClick,
+            onShareButtonClick = onShareButtonClick,
+            onReportButtonClick = onReportButtonClick
+        )
+        ApprovalItemContent(
+            challengeImage = missionHistory.submitImageId,
+            createdAt = missionHistory.createdAt,
+            areaName = missionHistory.commercialAreaName
+        )
+        ApprovalItemCtaCard(
+            questTitle = missionHistory.title,
+            writerName = missionHistory.writerName,
+            questType = missionHistory.questType,
+            onClick = onCtaButtonClick
+        )
+    }
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItem.kt
@@ -163,7 +163,9 @@ private fun ApprovalItemPreview() {
         writerName = "야미돈까스 정자동점",
         questType = QuestType.Repeat.Weekly,
         lastCompleteDate = "",
-        expireDate = ""
+        expireDate = "",
+        isIsZoneQuest = false,
+        questId = 0
     )
     ApprovalItem(
         missionHistory = missionHistory,

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItem.kt
@@ -35,6 +35,7 @@ import java.io.File
 @Composable
 internal fun ApprovalItem(
     missionHistory: MissionHistoryUiModel,
+    onItemClick: () -> Unit,
     onProfileClick: () -> Unit,
     onCtaCardClick: () -> Unit,
     onLikeButtonClick: () -> Unit,
@@ -96,7 +97,8 @@ internal fun ApprovalItem(
             }
         },
         color = Color.White,
-        shape = RoundedCornerShape(12.dp)
+        shape = RoundedCornerShape(12.dp),
+        onClick = onItemClick
     ) {
         Column(
             modifier = Modifier
@@ -169,6 +171,7 @@ private fun ApprovalItemPreview() {
     )
     ApprovalItem(
         missionHistory = missionHistory,
+        onItemClick = {},
         onProfileClick = {},
         onCtaCardClick = {},
         onLikeButtonClick = {},

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentItem.kt
@@ -66,7 +66,10 @@ import com.ilsangtech.ilsang.feature.approval.model.CommentUiModel
 internal fun CommentItem(
     modifier: Modifier = Modifier,
     comment: CommentUiModel,
-    onCommentButtonClick: () -> Unit
+    onProfileClick: () -> Unit,
+    onCommentButtonClick: () -> Unit,
+    onReportButtonClick: () -> Unit,
+    onDeleteButtonClick: () -> Unit
 ) {
     Column(
         modifier = modifier
@@ -99,7 +102,10 @@ internal fun CommentItem(
                 ) {
                     CommentItemHeader(
                         commentWriter = comment.commentWriter,
-                        isMyComment = comment.isMyComment
+                        isMyComment = comment.isMyComment,
+                        onProfileClick = onProfileClick,
+                        onDeleteButtonClick = onDeleteButtonClick,
+                        onReportButtonClick = onReportButtonClick
                     )
                     Spacer(Modifier.height(4.dp))
                     Text(
@@ -122,7 +128,10 @@ internal fun CommentItem(
 private fun CommentItemHeader(
     modifier: Modifier = Modifier,
     commentWriter: CommentUiModel.CommentWriterUiModel,
-    isMyComment: Boolean
+    isMyComment: Boolean,
+    onProfileClick: () -> Unit,
+    onDeleteButtonClick: () -> Unit,
+    onReportButtonClick: () -> Unit
 ) {
     var showPopup by remember { mutableStateOf(false) }
 
@@ -134,7 +143,12 @@ private fun CommentItemHeader(
         AsyncImage(
             modifier = Modifier
                 .size(35.dp)
-                .clip(CircleShape),
+                .clip(CircleShape)
+                .clickable(
+                    onClick = onProfileClick,
+                    indication = null,
+                    interactionSource = null
+                ),
             model = BuildConfig.IMAGE_URL + commentWriter.profileImageId,
             placeholder = painterResource(R.drawable.default_user_profile),
             error = painterResource(R.drawable.default_user_profile),
@@ -218,6 +232,14 @@ private fun CommentItemHeader(
                         .width(150.dp)
                         .padding(horizontal = 12.dp)
                         .padding(vertical = 2.dp)
+                        .clickable {
+                            if (isMyComment) {
+                                onDeleteButtonClick()
+                            } else {
+                                onReportButtonClick()
+                            }
+                            showPopup = false
+                        }
                 ) {
                     Text(
                         modifier = Modifier.align(Alignment.CenterStart),
@@ -369,6 +391,9 @@ private fun CommentItemPreview() {
             isReported = false,
             isDeleted = false
         ),
-        onCommentButtonClick = {}
+        onProfileClick = {},
+        onCommentButtonClick = {},
+        onReportButtonClick = {},
+        onDeleteButtonClick = {}
     )
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentItem.kt
@@ -2,7 +2,6 @@ package com.ilsangtech.ilsang.feature.approval.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -10,11 +9,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,16 +30,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import coil3.compose.AsyncImage
 import com.ilsangtech.ilsang.core.model.title.Title
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
@@ -47,14 +48,18 @@ import com.ilsangtech.ilsang.core.ui.title.TitleGradeIcon
 import com.ilsangtech.ilsang.designsystem.R
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.designsystem.theme.badge01TextStyle
+import com.ilsangtech.ilsang.designsystem.theme.badge02TextStyle
 import com.ilsangtech.ilsang.designsystem.theme.caption01
 import com.ilsangtech.ilsang.designsystem.theme.caption02
 import com.ilsangtech.ilsang.designsystem.theme.gray100
 import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
+import com.ilsangtech.ilsang.designsystem.theme.primary100
 import com.ilsangtech.ilsang.designsystem.theme.primary300
+import com.ilsangtech.ilsang.designsystem.theme.primary500
 import com.ilsangtech.ilsang.designsystem.theme.subTitle02
 import com.ilsangtech.ilsang.designsystem.theme.tapBoldTextStyle
+import com.ilsangtech.ilsang.designsystem.theme.toSp
 import com.ilsangtech.ilsang.feature.approval.model.CommentUiModel
 
 @Composable
@@ -66,54 +71,37 @@ internal fun CommentItem(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .heightIn(min = 144.dp)
-            .background(
-                if (comment.parentId == null) {
-                    Color.White
-                } else {
-                    background
-                }
-            )
+            .drawBehind {
+                drawRect(color = if (comment.parentId == null) Color.White else background)
+                drawLine(
+                    start = Offset(x = 0f, y = size.height),
+                    end = Offset(x = size.width, y = size.height),
+                    color = gray100,
+                    strokeWidth = 1.dp.toPx()
+                )
+            }
     ) {
         when {
             comment.isReported -> {
-                Text(
-                    text = "신고 누적으로 숨겨진 댓글입니다.",
-                    style = subTitle02,
-                    color = gray500,
-                    textAlign = TextAlign.Center
-                )
+                ReportedCommentBox()
             }
 
             comment.isDeleted -> {
-                Text(
-                    text = "삭제된 댓글입니다.",
-                    style = subTitle02,
-                    color = gray500,
-                    textAlign = TextAlign.Center
-                )
+                DeletedCommentBox()
             }
 
             else -> {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .drawBehind {
-                            drawLine(
-                                start = Offset(x = 0f, y = size.height),
-                                end = Offset(x = size.width, y = size.height),
-                                color = gray100,
-                                strokeWidth = 1.dp.toPx()
-                            )
-                        }
                         .padding(20.dp)
-                        .padding(start = comment.parentId?.let { 20.dp } ?: 0.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                        .padding(start = comment.parentId?.let { 20.dp } ?: 0.dp)
                 ) {
                     CommentItemHeader(
                         commentWriter = comment.commentWriter,
                         isMyComment = comment.isMyComment
                     )
+                    Spacer(Modifier.height(4.dp))
                     Text(
                         modifier = Modifier.fillMaxWidth(),
                         text = comment.comment,
@@ -121,6 +109,7 @@ internal fun CommentItem(
                     )
                     CommentItemFooter(
                         createdAt = comment.createdAt,
+                        parentId = comment.parentId,
                         onCommentButtonClick = onCommentButtonClick
                     )
                 }
@@ -136,79 +125,56 @@ private fun CommentItemHeader(
     isMyComment: Boolean
 ) {
     var showPopup by remember { mutableStateOf(false) }
-    val popupYOffset = with(LocalDensity.current) { 46.dp.roundToPx() }
+
     Row(
-        modifier = modifier,
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        if (showPopup) {
-            Popup(
-                alignment = Alignment.BottomEnd,
-                offset = IntOffset(x = 0, y = popupYOffset),
-                onDismissRequest = { showPopup = false }
-            ) {
-                Box(
-                    modifier = Modifier
-                        .width(150.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                        .border(
-                            border = BorderStroke(
-                                color = gray100,
-                                width = 1.dp
-                            ),
-                            shape = RoundedCornerShape(8.dp)
-                        )
-                        .padding(
-                            vertical = 10.dp,
-                            horizontal = 12.dp
-                        )
-                ) {
-                    Text(
-                        modifier = Modifier.align(Alignment.CenterStart),
-                        text = if (isMyComment) "삭제" else "신고",
-                        style = TextStyle(
-                            fontFamily = pretendardFontFamily,
-                            fontWeight = FontWeight.Normal,
-                            fontSize = 15.sp,
-                            lineHeight = 1.3.sp
-                        ),
-                        color = gray500
-                    )
-                    Icon(
-                        modifier = Modifier
-                            .size(15.dp)
-                            .align(Alignment.CenterEnd),
-                        painter = if (isMyComment) {
-                            painterResource(R.drawable.icon_delete)
-                        } else {
-                            painterResource(R.drawable.report)
-                        },
-                        tint = gray500,
-                        contentDescription = null
-                    )
-                }
-            }
-        }
-
         AsyncImage(
-            modifier = Modifier.size(35.dp),
+            modifier = Modifier
+                .size(35.dp)
+                .clip(CircleShape),
             model = BuildConfig.IMAGE_URL + commentWriter.profileImageId,
             placeholder = painterResource(R.drawable.default_user_profile),
             error = painterResource(R.drawable.default_user_profile),
             contentDescription = null
         )
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text(
-                text = commentWriter.nickname,
-                style = TextStyle(
-                    fontFamily = pretendardFontFamily,
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 14.sp,
-                    lineHeight = 12.sp
-                ),
-                color = gray500
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = commentWriter.nickname,
+                    style = TextStyle(
+                        fontFamily = pretendardFontFamily,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 14.sp,
+                        lineHeight = 12.sp
+                    ),
+                    color = gray500
+                )
+                if (commentWriter.isMissionHistoryUser) {
+                    Box(
+                        modifier = Modifier
+                            .height(20.dp)
+                            .clip(RoundedCornerShape(20.dp))
+                            .background(primary100),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            modifier = Modifier.padding(horizontal = 6.dp),
+                            text = "수행자",
+                            style = badge02TextStyle.copy(
+                                fontSize = 10.dp.toSp(),
+                                lineHeight = 12.dp.toSp()
+                            ),
+                            color = primary500
+                        )
+                    }
+                }
+            }
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp)
@@ -237,6 +203,48 @@ private fun CommentItemHeader(
             tint = gray500,
             contentDescription = null
         )
+        Box(modifier = Modifier.align(Alignment.Bottom)) {
+            DropdownMenu(
+                expanded = showPopup,
+                shape = RoundedCornerShape(8.dp),
+                border = BorderStroke(color = gray100, width = 1.dp),
+                containerColor = Color.White,
+                offset = DpOffset(x = 0.dp, y = 10.dp),
+                properties = PopupProperties(focusable = true),
+                onDismissRequest = { showPopup = false }
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(150.dp)
+                        .padding(horizontal = 12.dp)
+                        .padding(vertical = 2.dp)
+                ) {
+                    Text(
+                        modifier = Modifier.align(Alignment.CenterStart),
+                        text = if (isMyComment) "삭제" else "신고",
+                        style = TextStyle(
+                            fontFamily = pretendardFontFamily,
+                            fontWeight = FontWeight.Normal,
+                            fontSize = 15.sp,
+                            lineHeight = 1.3.sp
+                        ),
+                        color = gray500
+                    )
+                    Icon(
+                        modifier = Modifier
+                            .size(15.dp)
+                            .align(Alignment.CenterEnd),
+                        painter = if (isMyComment) {
+                            painterResource(R.drawable.icon_delete)
+                        } else {
+                            painterResource(R.drawable.report)
+                        },
+                        tint = gray500,
+                        contentDescription = null
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -244,27 +252,66 @@ private fun CommentItemHeader(
 private fun CommentItemFooter(
     modifier: Modifier = Modifier,
     createdAt: String,
+    parentId: Int?,
     onCommentButtonClick: () -> Unit
 ) {
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = if (parentId == null) 12.dp else 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Text(
-            modifier = Modifier.clickable(
-                onClick = onCommentButtonClick,
-                indication = null,
-                interactionSource = null
-            ),
-            text = "답글 달기",
-            style = tapBoldTextStyle,
-            color = primary300
-        )
+        if (parentId == null) {
+            Text(
+                modifier = Modifier.clickable(
+                    onClick = onCommentButtonClick,
+                    indication = null,
+                    interactionSource = null
+                ),
+                text = "답글 달기",
+                style = tapBoldTextStyle,
+                color = primary300
+            )
+        }
         Text(
             text = createdAt,
             style = caption02,
             color = gray500
+        )
+    }
+}
+
+@Composable
+private fun ReportedCommentBox() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(144.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "신고 누적으로 숨겨진 댓글입니다.",
+            style = subTitle02,
+            color = gray500,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun DeletedCommentBox() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(144.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "삭제된 댓글입니다.",
+            style = subTitle02,
+            color = gray500,
+            textAlign = TextAlign.Center
         )
     }
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentItem.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import coil3.compose.AsyncImage
-import com.ilsangtech.ilsang.core.model.comment.CommentWriter
 import com.ilsangtech.ilsang.core.model.title.Title
 import com.ilsangtech.ilsang.core.model.title.TitleGrade
 import com.ilsangtech.ilsang.core.model.title.TitleType
@@ -133,7 +132,7 @@ internal fun CommentItem(
 @Composable
 private fun CommentItemHeader(
     modifier: Modifier = Modifier,
-    commentWriter: CommentWriter,
+    commentWriter: CommentUiModel.CommentWriterUiModel,
     isMyComment: Boolean
 ) {
     var showPopup by remember { mutableStateOf(false) }
@@ -290,7 +289,7 @@ private fun CommentItemPreview() {
             id = 2,
             parentId = null,
             comment = commentContent,
-            commentWriter = CommentWriter(
+            commentWriter = CommentUiModel.CommentWriterUiModel(
                 userId = "",
                 nickname = "일상123",
                 profileImageId = null,
@@ -298,7 +297,8 @@ private fun CommentItemPreview() {
                     name = "세상을 움직이는 자",
                     grade = TitleGrade.Standard,
                     type = TitleType.Contribution
-                )
+                ),
+                isMissionHistoryUser = false
             ),
             createdAt = "2025.04.12 12:00",
             isMyComment = false,

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentItem.kt
@@ -316,6 +316,23 @@ private fun DeletedCommentBox() {
     }
 }
 
+@Composable
+internal fun EmptyCommentBox() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(144.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "댓글이 아직 없어요",
+            style = subTitle02,
+            color = gray500,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun CommentItemPreview() {

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentTextField.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/CommentTextField.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.ilsangtech.ilsang.designsystem.theme.buttonTextStyle
@@ -42,6 +43,7 @@ internal fun CommentTextField(
         modifier = modifier
             .fillMaxWidth()
             .drawBehind {
+                drawRect(color = Color.White)
                 drawLine(
                     color = gray100,
                     strokeWidth = 1.dp.toPx(),

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/RecommentProgressCard.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/RecommentProgressCard.kt
@@ -1,0 +1,61 @@
+package com.ilsangtech.ilsang.feature.approval.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ilsangtech.ilsang.designsystem.theme.caption02
+import com.ilsangtech.ilsang.designsystem.theme.gray400
+import com.ilsangtech.ilsang.designsystem.theme.primary
+import com.ilsangtech.ilsang.designsystem.theme.primary100
+import com.ilsangtech.ilsang.designsystem.theme.toSp
+
+@Composable
+internal fun RecommentProgressCard(
+    modifier: Modifier = Modifier,
+    commentWriterName: String,
+    onCancelButtonClick: () -> Unit
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(30.dp)
+            .background(primary100)
+            .padding(horizontal = 20.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "${commentWriterName}님께 답글 남기는 중",
+            style = caption02.copy(
+                fontSize = 12.dp.toSp(),
+                lineHeight = 16.dp.toSp()
+            ),
+            color = primary
+        )
+        Text(
+            modifier = Modifier.clickable(onClick = onCancelButtonClick),
+            text = "취소",
+            style = caption02.copy(
+                fontSize = 12.dp.toSp(),
+                lineHeight = 16.dp.toSp()
+            ),
+            color = gray400
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun RecommentProgressCardPreview() {
+    RecommentProgressCard(commentWriterName = "일상 123") { }
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/CommentUiModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/CommentUiModel.kt
@@ -1,14 +1,56 @@
 package com.ilsangtech.ilsang.feature.approval.model
 
+import com.ilsangtech.ilsang.core.model.comment.Comment
 import com.ilsangtech.ilsang.core.model.comment.CommentWriter
+import com.ilsangtech.ilsang.core.model.title.Title
+import com.ilsangtech.ilsang.core.util.DateConverter
 
 data class CommentUiModel(
     val id: Int,
     val parentId: Int?,
     val comment: String,
-    val commentWriter: CommentWriter,
+    val commentWriter: CommentWriterUiModel,
     val createdAt: String,
     val isMyComment: Boolean,
     val isReported: Boolean,
     val isDeleted: Boolean
-)
+) {
+    data class CommentWriterUiModel(
+        val userId: String,
+        val nickname: String,
+        val profileImageId: String?,
+        val title: Title,
+        val isMissionHistoryUser: Boolean
+    )
+}
+
+internal fun Comment.toUiModel(
+    isMyComment: Boolean,
+    isMissionHistoryUser: Boolean
+): CommentUiModel {
+    return CommentUiModel(
+        id = id,
+        parentId = parentId,
+        comment = comment,
+        commentWriter = writer.toUiModel(isMissionHistoryUser),
+        createdAt = DateConverter.formatDate(
+            input = createdAt,
+            outputPattern = "yyyy.MM.dd HH:mm"
+        ),
+        isMyComment = isMyComment,
+        isReported = hasReported,
+        isDeleted = isDeleted
+    )
+}
+
+internal fun CommentWriter.toUiModel(
+    isMissionHistoryUser: Boolean
+): CommentUiModel.CommentWriterUiModel {
+    return CommentUiModel.CommentWriterUiModel(
+        userId = userId,
+        nickname = nickname,
+        profileImageId = profileImageId,
+        title = title,
+        isMissionHistoryUser = isMissionHistoryUser
+    )
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/CommentUiState.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/CommentUiState.kt
@@ -4,7 +4,8 @@ sealed interface CommentUiState {
     data object Loading : CommentUiState
     data class Success(
         val comments: List<CommentUiModel>,
-        val validCommentsSize: Int
+        val validCommentsSize: Int,
+        val alertUiState: CommentAlertUiState?
     ) : CommentUiState
 
     data object Error : CommentUiState

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/CommentUiState.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/CommentUiState.kt
@@ -1,0 +1,11 @@
+package com.ilsangtech.ilsang.feature.approval.model
+
+sealed interface CommentUiState {
+    data object Loading : CommentUiState
+    data class Success(
+        val comments: List<CommentUiModel>,
+        val validCommentsSize: Int
+    ) : CommentUiState
+
+    data object Error : CommentUiState
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionHistoryUiModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionHistoryUiModel.kt
@@ -4,7 +4,9 @@ import com.ilsangtech.ilsang.core.model.mission.MissionHistoryUser
 import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistory
 import com.ilsangtech.ilsang.core.model.quest.QuestType
 import com.ilsangtech.ilsang.core.util.DateConverter
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class MissionHistoryUiModel(
     val missionHistoryId: Int,
     val questId: Int,

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionHistoryUiModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionHistoryUiModel.kt
@@ -6,12 +6,13 @@ import com.ilsangtech.ilsang.core.model.quest.QuestType
 import com.ilsangtech.ilsang.core.util.DateConverter
 
 data class MissionHistoryUiModel(
+    val missionHistoryId: Int,
+    val questId: Int,
     val commercialAreaName: String,
     val createdAt: String,
     val currentUserEmojis: List<String>,
     val hateCount: Int,
     val likeCount: Int,
-    val missionHistoryId: Int,
     val submitImageId: String,
     val title: String,
     val writerName: String,
@@ -21,11 +22,17 @@ data class MissionHistoryUiModel(
     val commentCount: Int,
     val shareCount: Int,
     val lastCompleteDate: String?,
-    val expireDate: String?
+    val expireDate: String?,
+    val isIsZoneQuest: Boolean
 )
 
-internal fun RandomMissionHistory.toUiModel(areaName: String): MissionHistoryUiModel {
+internal fun RandomMissionHistory.toUiModel(
+    areaName: String,
+    isIsZoneQuest: Boolean
+): MissionHistoryUiModel {
     return MissionHistoryUiModel(
+        missionHistoryId = missionHistoryId,
+        questId = 0, // TODO: 실제 quest id 적용 필요
         commercialAreaName = areaName,
         createdAt = DateConverter.formatDate(
             input = createdAt,
@@ -34,7 +41,6 @@ internal fun RandomMissionHistory.toUiModel(areaName: String): MissionHistoryUiM
         currentUserEmojis = currentUserEmojis,
         hateCount = hateCount,
         likeCount = likeCount,
-        missionHistoryId = missionHistoryId,
         submitImageId = submitImageId,
         title = title,
         writerName = writerName,
@@ -44,6 +50,7 @@ internal fun RandomMissionHistory.toUiModel(areaName: String): MissionHistoryUiM
         commentCount = commentCount,
         shareCount = shareCount,
         lastCompleteDate = lastCompleteDate,
-        expireDate = expireDate
+        expireDate = expireDate,
+        isIsZoneQuest = isIsZoneQuest
     )
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
@@ -10,6 +10,7 @@ import com.ilsangtech.ilsang.feature.approval.ApprovalDetailScreen
 import com.ilsangtech.ilsang.feature.approval.ApprovalExampleScreen
 import com.ilsangtech.ilsang.feature.approval.ApprovalScreen
 import com.ilsangtech.ilsang.feature.approval.ReportScreen
+import com.ilsangtech.ilsang.feature.approval.model.MissionHistoryUiModel
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlin.reflect.typeOf
@@ -37,14 +38,7 @@ data class ReportRoute(
 )
 
 @Serializable
-data class ApprovalDetailRoute(
-    val missionId: Int,
-    val questId: Int,
-    val title: String,
-    val writerName: String,
-    val questType: QuestType,
-    val isIsZoneQuest: Boolean
-)
+data class ApprovalDetailRoute(val missionHistory: MissionHistoryUiModel)
 
 fun NavGraphBuilder.approvalNavigation(
     popBackStack: () -> Unit,

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
@@ -1,6 +1,8 @@
 package com.ilsangtech.ilsang.feature.approval.navigation
 
+import android.net.Uri
 import android.os.Bundle
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
@@ -40,8 +42,14 @@ data class ReportRoute(
 @Serializable
 data class ApprovalDetailRoute(val missionHistory: MissionHistoryUiModel)
 
+
+fun NavController.navigateToApprovalDetail(missionHistory: MissionHistoryUiModel) {
+    navigate(ApprovalDetailRoute(missionHistory))
+}
+
 fun NavGraphBuilder.approvalNavigation(
     popBackStack: () -> Unit,
+    navigateToApprovalDetail: (MissionHistoryUiModel) -> Unit,
     navigateToQuestTab: (Int) -> Unit,
     navigateToImageCapture: (Int, Int, Boolean) -> Unit,
     navigateToProfile: (String) -> Unit,
@@ -50,6 +58,7 @@ fun NavGraphBuilder.approvalNavigation(
     navigation<ApprovalBaseRoute>(startDestination = ApprovalRoute) {
         composable<ApprovalRoute> {
             ApprovalScreen(
+                navigateToApprovalDetail = navigateToApprovalDetail,
                 navigateToQuestTab = navigateToQuestTab,
                 navigateToProfile = navigateToProfile,
                 navigateToReport = navigateToMissionReport

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
@@ -67,7 +67,7 @@ fun NavGraphBuilder.approvalNavigation(
     composable<ReportRoute> {
         ReportScreen(popBackStack = popBackStack)
     }
-    composable<ApprovalDetailRoute>(questTypeMap) {
+    composable<ApprovalDetailRoute>(missionHistoryUiModelTypeMap) {
         ApprovalDetailScreen()
     }
 }
@@ -98,4 +98,26 @@ private val questTypeNavType =
         }
     }
 
+private val missionHistoryUiModelNavType =
+    object : NavType<MissionHistoryUiModel>(isNullableAllowed = false) {
+        override fun get(bundle: Bundle, key: String): MissionHistoryUiModel? {
+            return bundle.getString(key)?.let {
+                Json.decodeFromString(Uri.decode(it))
+            }
+        }
+
+        override fun parseValue(value: String): MissionHistoryUiModel {
+            return Json.decodeFromString(Uri.decode(value))
+        }
+
+        override fun put(bundle: Bundle, key: String, value: MissionHistoryUiModel) {
+            bundle.putString(key, Uri.encode(Json.encodeToString(value)))
+        }
+
+        override fun serializeAsValue(value: MissionHistoryUiModel): String {
+            return Uri.encode(Json.encodeToString(value))
+        }
+    }
 internal val questTypeMap = mapOf(typeOf<QuestType>() to questTypeNavType)
+internal val missionHistoryUiModelTypeMap =
+    mapOf(typeOf<MissionHistoryUiModel>() to missionHistoryUiModelNavType)

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
@@ -77,7 +77,11 @@ fun NavGraphBuilder.approvalNavigation(
         ReportScreen(popBackStack = popBackStack)
     }
     composable<ApprovalDetailRoute>(missionHistoryUiModelTypeMap) {
-        ApprovalDetailScreen()
+        ApprovalDetailScreen(
+            onBackButtonClick = popBackStack,
+            onProfileClick = navigateToProfile,
+            onMissionHistoryReportClick = navigateToMissionReport
+        )
     }
 }
 

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
@@ -53,7 +53,8 @@ fun NavGraphBuilder.approvalNavigation(
     navigateToQuestTab: (Int) -> Unit,
     navigateToImageCapture: (Int, Int, Boolean) -> Unit,
     navigateToProfile: (String) -> Unit,
-    navigateToMissionReport: (Int) -> Unit
+    navigateToMissionReport: (Int) -> Unit,
+    navigateToCommentReport: (Int) -> Unit
 ) {
     navigation<ApprovalBaseRoute>(startDestination = ApprovalRoute) {
         composable<ApprovalRoute> {
@@ -80,7 +81,8 @@ fun NavGraphBuilder.approvalNavigation(
         ApprovalDetailScreen(
             onBackButtonClick = popBackStack,
             onProfileClick = navigateToProfile,
-            onMissionHistoryReportClick = navigateToMissionReport
+            onMissionHistoryReportClick = navigateToMissionReport,
+            onCommentReportClick = navigateToCommentReport
         )
     }
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/navigation/ApprovalNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.ilsangtech.ilsang.core.model.quest.QuestType
+import com.ilsangtech.ilsang.feature.approval.ApprovalDetailScreen
 import com.ilsangtech.ilsang.feature.approval.ApprovalExampleScreen
 import com.ilsangtech.ilsang.feature.approval.ApprovalScreen
 import com.ilsangtech.ilsang.feature.approval.ReportScreen
@@ -35,6 +36,16 @@ data class ReportRoute(
     val commentId: Int? = null
 )
 
+@Serializable
+data class ApprovalDetailRoute(
+    val missionId: Int,
+    val questId: Int,
+    val title: String,
+    val writerName: String,
+    val questType: QuestType,
+    val isIsZoneQuest: Boolean
+)
+
 fun NavGraphBuilder.approvalNavigation(
     popBackStack: () -> Unit,
     navigateToQuestTab: (Int) -> Unit,
@@ -61,6 +72,9 @@ fun NavGraphBuilder.approvalNavigation(
     }
     composable<ReportRoute> {
         ReportScreen(popBackStack = popBackStack)
+    }
+    composable<ApprovalDetailRoute>(questTypeMap) {
+        ApprovalDetailScreen()
     }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolves #305

## 📝작업 내용

> 인증 상세 화면 UI를 구현하고, 댓글 API를 연동해 댓글 기능이 동작하도록 하였습니다.
특이사항으로 퀘스트 id 를 받아 CTA 버튼을 눌렀을 때 처리 추가 구현 필요
### 스크린샷 (선택)
<img width="360" alt="image" src="https://github.com/user-attachments/assets/c505767d-7834-4536-942a-a30d7434f711" />
<img width="360" alt="Screenshot_20251230_191430" src="https://github.com/user-attachments/assets/f065a0e6-f9a1-4e16-8777-9500e80dab62" />

