### PR TITLE
[Feat] 인증 아이템의 CTA 컴포넌트에 수행 불가능 타입 UI 적용

### DIFF
--- a/core/util/src/main/java/com/ilsangtech/ilsang/core/util/DateConverter.kt
+++ b/core/util/src/main/java/com/ilsangtech/ilsang/core/util/DateConverter.kt
@@ -9,6 +9,13 @@ import java.util.TimeZone
 object DateConverter {
     private const val DEFAULT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss"
 
+    fun parseDate(dateStr: String): Date {
+        val sdf = SimpleDateFormat(DEFAULT_PATTERN, Locale.getDefault()).apply {
+            timeZone = TimeZone.getTimeZone("Asia/Seoul")
+        }
+        return sdf.parse(dateStr)!!
+    }
+
     fun formatDate(input: String, outputPattern: String = "yyyy.MM.dd"): String {
         return try {
             val inputFormat = SimpleDateFormat(DEFAULT_PATTERN, Locale.getDefault()).apply {

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalDetailScreen.kt
@@ -267,8 +267,6 @@ private fun ApprovalDetailScreenPreview() {
         questType = QuestType.Repeat.Weekly,
         commentCount = 10,
         shareCount = 2,
-        lastCompleteDate = "2025.04.12 12:00",
-        expireDate = "2025.04.12 12:00",
         isIsZoneQuest = false
     )
 

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalScreen.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/ApprovalScreen.kt
@@ -165,8 +165,6 @@ private fun ApprovalScreenPreview() {
             questType = QuestType.Normal,
             commentCount = 20,
             shareCount = 20,
-            lastCompleteDate = null,
-            expireDate = "",
             isIsZoneQuest = false,
             questId = 0
         ),
@@ -194,8 +192,6 @@ private fun ApprovalScreenPreview() {
             questType = QuestType.Repeat.Weekly,
             commentCount = 20,
             shareCount = 20,
-            lastCompleteDate = null,
-            expireDate = "",
             isIsZoneQuest = false,
             questId = 0
         )

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalDetailItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalDetailItem.kt
@@ -38,6 +38,7 @@ internal fun ApprovalDetailItem(
             questTitle = missionHistory.title,
             writerName = missionHistory.writerName,
             questType = missionHistory.questType,
+            missionExecutionUiState = missionHistory.missionExecutionUiState,
             onClick = onCtaButtonClick
         )
     }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalExampleCtaCard.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalExampleCtaCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import com.ilsangtech.ilsang.core.model.mission.MissionType
 import com.ilsangtech.ilsang.core.model.quest.QuestType
 import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.feature.approval.model.MissionExecutionUiState
 
 @Composable
 internal fun ApprovalExampleCtaCard(
@@ -22,6 +23,7 @@ internal fun ApprovalExampleCtaCard(
     writerName: String,
     questType: QuestType,
     missionType: MissionType = MissionType.Photo,
+    missionExecutionUiState: MissionExecutionUiState = MissionExecutionUiState.Available,
     onClick: () -> Unit
 ) {
     Box(
@@ -44,7 +46,11 @@ internal fun ApprovalExampleCtaCard(
             .clickable(
                 indication = null,
                 interactionSource = null,
-                onClick = onClick
+                onClick = {
+                    if (missionExecutionUiState is MissionExecutionUiState.Available) {
+                        onClick()
+                    }
+                }
             ),
     ) {
         ApprovalQuestContent(
@@ -56,6 +62,7 @@ internal fun ApprovalExampleCtaCard(
             writerName = writerName,
             questType = questType,
             missionType = missionType,
+            missionExecutionUiState = missionExecutionUiState,
             ctaText = "바로가기"
         )
     }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItem.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItem.kt
@@ -124,6 +124,7 @@ internal fun ApprovalItem(
                 questTitle = missionHistory.title,
                 questType = missionHistory.questType,
                 writerName = missionHistory.writerName,
+                missionExecutionUiState = missionHistory.missionExecutionUiState,
                 onClick = onCtaCardClick,
             )
             ApprovalItemStatsRow(
@@ -164,8 +165,6 @@ private fun ApprovalItemPreview() {
         commentCount = 20,
         writerName = "야미돈까스 정자동점",
         questType = QuestType.Repeat.Weekly,
-        lastCompleteDate = "",
-        expireDate = "",
         isIsZoneQuest = false,
         questId = 0
     )

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItemCtaCard.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalItemCtaCard.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import com.ilsangtech.ilsang.core.model.mission.MissionType
 import com.ilsangtech.ilsang.core.model.quest.QuestType
 import com.ilsangtech.ilsang.designsystem.theme.gray100
+import com.ilsangtech.ilsang.feature.approval.model.MissionExecutionUiState
 
 @Composable
 internal fun ApprovalItemCtaCard(
@@ -21,6 +22,7 @@ internal fun ApprovalItemCtaCard(
     writerName: String,
     questType: QuestType,
     missionType: MissionType = MissionType.Photo,
+    missionExecutionUiState: MissionExecutionUiState,
     onClick: () -> Unit
 ) {
     OutlinedCard(
@@ -28,7 +30,11 @@ internal fun ApprovalItemCtaCard(
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.outlinedCardColors(containerColor = Color.White),
         border = BorderStroke(width = 1.dp, color = gray100),
-        onClick = onClick
+        onClick = {
+            if (missionExecutionUiState is MissionExecutionUiState.Available) {
+                onClick()
+            }
+        }
     ) {
         ApprovalQuestContent(
             modifier = Modifier.padding(16.dp),
@@ -36,6 +42,7 @@ internal fun ApprovalItemCtaCard(
             writerName = writerName,
             questType = questType,
             missionType = missionType,
+            missionExecutionUiState = missionExecutionUiState,
             ctaText = "나도 하기"
         )
     }
@@ -49,6 +56,7 @@ private fun ApprovalItemCtaCardPreview() {
         writerName = "야미돈까스 정자동점",
         questType = QuestType.Repeat.Daily,
         missionType = MissionType.Photo,
+        missionExecutionUiState = MissionExecutionUiState.Available,
         onClick = {}
     )
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalQuestContent.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/component/ApprovalQuestContent.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,10 +31,12 @@ import com.ilsangtech.ilsang.core.ui.quest.EventQuestTypeBadge
 import com.ilsangtech.ilsang.core.ui.quest.MissionTypeBadge
 import com.ilsangtech.ilsang.core.ui.quest.RepeatQuestTypeBadge
 import com.ilsangtech.ilsang.designsystem.R
+import com.ilsangtech.ilsang.designsystem.theme.gray300
 import com.ilsangtech.ilsang.designsystem.theme.gray400
 import com.ilsangtech.ilsang.designsystem.theme.gray500
 import com.ilsangtech.ilsang.designsystem.theme.tapBoldTextStyle
 import com.ilsangtech.ilsang.designsystem.theme.toSp
+import com.ilsangtech.ilsang.feature.approval.model.MissionExecutionUiState
 
 @Composable
 internal fun ApprovalQuestContent(
@@ -42,8 +45,17 @@ internal fun ApprovalQuestContent(
     writerName: String,
     questType: QuestType,
     missionType: MissionType,
+    missionExecutionUiState: MissionExecutionUiState,
     ctaText: String
 ) {
+    val (chipText, chipTextColor) = remember {
+        when (missionExecutionUiState) {
+            MissionExecutionUiState.Available -> ctaText to gray500
+            MissionExecutionUiState.Completed -> "수행 완료" to gray300
+            MissionExecutionUiState.Expired -> "기간 만료" to gray300
+        }
+    }
+
     Row(
         modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
@@ -87,12 +99,12 @@ internal fun ApprovalQuestContent(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = ctaText,
+                text = chipText,
                 style = tapBoldTextStyle.copy(
                     fontSize = 14.dp.toSp(),
                     lineHeight = 24.dp.toSp(),
                 ),
-                color = gray500
+                color = chipTextColor
             )
             Icon(
                 modifier = Modifier.size(20.dp),
@@ -112,6 +124,7 @@ private fun ApprovalQuestContentPreview() {
         writerName = "야미돈까스 정자동점",
         questType = QuestType.Repeat.Daily,
         missionType = MissionType.Photo,
+        missionExecutionUiState = MissionExecutionUiState.Available,
         ctaText = "바로가기"
     )
 }

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionExecutionUiState.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionExecutionUiState.kt
@@ -1,0 +1,15 @@
+package com.ilsangtech.ilsang.feature.approval.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface MissionExecutionUiState {
+    @Serializable
+    data object Available : MissionExecutionUiState
+
+    @Serializable
+    data object Expired : MissionExecutionUiState
+
+    @Serializable
+    data object Completed : MissionExecutionUiState
+}

--- a/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionHistoryUiModel.kt
+++ b/feature/approval/src/main/java/com/ilsangtech/ilsang/feature/approval/model/MissionHistoryUiModel.kt
@@ -5,6 +5,7 @@ import com.ilsangtech.ilsang.core.model.mission.RandomMissionHistory
 import com.ilsangtech.ilsang.core.model.quest.QuestType
 import com.ilsangtech.ilsang.core.util.DateConverter
 import kotlinx.serialization.Serializable
+import java.util.Date
 
 @Serializable
 data class MissionHistoryUiModel(
@@ -23,15 +24,44 @@ data class MissionHistoryUiModel(
     val questType: QuestType,
     val commentCount: Int,
     val shareCount: Int,
-    val lastCompleteDate: String?,
-    val expireDate: String?,
-    val isIsZoneQuest: Boolean
+    val isIsZoneQuest: Boolean,
+    val missionExecutionUiState: MissionExecutionUiState = MissionExecutionUiState.Available
 )
 
 internal fun RandomMissionHistory.toUiModel(
     areaName: String,
     isIsZoneQuest: Boolean
 ): MissionHistoryUiModel {
+    val isExpired = expireDate?.let { dateStr ->
+        DateConverter.parseDate(dateStr).before(Date())
+    } ?: false
+    val isCompleted = lastCompleteDate?.let { dateStr ->
+        when (questType) {
+            is QuestType.Repeat.Daily -> {
+                DateConverter.getRemainHours(
+                    date = dateStr,
+                    day = 1
+                ) > 0
+            }
+
+            is QuestType.Repeat.Weekly -> {
+                DateConverter.getRemainHours(
+                    date = dateStr,
+                    week = 1
+                ) > 0
+            }
+
+            is QuestType.Repeat.Monthly -> {
+                DateConverter.getRemainHours(
+                    date = dateStr,
+                    month = 1
+                ) > 0
+            }
+
+            else -> true
+        }
+    } ?: false
+
     return MissionHistoryUiModel(
         missionHistoryId = missionHistoryId,
         questId = 0, // TODO: 실제 quest id 적용 필요
@@ -51,8 +81,11 @@ internal fun RandomMissionHistory.toUiModel(
         questType = questType,
         commentCount = commentCount,
         shareCount = shareCount,
-        lastCompleteDate = lastCompleteDate,
-        expireDate = expireDate,
-        isIsZoneQuest = isIsZoneQuest
+        isIsZoneQuest = isIsZoneQuest,
+        missionExecutionUiState = when {
+            isExpired -> MissionExecutionUiState.Expired
+            isCompleted -> MissionExecutionUiState.Completed
+            else -> MissionExecutionUiState.Available
+        }
     )
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> resolve #311 

## 📝작업 내용

> 수행 불가능한 상태 UI 타입 구현
수행 불가능한 타입에 맞게 UI 적용

### 스크린샷 (선택)
<img width="360"  alt="image" src="https://github.com/user-attachments/assets/9c3e242b-733e-413c-b4fd-711f20d520fe" />
