### PR TITLE
[Feat] 퀘스트 상세 하단시트 보상 UI, 퀘스트 수행 후 쿠폰 보상 다이얼로그 UI 표시

### DIFF
--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/coupon/mapper/CouponMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/coupon/mapper/CouponMapper.kt
@@ -24,6 +24,7 @@ internal fun QuestDetailCouponNetworkModel.toQuestDetailCoupon(): QuestDetailCou
     return QuestDetailCoupon(
         id = id,
         name = name,
+        type = type.toCouponType(),
         imageId = imageId,
         storeName = storeName,
         validTo = validTo,

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/coupon/mapper/CouponTypeMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/coupon/mapper/CouponTypeMapper.kt
@@ -1,0 +1,13 @@
+package com.ilsangtech.ilsang.core.data.coupon.mapper
+
+import com.ilsangtech.ilsang.core.model.coupon.CouponType
+
+internal fun String.toCouponType(): CouponType {
+    return when (this) {
+        "WEEK" -> CouponType.Week
+        "MONTH" -> CouponType.Month
+        "SEASON" -> CouponType.Season
+        "REALTIME" -> CouponType.RealTime
+        else -> throw IllegalArgumentException("Unknown coupon type: $this")
+    }
+}

--- a/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/mapper/RewardPointMapper.kt
+++ b/core/data/src/main/java/com/ilsangtech/ilsang/core/data/quest/mapper/RewardPointMapper.kt
@@ -7,7 +7,6 @@ fun RewardPointNetworkModel.toRewardPoint(): RewardPoint {
     return when (pointType) {
         "METRO" -> RewardPoint.Metro(point)
         "COMMERCIAL" -> RewardPoint.Commercial(point)
-        "CONTRIBUTION" -> RewardPoint.Contribute(point)
-        else -> throw IllegalArgumentException("Unknown point type: $pointType")
+        else -> RewardPoint.Contribute(point)
     }
 }

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/coupon/CouponType.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/coupon/CouponType.kt
@@ -1,0 +1,8 @@
+package com.ilsangtech.ilsang.core.model.coupon
+
+sealed interface CouponType {
+    data object Week : CouponType
+    data object Month : CouponType
+    data object Season : CouponType
+    data object RealTime : CouponType
+}

--- a/core/model/src/main/java/com/ilsangtech/ilsang/core/model/coupon/QuestDetailCoupon.kt
+++ b/core/model/src/main/java/com/ilsangtech/ilsang/core/model/coupon/QuestDetailCoupon.kt
@@ -3,6 +3,7 @@ package com.ilsangtech.ilsang.core.model.coupon
 data class QuestDetailCoupon(
     val id: Int,
     val name: String,
+    val type: CouponType,
     val imageId: String?,
     val validTo: String,
     val storeName: String?,

--- a/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/coupon/QuestDetailCouponNetworkModel.kt
+++ b/core/network/src/main/java/com/ilsangtech/ilsang/core/network/model/coupon/QuestDetailCouponNetworkModel.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 data class QuestDetailCouponNetworkModel(
     val id: Int,
     val name: String,
+    val type: String,
     val imageId: String?,
     val validTo: String,
     val storeName: String?,

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/coupon/QuestRewardCouponDialog.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/coupon/QuestRewardCouponDialog.kt
@@ -40,8 +40,9 @@ import com.ilsangtech.ilsang.designsystem.theme.tapRegularTextStyle
 import com.ilsangtech.ilsang.designsystem.theme.title02
 
 @Composable
-internal fun QuestRewardCouponDialog(
+fun QuestRewardCouponDialog(
     coupon: QuestDetailCoupon,
+    isObtained: Boolean = false,
     onDismissRequest: () -> Unit
 ) {
     Dialog(onDismissRequest = onDismissRequest) {
@@ -61,7 +62,7 @@ internal fun QuestRewardCouponDialog(
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Text(
-                        text = "이번 주 특별 보상",
+                        text = "특별 보상",
                         style = heading02
                     )
                     Icon(
@@ -112,7 +113,7 @@ internal fun QuestRewardCouponDialog(
                     onClick = onDismissRequest
                 ) {
                     Text(
-                        text = "확인",
+                        text = if (isObtained) "획득" else "확인",
                         style = TextStyle(
                             fontFamily = pretendardFontFamily,
                             fontWeight = FontWeight.SemiBold,

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/coupon/QuestRewardCouponDialog.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/coupon/QuestRewardCouponDialog.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import com.ilsangtech.ilsang.core.model.coupon.CouponType
 import com.ilsangtech.ilsang.core.model.coupon.QuestDetailCoupon
 import com.ilsangtech.ilsang.core.util.DateConverter
 import com.ilsangtech.ilsang.designsystem.R
@@ -131,6 +132,7 @@ private fun QuestRewardCouponDialogPreview() {
     val coupon = QuestDetailCoupon(
         id = 1,
         name = "아메리카노 1잔 무료",
+        type = CouponType.RealTime,
         imageId = null,
         validTo = "2025-12-31T23:59:59",
         storeName = "스타벅스",

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QuestInfoContent.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QuestInfoContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.ilsangtech.ilsang.core.model.coupon.CouponType
 import com.ilsangtech.ilsang.core.model.coupon.QuestDetailCoupon
 import com.ilsangtech.ilsang.core.model.mission.Mission
 import com.ilsangtech.ilsang.core.model.mission.MissionType
@@ -145,6 +146,7 @@ internal fun QuestDetailInfoContentPreview() {
             QuestDetailCoupon(
                 id = 201,
                 name = "10% Off Coupon",
+                type = CouponType.RealTime,
                 imageId = "coupon_image_id",
                 validTo = "2024-12-31",
                 storeName = "Store A",

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
@@ -178,7 +178,9 @@ private fun QuestBottomSheetContent(
             rewardPoints = quest.rewards,
             isIsZoneQuest = quest.isIsZoneQuest
         )
-        if (quest.coupons.isNotEmpty()) {
+        quest.coupons.firstOrNull { coupon ->
+            coupon.type is CouponType.RealTime
+        }?.let {
             QuestRewardCouponCard(
                 modifier = Modifier.padding(top = 24.dp),
                 onRewardButtonClick = onRewardButtonClick

--- a/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
+++ b/core/ui/src/main/java/com/ilsangtech/ilsang/core/ui/quest/bottomsheet/QueustBottomSheet.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.ilsangtech.ilsang.core.model.coupon.CouponType
 import com.ilsangtech.ilsang.core.model.coupon.QuestDetailCoupon
 import com.ilsangtech.ilsang.core.model.mission.Mission
 import com.ilsangtech.ilsang.core.model.mission.MissionType
@@ -263,6 +264,7 @@ fun QuestBottomSheetPreviewQuestDetail() {
             QuestDetailCoupon(
                 id = 1,
                 name = "쿠폰 이름",
+                type = CouponType.RealTime,
                 imageId = "couponImageId",
                 storeName = "쿠폰 가게 이름",
                 validTo = "2023-12-31",

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageSubmitScreen.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageSubmitScreen.kt
@@ -21,6 +21,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,6 +36,7 @@ import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import com.ilsangtech.ilsang.core.ui.coupon.QuestRewardCouponDialog
 import com.ilsangtech.ilsang.designsystem.R
 import com.ilsangtech.ilsang.designsystem.theme.buttonTextStyle
 import com.ilsangtech.ilsang.designsystem.theme.gray500
@@ -52,21 +56,43 @@ internal fun ImageSubmitScreen(
 ) {
     val submitUiState by imageSubmitViewModel.submitUiState.collectAsStateWithLifecycle()
 
-    when (submitUiState) {
+    when (val uiState = submitUiState) {
         is SubmitResultUiState.Loading -> {
             SubmitLoadingDialog()
         }
 
         is SubmitResultUiState.Success -> {
-            val rewardList = (submitUiState as SubmitResultUiState.Success).rewardPoints
-            SubmitSuccessDialog(
-                rewardPoints = rewardList,
-                isIsZoneQuest = imageSubmitViewModel.isIsZoneQuest,
-                onDismissRequest = {
-                    imageSubmitViewModel.completeSubmit()
-                    onSubmitSuccess()
+            val (rewardList, coupon) = uiState
+            var showPointDialog by remember { mutableStateOf(true) }
+            var showCouponDialog by remember { mutableStateOf(false) }
+            if (showPointDialog) {
+                SubmitSuccessDialog(
+                    rewardPoints = rewardList,
+                    isIsZoneQuest = imageSubmitViewModel.isIsZoneQuest,
+                    onDismissRequest = {
+                        showPointDialog = false
+                        if (coupon == null) {
+                            imageSubmitViewModel.completeSubmit()
+                            onSubmitSuccess()
+                        } else {
+                            showCouponDialog = true
+                        }
+                    }
+                )
+            }
+            coupon?.let {
+                if (showCouponDialog) {
+                    QuestRewardCouponDialog(
+                        coupon = coupon,
+                        isObtained = true,
+                        onDismissRequest = {
+                            showCouponDialog = false
+                            imageSubmitViewModel.completeSubmit()
+                            onSubmitSuccess()
+                        }
+                    )
                 }
-            )
+            }
         }
 
         is SubmitResultUiState.Error -> {

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageSubmitViewModel.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/ImageSubmitViewModel.kt
@@ -10,6 +10,7 @@ import com.ilsangtech.ilsang.core.domain.ImageRepository
 import com.ilsangtech.ilsang.core.domain.MissionRepository
 import com.ilsangtech.ilsang.core.domain.QuestCompleteDateRepository
 import com.ilsangtech.ilsang.core.domain.QuestRepository
+import com.ilsangtech.ilsang.core.model.coupon.CouponType
 import com.ilsangtech.ilsang.core.util.FileManager
 import com.ilsangtech.ilsang.feature.submit.model.SubmitResultUiState
 import com.ilsangtech.ilsang.feature.submit.navigation.ImageSubmitRoute
@@ -50,7 +51,12 @@ class ImageSubmitViewModel @Inject constructor(
                     imageId = imageId
                 ).onSuccess {
                     questRepository.getQuestDetail(questId).collect { quest ->
-                        _submitUiState.update { SubmitResultUiState.Success(quest.rewards) }
+                        _submitUiState.update {
+                            SubmitResultUiState.Success(
+                                rewardPoints = quest.rewards,
+                                coupon = quest.coupons.firstOrNull { it.type is CouponType.RealTime }
+                            )
+                        }
                     }
                     questCompleteDateRepository.updateQuestCompleteDate(questId)
                 }.onFailure {

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/OxQuizSubmitScreen.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/OxQuizSubmitScreen.kt
@@ -15,6 +15,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -26,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ilsangtech.ilsang.core.model.quest.QuestType
 import com.ilsangtech.ilsang.core.model.reward.RewardPoint
+import com.ilsangtech.ilsang.core.ui.coupon.QuestRewardCouponDialog
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.designsystem.theme.gray300
 import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
@@ -58,14 +62,35 @@ internal fun OxQuizSubmitScreen(
         }
 
         is SubmitResultUiState.Success -> {
-            SubmitSuccessDialog(
-                rewardPoints = result.rewardPoints,
-                isIsZoneQuest = viewModel.isIsZoneQuest,
-                onDismissRequest = {
-                    viewModel.resetResultUiState()
-                    onBackButtonClick()
+            var showPointDialog by remember { mutableStateOf(true) }
+            var showCouponDialog by remember { mutableStateOf(false) }
+            if (showPointDialog) {
+                SubmitSuccessDialog(
+                    rewardPoints = result.rewardPoints,
+                    isIsZoneQuest = viewModel.isIsZoneQuest,
+                    onDismissRequest = {
+                        if (result.coupon == null) {
+                            viewModel.resetResultUiState()
+                            onBackButtonClick()
+                        } else {
+                            showCouponDialog = true
+                        }
+                        showPointDialog = false
+                    }
+                )
+            }
+            result.coupon?.let {
+                if (showCouponDialog) {
+                    QuestRewardCouponDialog(
+                        coupon = result.coupon,
+                        isObtained = true,
+                        onDismissRequest = {
+                            showCouponDialog = false
+                            viewModel.resetResultUiState()
+                        }
+                    )
                 }
-            )
+            }
         }
 
         is SubmitResultUiState.WrongAnswer -> {
@@ -187,7 +212,8 @@ private fun OxQuizSubmitScreenPreview() {
             RewardPoint.Metro(5),
             RewardPoint.Commercial(10),
             RewardPoint.Contribute(15)
-        )
+        ),
+        coupon = null
     )
     val quizSubmitUiState = OxQuizSubmitUiState.NotSelected
 

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/OxQuizSubmitViewModel.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/OxQuizSubmitViewModel.kt
@@ -8,6 +8,7 @@ import com.ilsangtech.ilsang.core.domain.MissionRepository
 import com.ilsangtech.ilsang.core.domain.QuestCompleteDateRepository
 import com.ilsangtech.ilsang.core.domain.QuestRepository
 import com.ilsangtech.ilsang.core.domain.QuizRepository
+import com.ilsangtech.ilsang.core.model.coupon.CouponType
 import com.ilsangtech.ilsang.feature.submit.model.OxQuizSubmitUiState
 import com.ilsangtech.ilsang.feature.submit.model.OxQuizUiState
 import com.ilsangtech.ilsang.feature.submit.model.SubmitQuestUiState
@@ -53,7 +54,8 @@ class OxQuizSubmitViewModel @Inject constructor(
             title = quest.title,
             writerName = quest.writerName,
             questType = quest.questType,
-            rewards = quest.rewards
+            rewards = quest.rewards,
+            coupon = quest.coupons.firstOrNull { it.type is CouponType.RealTime }
         )
 
         OxQuizUiState.Success(
@@ -109,7 +111,10 @@ class OxQuizSubmitViewModel @Inject constructor(
                 ).onSuccess { isCorrect ->
                     if (isCorrect) {
                         _submitResultUiState.update {
-                            SubmitResultUiState.Success(submitQuestUiState.rewards)
+                            SubmitResultUiState.Success(
+                                rewardPoints = submitQuestUiState.rewards,
+                                coupon = submitQuestUiState.coupon
+                            )
                         }
                         questCompleteDateRepository.updateQuestCompleteDate(questId)
                     } else {

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/WordsQuizSubmitScreen.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/WordsQuizSubmitScreen.kt
@@ -107,7 +107,9 @@ private fun WordsQuizSubmitScreen(
     onBackButtonClick: () -> Unit
 ) {
     Surface(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .imePadding(),
         color = background
     ) {
         Column {

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/WordsQuizSubmitScreen.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/WordsQuizSubmitScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -17,6 +18,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -28,6 +32,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ilsangtech.ilsang.core.model.quest.QuestType
 import com.ilsangtech.ilsang.core.model.reward.RewardPoint
+import com.ilsangtech.ilsang.core.ui.coupon.QuestRewardCouponDialog
 import com.ilsangtech.ilsang.designsystem.theme.background
 import com.ilsangtech.ilsang.designsystem.theme.gray300
 import com.ilsangtech.ilsang.designsystem.theme.pretendardFontFamily
@@ -59,14 +64,35 @@ internal fun WordsQuizSubmitScreen(
         }
 
         is SubmitResultUiState.Success -> {
-            SubmitSuccessDialog(
-                rewardPoints = result.rewardPoints,
-                isIsZoneQuest = viewModel.isIsZoneQuest,
-                onDismissRequest = {
-                    viewModel.resetResultUiState()
-                    onBackButtonClick()
+            var showPointDialog by remember { mutableStateOf(true) }
+            var showCouponDialog by remember { mutableStateOf(false) }
+            if (showPointDialog) {
+                SubmitSuccessDialog(
+                    rewardPoints = result.rewardPoints,
+                    isIsZoneQuest = viewModel.isIsZoneQuest,
+                    onDismissRequest = {
+                        showPointDialog = false
+                        if (result.coupon == null) {
+                            viewModel.resetResultUiState()
+                            onBackButtonClick()
+                        } else {
+                            showCouponDialog = true
+                        }
+                    }
+                )
+            }
+            result.coupon?.let {
+                if (showCouponDialog) {
+                    QuestRewardCouponDialog(
+                        coupon = result.coupon,
+                        isObtained = true,
+                        onDismissRequest = {
+                            showCouponDialog = false
+                            viewModel.resetResultUiState()
+                        }
+                    )
                 }
-            )
+            }
         }
 
         SubmitResultUiState.WrongAnswer -> {
@@ -185,7 +211,8 @@ private fun WordsQuizScreenPreview() {
                 RewardPoint.Metro(5),
                 RewardPoint.Commercial(10),
                 RewardPoint.Contribute(15)
-            )
+            ),
+            coupon = null
         )
     )
 

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/WordsQuizSubmitViewModel.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/WordsQuizSubmitViewModel.kt
@@ -9,6 +9,7 @@ import com.ilsangtech.ilsang.core.domain.MissionRepository
 import com.ilsangtech.ilsang.core.domain.QuestCompleteDateRepository
 import com.ilsangtech.ilsang.core.domain.QuestRepository
 import com.ilsangtech.ilsang.core.domain.QuizRepository
+import com.ilsangtech.ilsang.core.model.coupon.CouponType
 import com.ilsangtech.ilsang.feature.submit.model.SubmitQuestUiState
 import com.ilsangtech.ilsang.feature.submit.model.SubmitResultUiState
 import com.ilsangtech.ilsang.feature.submit.model.WordsQuizUiState
@@ -54,7 +55,8 @@ class WordsQuizSubmitViewModel @Inject constructor(
                 title = quest.title,
                 writerName = quest.writerName,
                 questType = quest.questType,
-                rewards = quest.rewards
+                rewards = quest.rewards,
+                coupon = quest.coupons.firstOrNull { it.type is CouponType.RealTime }
             )
         )
     }.stateIn(
@@ -79,7 +81,11 @@ class WordsQuizSubmitViewModel @Inject constructor(
                     if (isCorrect) {
                         _submitResultUiState.update {
                             val rewardPoints = wordsQuizUiState.submitQuestUiState.rewards
-                            SubmitResultUiState.Success(rewardPoints)
+                            val coupon = wordsQuizUiState.submitQuestUiState.coupon
+                            SubmitResultUiState.Success(
+                                rewardPoints = rewardPoints,
+                                coupon = coupon
+                            )
                         }
                         questCompleteDateRepository.updateQuestCompleteDate(questId)
                     } else {

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/model/SubmitQuestUiState.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/model/SubmitQuestUiState.kt
@@ -1,5 +1,6 @@
 package com.ilsangtech.ilsang.feature.submit.model
 
+import com.ilsangtech.ilsang.core.model.coupon.QuestDetailCoupon
 import com.ilsangtech.ilsang.core.model.quest.QuestType
 import com.ilsangtech.ilsang.core.model.reward.RewardPoint
 
@@ -8,5 +9,6 @@ data class SubmitQuestUiState(
     val title: String,
     val writerName: String,
     val questType: QuestType,
-    val rewards: List<RewardPoint>
+    val rewards: List<RewardPoint>,
+    val coupon: QuestDetailCoupon?
 )

--- a/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/model/SubmitResultUiState.kt
+++ b/feature/submit/src/main/java/com/ilsangtech/ilsang/feature/submit/model/SubmitResultUiState.kt
@@ -1,11 +1,16 @@
 package com.ilsangtech.ilsang.feature.submit.model
 
+import com.ilsangtech.ilsang.core.model.coupon.QuestDetailCoupon
 import com.ilsangtech.ilsang.core.model.reward.RewardPoint
 
 sealed interface SubmitResultUiState {
     data object NotSubmitted : SubmitResultUiState
     data object Loading : SubmitResultUiState
-    data class Success(val rewardPoints: List<RewardPoint>) : SubmitResultUiState
+    data class Success(
+        val rewardPoints: List<RewardPoint>,
+        val coupon: QuestDetailCoupon?
+    ) : SubmitResultUiState
+
     data object WrongAnswer : SubmitResultUiState
     data object Error : SubmitResultUiState
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolves #306 

## 📝작업 내용

> 퀘스트 상세 조회 응답 DTO 클래스 수정
퀘스트 하단 시트 보상 UI 표시
퀘스트 수행 후 쿠폰 보상 다이얼로그 UI 표시
 

### 스크린샷 (선택)
<img width="360" alt="image" src="https://github.com/user-attachments/assets/661f8edf-5394-4afe-964b-70fdf3a48e1e" />
